### PR TITLE
BLD: Use `meson` without `lua`, add CI

### DIFF
--- a/.github/workflows/build_lib.yml
+++ b/.github/workflows/build_lib.yml
@@ -1,0 +1,19 @@
+name: "Build d-SEAMS yodaLib"
+on: [push, pull_request]
+jobs:
+  build_lib:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Conda environment from environment.yml
+        uses: mamba-org/provision-with-micromamba@main
+
+      # Linux and macOS
+      - name: Run Python
+        shell: bash -l {0}
+        run: |
+          cd src
+          mkdir bbdir
+          meson setup bbdir
+          meson compile -C bbdir

--- a/environment.yml
+++ b/environment.yml
@@ -16,6 +16,7 @@ dependencies:
   - libblas
   - boost-cpp
   - cmake
+  - meson
   - lua-luafilesystem
   # Pinned
   - eigen==3.3.9

--- a/src/meson.build
+++ b/src/meson.build
@@ -37,19 +37,6 @@ fmt_dep = dependency('fmt', method : 'cmake',  modules : ['fmt::fmt'],  required
 libyamlcpp = dependency('yaml-cpp',
                         fallback: ['yaml-cpp', 'libyamlcpp_dep'])
 
-lua_dep = dependency('lua',
-                     version : '<5.3',
-                     required : false)
-if lua_dep.found()
-  yds_deps += [ lua_dep ]
-else
-  # Assume spack
-  lua_spack_dep = cppc.find_library('lua', dirs:
-       meson.source_root()+'/../.spack-env/view/lib',
-                                    required: true)
-  yds_deps += [lua_spack_dep]
-endif
-
 yds_deps += [ boost_dep, fmt_dep, libyamlcpp ]
 
 incdir = include_directories([ 'include/internal', 'include/external' ])
@@ -88,11 +75,26 @@ ydslib = library('yodaLib',
                 install: true
                )
 
-yds = executable('yodaStruct',
-                ['main.cpp'],
-                link_with : ydslib,
-                dependencies: yds_deps,
-                cpp_args : yoda_extra_args,
-                include_directories : incdir,
-                install : true)
-
+# Lua is only used in the executable
+if get_option('with_lua')
+  lua_dep = dependency('lua',
+                       version : '<5.3',
+                       required : false)
+  if lua_dep.found()
+    yds_deps += [ lua_dep ]
+  else
+    # Assume spack
+    lua_spack_dep = cppc.find_library('lua', dirs:
+         meson.source_root()+'/../.spack-env/view/lib',
+                                      required: true)
+    yds_deps += [lua_spack_dep]
+  endif
+  # Build the executable
+  yds = executable('yodaStruct',
+                   ['main.cpp'],
+                   link_with : ydslib,
+                   dependencies: yds_deps,
+                   cpp_args : yoda_extra_args,
+                   include_directories : incdir,
+                   install : true)
+endif

--- a/src/meson_options.txt
+++ b/src/meson_options.txt
@@ -1,0 +1,2 @@
+# Booleans
+option('with_lua', type : 'boolean', value : false)


### PR DESCRIPTION
Closes #13. Also, since the GSoC'23 project seeks to swap `lua` for `python`, and as the version is hard to constrain, this disables `lua` by default.