### PR TITLE
BLD: Fix meson / library paths

### DIFF
--- a/.github/workflows/build_pkg.yml
+++ b/.github/workflows/build_pkg.yml
@@ -15,6 +15,7 @@ jobs:
           luarocks install luafilesystem
           mkdir bbdir
           cd bbdir
+          export CXXFLAGS="-I$CONDA_PREFIX/include/eigen3 -I$CONDA_PREFIX/include/"
           cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_EXPORT_COMPILE_COMMANDS=YES -DCMAKE_INSTALL_PREFIX:PATH=$CONDA_PREFIX ../
           make -j$(nproc)
           make install

--- a/cmake/FindEigen.cmake
+++ b/cmake/FindEigen.cmake
@@ -1,0 +1,29 @@
+# Find Eigen library
+# This module sets the following variables:
+#   EIGEN_FOUND        : True if Eigen library is found, False otherwise
+#   EIGEN_INCLUDE_DIRS : Include directories for Eigen headers
+#   EIGEN_LIBRARIES    : Eigen library to link against
+
+# Search for Eigen headers
+find_path(EIGEN_INCLUDE_DIR NAMES Eigen/Core PATH_SUFFIXES eigen3)
+
+# Check if Eigen headers are found
+if(EIGEN_INCLUDE_DIR)
+  set(EIGEN_FOUND TRUE)
+  set(EIGEN_INCLUDE_DIRS ${EIGEN_INCLUDE_DIR})
+else()
+  set(EIGEN_FOUND FALSE)
+  set(EIGEN_INCLUDE_DIRS)
+endif()
+
+# Provide the information to CMake
+if(EIGEN_FOUND)
+  message(STATUS "Found Eigen: ${EIGEN_INCLUDE_DIRS}")
+else()
+  message(STATUS "Eigen not found. Please set EIGEN_INCLUDE_DIRS manually.")
+endif()
+
+# Export the variables
+set(EIGEN_INCLUDE_DIRS ${EIGEN_INCLUDE_DIRS} CACHE PATH "Eigen include directories" FORCE)
+mark_as_advanced(EIGEN_INCLUDE_DIRS)
+

--- a/environment.yml
+++ b/environment.yml
@@ -21,5 +21,5 @@ dependencies:
   - luarocks
   # Pinned
   - fmt==9.0.0
-  - eigen==3.3.9
+  - eigen==3.4.0
   - lua==5.4.4

--- a/meson.build
+++ b/meson.build
@@ -39,6 +39,11 @@ endif
 cppc = meson.get_compiler('cpp')
 
 # Dependencies
