### PR TITLE
BLD: Pin fmt to v9

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,6 @@ dependencies:
   - compilers
   - gfortran
   - catch2
-  - fmt
   - yaml-cpp
   - liblapack
   - libblas
@@ -21,5 +20,6 @@ dependencies:
   # - lua-luafilesystem
   - luarocks
   # Pinned
+  - fmt==9.0.0
   - eigen==3.3.9
   - lua==5.4.4


### PR DESCRIPTION
Closes #26 by pinning to the last working version.