+# libm for Unix systems
+m_dep = cppc.find_library('m', required: false)
+_deps += m_dep
+_deps += [declare_dependency(link_args: '-lstdc++')]
+
 # All of which can be installed with meson wrap install <blah> originally
 subproject('eigen')
 eigen_dep = dependency('eigen3',
@@ -46,8 +51,9 @@ eigen_dep = dependency('eigen3',
                        required: true)
 _deps += [ eigen_dep ]
 
-subproject('fmt')
-fmt_dep = dependency('fmt', required: true)
+fmt_dep = dependency('fmt',
+                     version: '9.0.0',
+                     required: true)
 _deps += [ fmt_dep ]
 
 boost_dep = dependency('boost',
@@ -66,7 +72,7 @@ _deps += [ libyamlcpp_dep ]
 
 # Include Sources
 
-incdir = include_directories([ 'src/include/internal',
+_incdirs += include_directories([ 'src/include/internal',
                                'src/include/external' ])
 
 # --------------------- Library
@@ -99,7 +105,7 @@ ydslib = library('yodaLib',
                 ydsl_sources,
                 dependencies: _deps,
                 cpp_args: _args,
-                include_directories : incdir,
+                include_directories : _incdirs,
                 install: true
                )
 
@@ -138,7 +144,7 @@ if (not meson.is_subproject())
                        link_with : _linkto,
                        dependencies: _deps,
                        cpp_args : _args,
-                       include_directories : incdir,
+                       include_directories : _incdirs,
                        install : true)
     endif
 endif

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,6 +21,8 @@ set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR})
 include(FindBLAS)
 include(FindLAPACK)
 include(FindBoost)
+include(FindEigen)
+find_package (Eigen3 3.4 REQUIRED NO_MODULE)
 add_compile_options(
   # "-Wall" "-Wpedantic" "-Wextra" "-fexceptions"
   "$<$<CONFIG:Debug>:-O0;-g3;-ggdb>"
@@ -36,13 +38,11 @@ include_directories(
   include/external
   ${LUA_INCLUDE_DIR}
   ${Boost_INCLUDE_DIRS}
-  ${Eigen3_INCLUDE_DIRS}
   )
 add_definitions(-DBOOST_ERROR_CODE_HEADER_ONLY)
 find_package(
   "Lua" REQUIRED
   "Boost" REQUIRED COMPONENTS system filesystem
-  "Eigen3 3.3" REQUIRED
   "yaml-cpp"
   "fmt")
 
@@ -51,7 +51,7 @@ link_directories(${Boost_LIBRARY_DIRS})
 target_link_libraries(
   yodaStruct
   ${Boost_LIBRARIES}
-  ${Eigen3_LIBRARIES}
+  Eigen3::Eigen
   ${LUA_LIBRARIES}
   fmt
   yaml-cpp

--- a/src/include/external/Spectra/GenEigsBase.h
+++ b/src/include/external/Spectra/GenEigsBase.h
@@ -10,7 +10,7 @@
 #include <algorithm>  // std::min, std::copy
 #include <cmath>      // std::abs, std::pow, std::sqrt
 #include <complex>    // std::complex, std::conj, std::norm, std::abs
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 #include <stdexcept>  // std::invalid_argument
 #include <vector>     // std::vector
 

--- a/src/include/external/Spectra/GenEigsComplexShiftSolver.h
+++ b/src/include/external/Spectra/GenEigsComplexShiftSolver.h
@@ -7,7 +7,7 @@
 #ifndef GEN_EIGS_COMPLEX_SHIFT_SOLVER_H
 #define GEN_EIGS_COMPLEX_SHIFT_SOLVER_H
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 #include "GenEigsBase.h"
 #include "MatOp/DenseGenComplexShiftSolve.h"

--- a/src/include/external/Spectra/GenEigsRealShiftSolver.h
+++ b/src/include/external/Spectra/GenEigsRealShiftSolver.h
@@ -7,7 +7,7 @@
 #ifndef GEN_EIGS_REAL_SHIFT_SOLVER_H
 #define GEN_EIGS_REAL_SHIFT_SOLVER_H
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 #include "GenEigsBase.h"
 #include "MatOp/DenseGenRealShiftSolve.h"

--- a/src/include/external/Spectra/GenEigsSolver.h
+++ b/src/include/external/Spectra/GenEigsSolver.h
@@ -7,7 +7,7 @@
 #ifndef GEN_EIGS_SOLVER_H
 #define GEN_EIGS_SOLVER_H
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 #include "GenEigsBase.h"
 #include "MatOp/DenseGenMatProd.h"

--- a/src/include/external/Spectra/LinAlg/Arnoldi.h
+++ b/src/include/external/Spectra/LinAlg/Arnoldi.h
@@ -8,7 +8,7 @@
 #define ARNOLDI_H
 
 #include <cmath>  // std::sqrt
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 #include <sstream>    // std::stringstream
 #include <stdexcept>  // std::invalid_argument
 

--- a/src/include/external/Spectra/LinAlg/BKLDLT.h
+++ b/src/include/external/Spectra/LinAlg/BKLDLT.h
@@ -7,7 +7,7 @@
 #ifndef BK_LDLT_H
 #define BK_LDLT_H
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 #include <stdexcept>
 #include <vector>
 

--- a/src/include/external/Spectra/LinAlg/DoubleShiftQR.h
+++ b/src/include/external/Spectra/LinAlg/DoubleShiftQR.h
@@ -9,7 +9,7 @@
 
 #include <algorithm>  // std::min, std::fill, std::copy
 #include <cmath>      // std::abs, std::sqrt, std::pow
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 #include <stdexcept>  // std::invalid_argument, std::logic_error
 #include <vector>     // std::vector
 

--- a/src/include/external/Spectra/LinAlg/Lanczos.h
+++ b/src/include/external/Spectra/LinAlg/Lanczos.h
@@ -8,7 +8,7 @@
 #define LANCZOS_H
 
 #include <cmath>  // std::sqrt
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 #include <sstream>    // std::stringstream
 #include <stdexcept>  // std::invalid_argument
 

--- a/src/include/external/Spectra/LinAlg/TridiagEigen.h
+++ b/src/include/external/Spectra/LinAlg/TridiagEigen.h
@@ -11,8 +11,8 @@
 #ifndef TRIDIAG_EIGEN_H
 #define TRIDIAG_EIGEN_H
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Jacobi>
+#include <Eigen/Core>
+#include <Eigen/Jacobi>
 #include <stdexcept>
 
 #include "../Util/TypeTraits.h"

--- a/src/include/external/Spectra/LinAlg/UpperHessenbergEigen.h
+++ b/src/include/external/Spectra/LinAlg/UpperHessenbergEigen.h
@@ -11,8 +11,8 @@
 #ifndef UPPER_HESSENBERG_EIGEN_H
 #define UPPER_HESSENBERG_EIGEN_H
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Eigenvalues>
+#include <Eigen/Core>
+#include <Eigen/Eigenvalues>
 #include <stdexcept>
 
 namespace Spectra {

--- a/src/include/external/Spectra/LinAlg/UpperHessenbergQR.h
+++ b/src/include/external/Spectra/LinAlg/UpperHessenbergQR.h
@@ -9,7 +9,7 @@
 
 #include <algorithm>  // std::fill, std::copy
 #include <cmath>      // std::sqrt
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 #include <stdexcept>  // std::logic_error
 
 namespace Spectra {

--- a/src/include/external/Spectra/MatOp/DenseCholesky.h
+++ b/src/include/external/Spectra/MatOp/DenseCholesky.h
@@ -7,8 +7,8 @@
 #ifndef DENSE_CHOLESKY_H
 #define DENSE_CHOLESKY_H
 
-#include <eigen3/Eigen/Cholesky>
-#include <eigen3/Eigen/Core>
+#include <Eigen/Cholesky>
+#include <Eigen/Core>
 #include <stdexcept>
 #include "../Util/CompInfo.h"
 

--- a/src/include/external/Spectra/MatOp/DenseGenComplexShiftSolve.h
+++ b/src/include/external/Spectra/MatOp/DenseGenComplexShiftSolve.h
@@ -7,8 +7,8 @@
 #ifndef DENSE_GEN_COMPLEX_SHIFT_SOLVE_H
 #define DENSE_GEN_COMPLEX_SHIFT_SOLVE_H
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/LU>
+#include <Eigen/Core>
+#include <Eigen/LU>
 #include <stdexcept>
 
 namespace Spectra {

--- a/src/include/external/Spectra/MatOp/DenseGenMatProd.h
+++ b/src/include/external/Spectra/MatOp/DenseGenMatProd.h
@@ -7,7 +7,7 @@
 #ifndef DENSE_GEN_MAT_PROD_H
 #define DENSE_GEN_MAT_PROD_H
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 namespace Spectra {
 

--- a/src/include/external/Spectra/MatOp/DenseGenRealShiftSolve.h
+++ b/src/include/external/Spectra/MatOp/DenseGenRealShiftSolve.h
@@ -7,8 +7,8 @@
 #ifndef DENSE_GEN_REAL_SHIFT_SOLVE_H
 #define DENSE_GEN_REAL_SHIFT_SOLVE_H
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/LU>
+#include <Eigen/Core>
+#include <Eigen/LU>
 #include <stdexcept>
 
 namespace Spectra {

--- a/src/include/external/Spectra/MatOp/DenseSymMatProd.h
+++ b/src/include/external/Spectra/MatOp/DenseSymMatProd.h
@@ -7,7 +7,7 @@
 #ifndef DENSE_SYM_MAT_PROD_H
 #define DENSE_SYM_MAT_PROD_H
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 namespace Spectra {
 

--- a/src/include/external/Spectra/MatOp/DenseSymShiftSolve.h
+++ b/src/include/external/Spectra/MatOp/DenseSymShiftSolve.h
@@ -7,7 +7,7 @@
 #ifndef DENSE_SYM_SHIFT_SOLVE_H
 #define DENSE_SYM_SHIFT_SOLVE_H
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 #include <stdexcept>
 
 #include "../LinAlg/BKLDLT.h"

--- a/src/include/external/Spectra/MatOp/SparseCholesky.h
+++ b/src/include/external/Spectra/MatOp/SparseCholesky.h
@@ -7,9 +7,9 @@
 #ifndef SPARSE_CHOLESKY_H
 #define SPARSE_CHOLESKY_H
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/SparseCholesky>
-#include <eigen3/Eigen/SparseCore>
+#include <Eigen/Core>
+#include <Eigen/SparseCholesky>
+#include <Eigen/SparseCore>
 #include <stdexcept>
 #include "../Util/CompInfo.h"
 

--- a/src/include/external/Spectra/MatOp/SparseGenMatProd.h
+++ b/src/include/external/Spectra/MatOp/SparseGenMatProd.h
@@ -7,8 +7,8 @@
 #ifndef SPARSE_GEN_MAT_PROD_H
 #define SPARSE_GEN_MAT_PROD_H
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/SparseCore>
+#include <Eigen/Core>
+#include <Eigen/SparseCore>
 
 namespace Spectra {
 

--- a/src/include/external/Spectra/MatOp/SparseGenRealShiftSolve.h
+++ b/src/include/external/Spectra/MatOp/SparseGenRealShiftSolve.h
@@ -7,9 +7,9 @@
 #ifndef SPARSE_GEN_REAL_SHIFT_SOLVE_H
 #define SPARSE_GEN_REAL_SHIFT_SOLVE_H
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/SparseCore>
-#include <eigen3/Eigen/SparseLU>
+#include <Eigen/Core>
+#include <Eigen/SparseCore>
+#include <Eigen/SparseLU>
 #include <stdexcept>
 
 namespace Spectra {

--- a/src/include/external/Spectra/MatOp/SparseRegularInverse.h
+++ b/src/include/external/Spectra/MatOp/SparseRegularInverse.h
@@ -7,9 +7,9 @@
 #ifndef SPARSE_REGULAR_INVERSE_H
 #define SPARSE_REGULAR_INVERSE_H
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/IterativeLinearSolvers>
-#include <eigen3/Eigen/SparseCore>
+#include <Eigen/Core>
+#include <Eigen/IterativeLinearSolvers>
+#include <Eigen/SparseCore>
 #include <stdexcept>
 
 namespace Spectra {

--- a/src/include/external/Spectra/MatOp/SparseSymMatProd.h
+++ b/src/include/external/Spectra/MatOp/SparseSymMatProd.h
@@ -7,8 +7,8 @@
 #ifndef SPARSE_SYM_MAT_PROD_H
 #define SPARSE_SYM_MAT_PROD_H
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/SparseCore>
+#include <Eigen/Core>
+#include <Eigen/SparseCore>
 
 namespace Spectra {
 

--- a/src/include/external/Spectra/MatOp/SparseSymShiftSolve.h
+++ b/src/include/external/Spectra/MatOp/SparseSymShiftSolve.h
@@ -7,9 +7,9 @@
 #ifndef SPARSE_SYM_SHIFT_SOLVE_H
 #define SPARSE_SYM_SHIFT_SOLVE_H
 
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/SparseCore>
-#include <eigen3/Eigen/SparseLU>
+#include <Eigen/Core>
+#include <Eigen/SparseCore>
+#include <Eigen/SparseLU>
 #include <stdexcept>
 
 namespace Spectra {

--- a/src/include/external/Spectra/MatOp/internal/ArnoldiOp.h
+++ b/src/include/external/Spectra/MatOp/internal/ArnoldiOp.h
@@ -8,7 +8,7 @@
 #define ARNOLDI_OP_H
 
 #include <cmath>  // std::sqrt
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 namespace Spectra {
 

--- a/src/include/external/Spectra/MatOp/internal/SymGEigsCholeskyOp.h
+++ b/src/include/external/Spectra/MatOp/internal/SymGEigsCholeskyOp.h
@@ -7,7 +7,7 @@
 #ifndef SYM_GEIGS_CHOLESKY_OP_H
 #define SYM_GEIGS_CHOLESKY_OP_H
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 #include "../DenseCholesky.h"
 #include "../DenseSymMatProd.h"
 

--- a/src/include/external/Spectra/MatOp/internal/SymGEigsRegInvOp.h
+++ b/src/include/external/Spectra/MatOp/internal/SymGEigsRegInvOp.h
@@ -7,7 +7,7 @@
 #ifndef SYM_GEIGS_REG_INV_OP_H
 #define SYM_GEIGS_REG_INV_OP_H
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 #include "../SparseRegularInverse.h"
 #include "../SparseSymMatProd.h"
 

--- a/src/include/external/Spectra/SymEigsBase.h
+++ b/src/include/external/Spectra/SymEigsBase.h
@@ -9,7 +9,7 @@
 
 #include <algorithm>  // std::min, std::copy
 #include <cmath>      // std::abs, std::pow, std::sqrt
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 #include <stdexcept>  // std::invalid_argument
 #include <vector>     // std::vector
 

--- a/src/include/external/Spectra/SymEigsShiftSolver.h
+++ b/src/include/external/Spectra/SymEigsShiftSolver.h
@@ -7,7 +7,7 @@
 #ifndef SYM_EIGS_SHIFT_SOLVER_H
 #define SYM_EIGS_SHIFT_SOLVER_H
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 #include "MatOp/DenseSymShiftSolve.h"
 #include "SymEigsBase.h"

--- a/src/include/external/Spectra/SymEigsSolver.h
+++ b/src/include/external/Spectra/SymEigsSolver.h
@@ -7,7 +7,7 @@
 #ifndef SYM_EIGS_SOLVER_H
 #define SYM_EIGS_SOLVER_H
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 #include "MatOp/DenseSymMatProd.h"
 #include "SymEigsBase.h"

--- a/src/include/external/Spectra/Util/SimpleRandom.h
+++ b/src/include/external/Spectra/Util/SimpleRandom.h
@@ -7,7 +7,7 @@
 #ifndef SIMPLE_RANDOM_H
 #define SIMPLE_RANDOM_H
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 /// \cond
 

--- a/src/include/external/Spectra/Util/TypeTraits.h
+++ b/src/include/external/Spectra/Util/TypeTraits.h
@@ -7,7 +7,7 @@
 #ifndef TYPE_TRAITS_H
 #define TYPE_TRAITS_H
 
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 #include <limits>
 
 /// \cond

--- a/src/include/internal/absOrientation.hpp
+++ b/src/include/internal/absOrientation.hpp
@@ -30,8 +30,8 @@
 // External
 #include <Spectra/SymEigsShiftSolver.h>
 #include <Spectra/SymEigsSolver.h>
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Core>
+#include <Eigen/Dense>
 
 #include <mol_sys.hpp>
 #include <ring.hpp>

--- a/src/include/internal/generic.hpp
+++ b/src/include/internal/generic.hpp
@@ -23,8 +23,8 @@
 // Boost
 #include <boost/math/constants/constants.hpp>
 // Eigen
-#include <eigen3/Eigen/Core>
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Core>
+#include <Eigen/Dense>
 
 /** @file generic.hpp
  *   @brief File for containing generic or common functions.

--- a/src/include/internal/pntCorrespondence.hpp
+++ b/src/include/internal/pntCorrespondence.hpp
@@ -28,7 +28,7 @@
 #include <vector>
 
 // External
-#include <eigen3/Eigen/Core>
+#include <Eigen/Core>
 
 #include <cage.hpp>
 #include <mol_sys.hpp>


### PR DESCRIPTION
The `cmake` builds required `eigen3/` as the header include style which is incompatible with the more general usage e.g. `<Eigen/Core>`. In fixing this with a regex search and replace, the `cmake` build broke, and now explicitly needs the include directories to be set in the environment variable [ref: [stackoverflow](https://stackoverflow.com/a/41843596/1895378)].