### PR TITLE
ENH: Enum class fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -313,3 +313,27 @@ TSWLatexianTemp*
 
 # standalone packages
 *.sta
+
+# Created by https://www.toptal.com/developers/gitignore/api/visualstudiocode
+# Edit at https://www.toptal.com/developers/gitignore?templates=visualstudiocode
+
+### VisualStudioCode ###
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+
+# Local History for Visual Studio Code
+.history/
+
+# Built Visual Studio Code Extensions
+*.vsix
+
+### VisualStudioCode Patch ###
+# Ignore all local history of files
+.history
+.ionide
+
+# End of https://www.toptal.com/developers/gitignore/api/visualstudiocode

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,19 @@
+{
+    "files.associations": {
+        "deque": "cpp",
+        "string": "cpp",
+        "vector": "cpp",
+        "alignedvector3": "cpp",
+        "any": "cpp",
+        "array": "cpp",
+        "chrono": "cpp",
+        "functional": "cpp",
+        "istream": "cpp",
+        "ostream": "cpp",
+        "ratio": "cpp",
+        "tuple": "cpp",
+        "type_traits": "cpp",
+        "utility": "cpp",
+        "variant": "cpp"
+    }
+}

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -120,7 +120,7 @@ bond::populateBonds(std::vector<std::vector<int>> nList,
   for (int i = 0; i < nList.size(); i++) {
     iatom = nList[i][0]; // Index of the i^th atom
     // Skip for dummy atoms
-    if (atomTypes[iatom] == cage::dummy) {
+    if (atomTypes[iatom] == cage::iceType::dummy) {
       continue;
     } // Skip for dummy atoms
     // Get the neighbours of iatom
@@ -128,7 +128,7 @@ bond::populateBonds(std::vector<std::vector<int>> nList,
       //
       jatom = nList[iatom][j]; // Index of the neighbour
       // Skip for dummy atoms
-      if (atomTypes[jatom] == cage::dummy) {
+      if (atomTypes[jatom] == cage::iceType::dummy) {
         continue;
       } // Skip for dummy atoms
       // To avoid duplicates, skip all bonds such

--- a/src/bop.cpp
+++ b/src/bop.cpp
@@ -420,11 +420,11 @@ chill::getCorrel(molSys::PointCloud<molSys::Point<double>, double> *yCloud,
       cij_real = complexCij.real();
       temp_cij.c_value = cij_real;
       if (cij_real < -0.8) {
-        temp_cij.classifier = molSys::staggered;
+        temp_cij.classifier = molSys::bond_type::staggered;
       } else if (cij_real > -0.2 && cij_real < -0.05) {
-        temp_cij.classifier = molSys::eclipsed;
+        temp_cij.classifier = molSys::bond_type::eclipsed;
       } else {
-        temp_cij.classifier = molSys::out_of_range;
+        temp_cij.classifier = molSys::bond_type::out_of_range;
       }
       yCloud->pts[iatomIndex].c_ij.push_back(temp_cij);
     } // end loop over nearest neighbours
@@ -461,9 +461,9 @@ molSys::PointCloud<molSys::Point<double>, double> chill::getIceTypeNoPrint(
     // Loop through the bond cij and get the number of staggered, eclipsed bonds
     for (int j = 0; j < nnumNeighbours; j++) {
       bondType = yCloud->pts[iatom].c_ij[j].classifier;
-      if (bondType == molSys::eclipsed) {
+      if (bondType == molSys::bond_type::eclipsed) {
         num_eclipsd++;
-      } else if (bondType == molSys::staggered) {
+      } else if (bondType == molSys::bond_type::staggered) {
         num_staggrd++;
       } else {
         na++;
@@ -471,27 +471,27 @@ molSys::PointCloud<molSys::Point<double>, double> chill::getIceTypeNoPrint(
     } // End of loop through neighbours
 
     // Add more tests later
-    yCloud->pts[iatom].iceType = molSys::unclassified; // default
+    yCloud->pts[iatom].iceType = molSys::atom_state_type::unclassified; // default
     // Cubic ice
     // if (num_eclipsd==0 && num_staggrd==4){
     //  yCloud->pts[iatom].iceType = molSys::cubic;
     //  ic++;
     // }
     if (num_staggrd >= 4) {
-      yCloud->pts[iatom].iceType = molSys::cubic;
+      yCloud->pts[iatom].iceType = molSys::atom_state_type::cubic;
       ic++;
     }
     // Hexagonal
     else if (num_eclipsd == 1 && num_staggrd == 3) {
-      yCloud->pts[iatom].iceType = molSys::hexagonal;
+      yCloud->pts[iatom].iceType = molSys::atom_state_type::hexagonal;
       ih++;
     }
     // Interfacial
     else if (isInterfacial(yCloud, nList, iatom, num_staggrd, num_eclipsd)) {
-      yCloud->pts[iatom].iceType = molSys::interfacial;
+      yCloud->pts[iatom].iceType = molSys::atom_state_type::interfacial;
       interIce++;
     } else {
-      yCloud->pts[iatom].iceType = molSys::water;
+      yCloud->pts[iatom].iceType = molSys::atom_state_type::water;
       water++;
     }
 
@@ -529,9 +529,9 @@ chill::getIceType(molSys::PointCloud<molSys::Point<double>, double> *yCloud,
     // Loop through the bond cij and get the number of staggered, eclipsed bonds
     for (int j = 0; j < nnumNeighbours; j++) {
       bondType = yCloud->pts[iatom].c_ij[j].classifier;
-      if (bondType == molSys::eclipsed) {
+      if (bondType == molSys::bond_type::eclipsed) {
         num_eclipsd++;
-      } else if (bondType == molSys::staggered) {
+      } else if (bondType == molSys::bond_type::staggered) {
         num_staggrd++;
       } else {
         na++;
@@ -539,27 +539,27 @@ chill::getIceType(molSys::PointCloud<molSys::Point<double>, double> *yCloud,
     } // End of loop through neighbours
 
     // Add more tests later
-    yCloud->pts[iatom].iceType = molSys::unclassified; // default
+    yCloud->pts[iatom].iceType = molSys::atom_state_type::unclassified; // default
     // Cubic ice
     // if (num_eclipsd==0 && num_staggrd==4){
     // 	yCloud->pts[iatom].iceType = molSys::cubic;
     // 	ic++;
     // }
     if (num_staggrd >= 4) {
-      yCloud->pts[iatom].iceType = molSys::cubic;
+      yCloud->pts[iatom].iceType = molSys::atom_state_type::cubic;
       ic++;
     }
     // Hexagonal
     else if (num_eclipsd == 1 && num_staggrd == 3) {
-      yCloud->pts[iatom].iceType = molSys::hexagonal;
+      yCloud->pts[iatom].iceType = molSys::atom_state_type::hexagonal;
       ih++;
     }
     // Interfacial
     else if (isInterfacial(yCloud, nList, iatom, num_staggrd, num_eclipsd)) {
-      yCloud->pts[iatom].iceType = molSys::interfacial;
+      yCloud->pts[iatom].iceType = molSys::atom_state_type::interfacial;
       interIce++;
     } else {
-      yCloud->pts[iatom].iceType = molSys::water;
+      yCloud->pts[iatom].iceType = molSys::atom_state_type::water;
       water++;
     }
 
@@ -723,11 +723,11 @@ chill::getCorrelPlus(molSys::PointCloud<molSys::Point<double>, double> *yCloud,
       cij_real = complexCij.real();
       temp_cij.c_value = cij_real;
       if (cij_real <= -0.8) {
-        temp_cij.classifier = molSys::staggered;
+        temp_cij.classifier = molSys::bond_type::staggered;
       } else if (cij_real >= -0.35 && cij_real <= 0.25) {
-        temp_cij.classifier = molSys::eclipsed;
+        temp_cij.classifier = molSys::bond_type::eclipsed;
       } else {
-        temp_cij.classifier = molSys::out_of_range;
+        temp_cij.classifier = molSys::bond_type::out_of_range;
       }
       yCloud->pts[iatomIndex].c_ij.push_back(temp_cij);
     } // end loop over nearest neighbours
@@ -782,9 +782,9 @@ chill::getIceTypePlus(molSys::PointCloud<molSys::Point<double>, double> *yCloud,
     // Loop through the bond cij and get the number of staggered, eclipsed bonds
     for (int j = 0; j < nnumNeighbours; j++) {
       bondType = yCloud->pts[iatom].c_ij[j].classifier;
-      if (bondType == molSys::eclipsed) {
+      if (bondType == molSys::bond_type::eclipsed) {
         num_eclipsd++;
-      } else if (bondType == molSys::staggered) {
+      } else if (bondType == molSys::bond_type::staggered) {
         num_staggrd++;
       } else {
         na++;
@@ -792,40 +792,40 @@ chill::getIceTypePlus(molSys::PointCloud<molSys::Point<double>, double> *yCloud,
     } // End of loop through neighbours
 
     // Add more tests later
-    yCloud->pts[iatom].iceType = molSys::unclassified; // default
+    yCloud->pts[iatom].iceType = molSys::atom_state_type::unclassified; // default
     if (nnumNeighbours == 4) {
       // Cubic ice
       if (num_eclipsd == 0 && num_staggrd == 4) {
-        yCloud->pts[iatom].iceType = molSys::cubic;
+        yCloud->pts[iatom].iceType = molSys::atom_state_type::cubic;
         ic++;
       }
       // Hexagonal
       else if (num_eclipsd == 1 && num_staggrd == 3) {
-        yCloud->pts[iatom].iceType = molSys::hexagonal;
+        yCloud->pts[iatom].iceType = molSys::atom_state_type::hexagonal;
         ih++;
       }
       // Interfacial
       else if (isInterfacial(yCloud, nList, iatom, num_staggrd, num_eclipsd)) {
-        yCloud->pts[iatom].iceType = molSys::interfacial;
+        yCloud->pts[iatom].iceType = molSys::atom_state_type::interfacial;
         interIce++;
       }
       // Clathrate
       else if (num_eclipsd == 4 && num_staggrd == 0) {
-        yCloud->pts[iatom].iceType = molSys::clathrate;
+        yCloud->pts[iatom].iceType = molSys::atom_state_type::clathrate;
         clath++;
       }
       // Interfacial clathrate
       else if (num_eclipsd == 3) {
-        yCloud->pts[iatom].iceType = molSys::interClathrate;
+        yCloud->pts[iatom].iceType = molSys::atom_state_type::interClathrate;
         interClath++;
       }
       // Water
       else {
-        yCloud->pts[iatom].iceType = molSys::water;
+        yCloud->pts[iatom].iceType = molSys::atom_state_type::water;
         water++;
       }
     } else {
-      yCloud->pts[iatom].iceType = molSys::water;
+      yCloud->pts[iatom].iceType = molSys::atom_state_type::water;
       water++;
     }
 
@@ -1019,7 +1019,7 @@ molSys::PointCloud<molSys::Point<double>, double> chill::reclassifyWater(
 
   for (int iatom = 0; iatom < yCloud->nop; iatom++) {
     // Check if it has been classified as water
-    if (yCloud->pts[iatom].iceType == molSys::water) {
+    if (yCloud->pts[iatom].iceType == molSys::atom_state_type::water) {
       if ((*q6)[iatom] > 0.5) {
         avgQ3 = 0.0; // init to zero
         // Loop through all c_ij
@@ -1032,10 +1032,10 @@ molSys::PointCloud<molSys::Point<double>, double> chill::reclassifyWater(
         // If averaged q3 < -0.75, then reclassify
         if (avgQ3 <= -0.75) {
           if (avgQ3 < -0.85) {
-            yCloud->pts[iatom].iceType = molSys::reCubic;
+            yCloud->pts[iatom].iceType = molSys::atom_state_type::reCubic;
           } // molSys::cubic
           else {
-            yCloud->pts[iatom].iceType = molSys::reHex;
+            yCloud->pts[iatom].iceType = molSys::atom_state_type::reHex;
           } // molSys::hexagonal
         }   // end of reclassification
       }     // check for solid atom!
@@ -1074,17 +1074,17 @@ int chill::printIceType(
       }
     }
     total++;
-    if (yCloud->pts[iatom].iceType == molSys::cubic) {
+    if (yCloud->pts[iatom].iceType == molSys::atom_state_type::cubic) {
       ic++;
-    } else if (yCloud->pts[iatom].iceType == molSys::hexagonal) {
+    } else if (yCloud->pts[iatom].iceType == molSys::atom_state_type::hexagonal) {
       ih++;
-    } else if (yCloud->pts[iatom].iceType == molSys::water) {
+    } else if (yCloud->pts[iatom].iceType == molSys::atom_state_type::water) {
       water++;
-    } else if (yCloud->pts[iatom].iceType == molSys::interfacial) {
+    } else if (yCloud->pts[iatom].iceType == molSys::atom_state_type::interfacial) {
       interIce++;
-    } else if (yCloud->pts[iatom].iceType == molSys::clathrate) {
+    } else if (yCloud->pts[iatom].iceType == molSys::atom_state_type::clathrate) {
       clath++;
-    } else if (yCloud->pts[iatom].iceType == molSys::interClathrate) {
+    } else if (yCloud->pts[iatom].iceType == molSys::atom_state_type::interClathrate) {
       interClath++;
     } else {
       unknown++;
@@ -1211,7 +1211,7 @@ int chill::numStaggered(
   for (int i = 0; i < nnumNeighbours; i++) {
     bondType = yCloud->pts[jatom].c_ij[i].classifier;
     // If the bond is staggered increment the number of staggered bonds
-    if (bondType == molSys::staggered) {
+    if (bondType == molSys::bond_type::staggered) {
       num_staggrd++;
     }
   } // end of loop over c_ij

--- a/src/bulkTUM.cpp
+++ b/src/bulkTUM.cpp
@@ -202,19 +202,19 @@ int tum3::topoUnitMatchingBulk(
   dumpAtomTypes.resize(atomTypes.size());
   // Change from enum to int
   for (int i = 0; i < atomTypes.size(); i++) {
-    if (atomTypes[i] == cage::hc) {
+    if (atomTypes[i] == cage::iceType::hc) {
       dumpAtomTypes[i] = 1;
     } // HC
-    else if (atomTypes[i] == cage::ddc) {
+    else if (atomTypes[i] == cage::iceType::ddc) {
       dumpAtomTypes[i] = 2;
     } // DDC
-    else if (atomTypes[i] == cage::mixed) {
+    else if (atomTypes[i] == cage::iceType::mixed) {
       dumpAtomTypes[i] = 3;
     } // mixed rings
-    else if (atomTypes[i] == cage::pnc) {
+    else if (atomTypes[i] == cage::iceType::pnc) {
       dumpAtomTypes[i] = 4;
     } // pnc
-    else if (atomTypes[i] == cage::mixed2) {
+    else if (atomTypes[i] == cage::iceType::mixed2) {
       dumpAtomTypes[i] = 5;
     } // shared by pnc and ddc/hc
     else {
@@ -504,7 +504,7 @@ int tum3::updateRMSDatom(std::vector<std::vector<int>> rings,
       iatom = rings[iring][j]; // Current atom index
 
       // Skip for PNC atoms
-      if (atomTypes[iatom] == cage::pnc || atomTypes[iatom] == cage::mixed2) {
+      if (atomTypes[iatom] == cage::iceType::pnc || atomTypes[iatom] == cage::iceType::mixed2) {
         continue;
       } // Do not update if the atom is a PNC
       //
@@ -730,7 +730,7 @@ int tum3::clusterCages(
     // If only one cage is in the cluster
     if (linkedList[i] == i) {
       // Add to the number of single DDCs
-      if (cageList[i].type == cage::DoubleDiaC) {
+      if (cageList[i].type == cage::cageType::DoubleDiaC) {
         singleDDCs++;
       } // add to the single DDCs
       else {

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -363,10 +363,10 @@ int clump::clusterAnalysis(
     // Assign values to isIce according to the CHILL algorithm
     for (int iatom = 0; iatom < yCloud->nop; iatom++) {
       // If it is an ice-like molecule, add it, otherwise skip
-      if (yCloud->pts[iatom].iceType == molSys::water) {
+      if (yCloud->pts[iatom].iceType == molSys::atom_state_type::water) {
         continue;
       } // water
-      if (yCloud->pts[iatom].iceType == molSys::unclassified) {
+      if (yCloud->pts[iatom].iceType == molSys::atom_state_type::unclassified) {
         continue;
       }                    // unclassified
       isIce[iatom] = true; // is ice-like; by default false

--- a/src/generic.cpp
+++ b/src/generic.cpp
@@ -40,7 +40,8 @@ int gen::prettyPrintYoda(
       // Print out cij
       // for(int c=0; c<yCloud->pts[i].c_ij.size(); c++){outputFile <<
       // yCloud->pts[i].c_ij[c]<<"\t";} Print out the classifier
-      outputFile << yCloud->pts[i].iceType << "\n";
+      // TODO: Should print string representation
+      outputFile << static_cast<int>(yCloud->pts[i].iceType) << "\n";
     }
   }
   // Close the file

--- a/src/include/internal/cage.hpp
+++ b/src/include/internal/cage.hpp
@@ -41,7 +41,7 @@
 namespace cage {
 
 // Type of a cage (a group of rings)
-/** @enum cage::cageType
+/** @enum class cage::cageType
  * Qualifier for a cage.
  * According to the topological network criterion for DDCs and HCs
  *
@@ -51,11 +51,11 @@ namespace cage {
  * @var molSys::cageType DoubleDiaC
  * The type for a double-diamond cage
  */
-enum cageType { HexC, DoubleDiaC };
+enum class cageType { HexC, DoubleDiaC };
 
 // Type of ice for a particular atom. Dummy means that the atom is unclassified
 // and is most probably water
-/** @enum cage::iceType
+/** @enum class cage::iceType
  * Qualifier for an atom, based on whether it is part of cages,
  * according to the topological network criterion for DDCs and HCs
  *
@@ -72,7 +72,7 @@ enum cageType { HexC, DoubleDiaC };
  * Type for an atom which is part of a mixed ring, shared by both a DDC and an
  * HC
  */
-enum iceType { dummy, hc, ddc, mixed, pnc, mixed2 };
+enum class iceType { dummy, hc, ddc, mixed, pnc, mixed2 };
 
 // Each DDC has one equatorial ring and 6 peripheral rings
 // Each HC has two basal planes and 3 prismatic planes

--- a/src/include/internal/mol_sys.hpp
+++ b/src/include/internal/mol_sys.hpp
@@ -58,7 +58,7 @@ namespace molSys {
 
 // Enum type for bond type
 
-/** @enum molSys::bond_type
+/** @enum class molSys::bond_type
  * @brief Qualifier for the bond type between two nearest-neighbours, according
  *  to the CHILL or CHILL+ classification scheme.
  *
@@ -72,9 +72,9 @@ namespace molSys {
  * @var molSys::bond_type out_of_range
  * @brief The bond cannot be classified as either staggered or eclipsed.
  */
-enum bond_type { staggered, eclipsed, out_of_range };
+enum class bond_type { staggered, eclipsed, out_of_range };
 
-/** \enum molSys::atom_state_type
+/** \enum class molSys::atom_state_type
  * @brief Qualifier for the per-particle phase state, according to the CHILL,
  *  CHILL+, or @f$q_6@f$ order parameter.
  *
@@ -110,7 +110,7 @@ enum bond_type { staggered, eclipsed, out_of_range };
  * @brief Reclassified as hexagonal ice, according
  *  to the @f$q_6@f$ order parameter.
  */
-enum atom_state_type {
+enum class atom_state_type {
   cubic,
   hexagonal,
   water,
@@ -123,7 +123,7 @@ enum atom_state_type {
 };
 
 /** @struct Result
- * @brief This contains the bond classifier of enum type #bond_type, and the
+ * @brief This contains the bond classifier of enum class type #bond_type, and the
  *  bond correlation factor.
  * @details Contains specifically the members:
  * - Bond classifier or the type of the bond (staggered, eclipsed, out-of-range)
@@ -151,7 +151,7 @@ template <typename T> struct Point {
   T x, y, z;                //! coordinates
   std::vector<Result> c_ij; //! Results (contains bond correlation type)
   atom_state_type iceType =
-      molSys::unclassified; //! Type of ice/water etc based on cij
+      molSys::atom_state_type::unclassified; //! Type of ice/water etc based on cij
   bool inSlice = true;      //! Is the point inside the slice or not?
 };
 

--- a/src/include/internal/ring.hpp
+++ b/src/include/internal/ring.hpp
@@ -63,9 +63,9 @@
 
 namespace ring {
 
-// General enum used throughout this program (Prism is for our prism
+// General enum class used throughout this program (Prism is for our prism
 // classification) {per-ring classification}
-/** @enum ring::strucType Qualifier for each ring, based on the classification
+/** @enum class ring::strucType Qualifier for each ring, based on the classification
  * type determined by the bulk or confined ice topological network criteria.
  * @var ring::strucType unclassified
  * @brief The ring is unclassified, which may be either water or a deformed type
@@ -113,7 +113,7 @@ namespace ring {
  * @brief The ring belongs to a prism block, classified according to the prism
  * identification scheme.
  */
-enum strucType {
+enum class strucType {
   unclassified,
   DDC,
   HCbasal,

--- a/src/include/internal/topo_bulk.hpp
+++ b/src/include/internal/topo_bulk.hpp
@@ -121,7 +121,7 @@ int findPrismatic(std::vector<std::vector<int>> rings, std::vector<int> *listHC,
                   std::vector<strucType> *ringType, int iring, int jring,
                   std::vector<int> *prismaticRings);
 
-//! Assigns a type of enum iceType, to every atom, using information from
+//! Assigns a type of enum class iceType, to every atom, using information from
 //! ringType, which has the information of every ring
 int getAtomTypesTopoBulk(std::vector<std::vector<int>> rings,
                          std::vector<ring::strucType> ringType,

--- a/src/pntCorrespondence.cpp
+++ b/src/pntCorrespondence.cpp
@@ -571,7 +571,7 @@ Eigen::MatrixXd pntToPnt::getPointSetCage(ring::strucType type) {
   molSys::PointCloud<molSys::Point<double>, double>
       setCloud; // PointCloud for holding the reference point values
 
-  if (type == ring::HCbasal) {
+  if (type == ring::strucType::HCbasal) {
     // Read in the XYZ file
     std::string fileName = "templates/hc.xyz";
     //

--- a/src/seams_output.cpp
+++ b/src/seams_output.cpp
@@ -313,13 +313,13 @@ int sout::writeAllCages(
     // ------
     // Add to the cage type and write out to the appropriate folders
     // Hexagonal Cages
-    if (type == cage::HexC) {
+    if (type == cage::cageType::HexC) {
       numHC++;
       sout::writeEachCage((*cageList)[icage].rings, numHC, type, rings, yCloud);
       sout::writeBasalRingsHex((*cageList)[icage].rings, numHC, nList, rings);
     } // end of write out of HCs
     // Double diamond Cages
-    else if (type == cage::DoubleDiaC) {
+    else if (type == cage::cageType::DoubleDiaC) {
       numDDC++;
       sout::writeEachCage((*cageList)[icage].rings, numDDC, type, rings,
                           yCloud);
@@ -359,10 +359,10 @@ int sout::writeEachCage(
   char cageChar[100];         // is icage a DDC, HC or MC?
   int iring;                  // Ring index of the current ring
 
-  if (type == cage::HexC) {
+  if (type == cage::cageType::HexC) {
     strcpy(cageChar, "../output/cages/hexCages");
     actualCageType = "hexCages";
-  } else if (type == cage::DoubleDiaC) {
+  } else if (type == cage::cageType::DoubleDiaC) {
     strcpy(cageChar, "../output/cages/doubleDiaCages");
     actualCageType = "doubleDiaCages";
   } else {
@@ -393,7 +393,7 @@ int sout::writeEachCage(
   // x y z coordinates of each node
 
   // For hexagonal cages:
-  if (type == cage::HexC) {
+  if (type == cage::cageType::HexC) {
     // Print out only basal ring atoms, since they describe the outer structure
     // The first two rings are basal rings
     for (int i = 0; i < 2; i++) {
@@ -2156,9 +2156,9 @@ int sout::writeLAMMPSdataCages(
   // Masses
   outputFile << "\nMasses\n\n";
   // For DDCs and HCs
-  if (type == cage::HexC) {
+  if (type == cage::cageType::HexC) {
     actualCageType = "HC";
-  } else if (type == cage::DoubleDiaC) {
+  } else if (type == cage::cageType::DoubleDiaC) {
     actualCageType = "DDC";
   } else {
     actualCageType = "error";
@@ -2280,42 +2280,42 @@ int sout::writeDump(molSys::PointCloud<molSys::Point<double>, double> *yCloud,
     outputFile << yCloud->pts[iatom].atomID << " " << yCloud->pts[iatom].molID;
 
     // Cubic ice
-    if (yCloud->pts[iatom].iceType == molSys::cubic) {
+    if (yCloud->pts[iatom].iceType == molSys::atom_state_type::cubic) {
       outputFile << " Ic " << yCloud->pts[iatom].x << " "
                  << yCloud->pts[iatom].y << " " << yCloud->pts[iatom].z << "\n";
     } // end of cubic ice
     // Hexagonal ice
-    else if (yCloud->pts[iatom].iceType == molSys::hexagonal) {
+    else if (yCloud->pts[iatom].iceType == molSys::atom_state_type::hexagonal) {
       outputFile << " Ih " << yCloud->pts[iatom].x << " "
                  << yCloud->pts[iatom].y << " " << yCloud->pts[iatom].z << "\n";
     } // end hexagonal ice
     // water
-    else if (yCloud->pts[iatom].iceType == molSys::water) {
+    else if (yCloud->pts[iatom].iceType == molSys::atom_state_type::water) {
       outputFile << " wat " << yCloud->pts[iatom].x << " "
                  << yCloud->pts[iatom].y << " " << yCloud->pts[iatom].z << "\n";
     } // end water
     // interfacial
-    else if (yCloud->pts[iatom].iceType == molSys::interfacial) {
+    else if (yCloud->pts[iatom].iceType == molSys::atom_state_type::interfacial) {
       outputFile << " intFc " << yCloud->pts[iatom].x << " "
                  << yCloud->pts[iatom].y << " " << yCloud->pts[iatom].z << "\n";
     } // end interfacial
     // clathrate
-    else if (yCloud->pts[iatom].iceType == molSys::clathrate) {
+    else if (yCloud->pts[iatom].iceType == molSys::atom_state_type::clathrate) {
       outputFile << " clathrate " << yCloud->pts[iatom].x << " "
                  << yCloud->pts[iatom].y << " " << yCloud->pts[iatom].z << "\n";
     } // end clathrate
     // interClathrate
-    else if (yCloud->pts[iatom].iceType == molSys::interClathrate) {
+    else if (yCloud->pts[iatom].iceType == molSys::atom_state_type::interClathrate) {
       outputFile << " interClathrate " << yCloud->pts[iatom].x << " "
                  << yCloud->pts[iatom].y << " " << yCloud->pts[iatom].z << "\n";
     } // end interClathrate
     // unclassified
-    else if (yCloud->pts[iatom].iceType == molSys::unclassified) {
+    else if (yCloud->pts[iatom].iceType == molSys::atom_state_type::unclassified) {
       outputFile << " unclassified " << yCloud->pts[iatom].x << " "
                  << yCloud->pts[iatom].y << " " << yCloud->pts[iatom].z << "\n";
     } // end unclassified
     // reCubic
-    else if (yCloud->pts[iatom].iceType == molSys::reCubic) {
+    else if (yCloud->pts[iatom].iceType == molSys::atom_state_type::reCubic) {
       outputFile << " reIc " << yCloud->pts[iatom].x << " "
                  << yCloud->pts[iatom].y << " " << yCloud->pts[iatom].z << "\n";
     } // end reCubic
@@ -2499,22 +2499,22 @@ int sout::writeLAMMPSdataTopoBulk(
     //
     // Get the atom type
     // hc atom type
-    if (atomTypes[i] == cage::hc) {
+    if (atomTypes[i] == cage::iceType::hc) {
       currentAtomType = 2;
     } // hc
-    else if (atomTypes[i] == cage::ddc) {
+    else if (atomTypes[i] == cage::iceType::ddc) {
       currentAtomType = 3;
     } // ddc
     // mixed
-    else if (atomTypes[i] == cage::mixed) {
+    else if (atomTypes[i] == cage::iceType::mixed) {
       currentAtomType = 4;
     } // mixed
     // pnc
-    else if (atomTypes[i] == cage::pnc) {
+    else if (atomTypes[i] == cage::iceType::pnc) {
       currentAtomType = 5;
     } // mixed
     // pnc and DDCs/HCs mixed
-    else if (atomTypes[i] == cage::mixed2) {
+    else if (atomTypes[i] == cage::iceType::mixed2) {
       currentAtomType = 6;
     } // mixed
     // dummy
@@ -2582,8 +2582,8 @@ int sout::writeXYZcluster(
   // Write out all the atom coordinates
   for (int i = 0; i < nAtoms; i++) {
     iatom = atoms[i]; // Atom index to be printed out
-    //
-    outputFile << type << " " << yCloud->pts[iatom].x << " "
+    // TODO: Should print string representation
+    outputFile << static_cast<int>(type) << " " << yCloud->pts[iatom].x << " "
                << yCloud->pts[iatom].y << " " << yCloud->pts[iatom].z << "\n";
   } // end of loop through all atoms
 

--- a/src/topo_bulk.cpp
+++ b/src/topo_bulk.cpp
@@ -362,23 +362,23 @@ std::vector<int> ring::findDDC(std::vector<std::vector<int>> rings,
     }
     // ------------
     // If iring is an equatorial ring, add it to the listDDC vector
-    if ((*ringType)[iring] == ring::unclassified) {
-      (*ringType)[iring] = ring::DDC;
+    if ((*ringType)[iring] == ring::strucType::unclassified) {
+      (*ringType)[iring] = ring::strucType::DDC;
       listDDC.push_back(iring);
     }
     // Add the peripheral ring IDs too
     for (int j = 0; j < peripheralRings.size(); j++) {
       jring = peripheralRings[j];
-      if ((*ringType)[jring] == ring::unclassified) {
-        (*ringType)[jring] = ring::DDC;
+      if ((*ringType)[jring] == ring::strucType::unclassified) {
+        (*ringType)[jring] = ring::strucType::DDC;
         listDDC.push_back(jring);
-      } else if ((*ringType)[jring] == ring::HCbasal) {
-        (*ringType)[jring] = ring::bothBasal;
+      } else if ((*ringType)[jring] == ring::strucType::HCbasal) {
+        (*ringType)[jring] = ring::strucType::bothBasal;
         listDDC.push_back(jring);
       } // end of update
       // never true
-      else if ((*ringType)[jring] == ring::HCprismatic) {
-        (*ringType)[jring] = ring::bothPrismatic;
+      else if ((*ringType)[jring] == ring::strucType::HCprismatic) {
+        (*ringType)[jring] = ring::strucType::bothPrismatic;
         listDDC.push_back(jring);
       }
       //
@@ -390,7 +390,7 @@ std::vector<int> ring::findDDC(std::vector<std::vector<int>> rings,
     DDCRings.push_back(iring); // Add the equatorial ring first
     DDCRings.insert(std::end(DDCRings), std::begin(peripheralRings),
                     std::end(peripheralRings));
-    (*cageList).push_back({cage::DoubleDiaC, DDCRings});
+    (*cageList).push_back({cage::cageType::DoubleDiaC, DDCRings});
     // ------------
   } // end of loop through all hexagonal rings
 
@@ -706,19 +706,19 @@ std::vector<int> ring::findHC(std::vector<std::vector<int>> rings,
       // -----------
       // iring and jring are basal rings!
       // Update iring
-      if ((*ringType)[iring] == ring::unclassified) {
-        (*ringType)[iring] = ring::HCbasal;
+      if ((*ringType)[iring] == ring::strucType::unclassified) {
+        (*ringType)[iring] = ring::strucType::HCbasal;
         listHC.push_back(iring);
-      } else if ((*ringType)[iring] == ring::DDC) {
-        (*ringType)[iring] = ring::bothBasal;
+      } else if ((*ringType)[iring] == ring::strucType::DDC) {
+        (*ringType)[iring] = ring::strucType::bothBasal;
         listHC.push_back(iring);
       }
       // Update jring
-      if ((*ringType)[jring] == ring::unclassified) {
-        (*ringType)[jring] = ring::HCbasal;
+      if ((*ringType)[jring] == ring::strucType::unclassified) {
+        (*ringType)[jring] = ring::strucType::HCbasal;
         listHC.push_back(jring);
-      } else if ((*ringType)[jring] == ring::DDC) {
-        (*ringType)[jring] = ring::bothBasal;
+      } else if ((*ringType)[jring] == ring::strucType::DDC) {
+        (*ringType)[jring] = ring::strucType::bothBasal;
         listHC.push_back(jring);
       }
       // Find the prismatic rings
@@ -730,11 +730,11 @@ std::vector<int> ring::findHC(std::vector<std::vector<int>> rings,
         kring =
             prismaticRings[k]; // Current ring index of the (3) prismatic rings
         // Update kring
-        if ((*ringType)[kring] == ring::unclassified) {
-          (*ringType)[kring] = ring::HCprismatic;
+        if ((*ringType)[kring] == ring::strucType::unclassified) {
+          (*ringType)[kring] = ring::strucType::HCprismatic;
           listHC.push_back(kring);
-        } else if ((*ringType)[kring] == ring::DDC) {
-          (*ringType)[kring] = ring::bothPrismatic;
+        } else if ((*ringType)[kring] == ring::strucType::DDC) {
+          (*ringType)[kring] = ring::strucType::bothPrismatic;
           listHC.push_back(kring);
         }
         //
@@ -751,7 +751,7 @@ std::vector<int> ring::findHC(std::vector<std::vector<int>> rings,
       // Add the prismaticRings
       HCRings.insert(std::end(HCRings), std::begin(prismaticRings),
                      std::end(prismaticRings));
-      (*cageList).push_back({cage::HexC, HCRings});
+      (*cageList).push_back({cage::cageType::HexC, HCRings});
       // -----------
     } // end of loop through rest of the rings to get the second basal ring
   }   // end of loop through all rings for first basal ring
@@ -1086,12 +1086,12 @@ int ring::findPrismatic(std::vector<std::vector<int>> rings,
         (*prismaticRings).push_back(kring); // Update prismatic rings
         // Update the type inside ringType
         // If the ring is already a DDC ring, it is a mixed ring
-        if ((*ringType)[kring] == ring::DDC) {
-          (*ringType)[kring] = ring::bothPrismatic;
+        if ((*ringType)[kring] == ring::strucType::DDC) {
+          (*ringType)[kring] = ring::strucType::bothPrismatic;
         }
         // If it is unclassified, it is just a prismatic ring
-        if ((*ringType)[kring] == ring::unclassified) {
-          (*ringType)[kring] = ring::HCprismatic;
+        if ((*ringType)[kring] == ring::strucType::unclassified) {
+          (*ringType)[kring] = ring::strucType::HCprismatic;
         } // end ring update
       }   // add kring to the list of prismatic rings
     }     // end of searching through rings for kring
@@ -1125,8 +1125,8 @@ std::vector<int> ring::findMixedRings(std::vector<std::vector<int>> rings,
   // adds the ring Indices of all rings which are both DDCs and HCs
   for (int iring = 0; iring < (*ringType).size(); iring++) {
     // If iring is of mixed type, add it to the listMixed vector
-    if ((*ringType)[iring] == ring::bothBasal ||
-        (*ringType)[iring] == ring::bothPrismatic) {
+    if ((*ringType)[iring] == ring::strucType::bothBasal ||
+        (*ringType)[iring] == ring::strucType::bothPrismatic) {
       listMixed.push_back(iring);
 
       //-----------------
@@ -1172,33 +1172,33 @@ int ring::getAtomTypesTopoBulk(std::vector<std::vector<int>> rings,
   for (int iring = 0; iring < ringType.size(); iring++) {
     //
     // Skip if the ring is unclassified
-    if (ringType[iring] == ring::unclassified) {
+    if (ringType[iring] == ring::strucType::unclassified) {
       continue;
     } // skip for unclassified rings
 
     // ------------
     // Get the current ring type
     // DDC
-    if (ringType[iring] == ring::DDC) {
-      iRingType = cage::ddc;
+    if (ringType[iring] == ring::strucType::DDC) {
+      iRingType = cage::iceType::ddc;
     } // DDC atoms
     //
     // HC
-    else if (ringType[iring] == ring::HCbasal ||
-             ringType[iring] == ring::HCprismatic) {
-      iRingType = cage::hc;
+    else if (ringType[iring] == ring::strucType::HCbasal ||
+             ringType[iring] == ring::strucType::HCprismatic) {
+      iRingType = cage::iceType::hc;
     } // HC atoms
     //
     // Mixed
-    else if (ringType[iring] == ring::bothBasal ||
-             ringType[iring] == ring::bothPrismatic) {
-      iRingType = cage::mixed;
+    else if (ringType[iring] == ring::strucType::bothBasal ||
+             ringType[iring] == ring::strucType::bothPrismatic) {
+      iRingType = cage::iceType::mixed;
     } // HC atoms
     // Prism
-    else if (ringType[iring] == ring::Prism ||
-             ringType[iring] == ring::deformedPrism ||
-             ringType[iring] == ring::mixedPrismRing) {
-      iRingType = cage::pnc; // 5 membered pnc
+    else if (ringType[iring] == ring::strucType::Prism ||
+             ringType[iring] == ring::strucType::deformedPrism ||
+             ringType[iring] == ring::strucType::mixedPrismRing) {
+      iRingType = cage::iceType::pnc; // 5 membered pnc
     }                        // prism
     // Should never go here
     else {
@@ -1209,14 +1209,14 @@ int ring::getAtomTypesTopoBulk(std::vector<std::vector<int>> rings,
     // iRingType
     for (int i = 0; i < ringSize; i++) {
       iatom = rings[iring][i]; // Atom index in ring
-      if ((*atomTypes)[iatom] == cage::mixed ||
-          (*atomTypes)[iatom] == cage::mixed2) {
+      if ((*atomTypes)[iatom] == cage::iceType::mixed ||
+          (*atomTypes)[iatom] == cage::iceType::mixed2) {
         continue;
       } // Don't reassign
       // For atoms shared by PNCs and DDCs/HCs
       if (ringSize == 6) {
-        if ((*atomTypes)[iatom] == cage::pnc) {
-          (*atomTypes)[iatom] = cage::mixed2;
+        if ((*atomTypes)[iatom] == cage::iceType::pnc) {
+          (*atomTypes)[iatom] = cage::iceType::mixed2;
         } else {
           (*atomTypes)[iatom] = iRingType;
         }
@@ -1261,12 +1261,12 @@ int ring::getStrucNumbers(std::vector<ring::strucType> ringType,
   for (int icage = 0; icage < cageList.size(); icage++) {
     //
     // HC
-    if (cageList[icage].type == cage::HexC) {
+    if (cageList[icage].type == cage::cageType::HexC) {
       *numHC += 1;
     } // end of updating HC number
     //
     // DDC
-    if (cageList[icage].type == cage::DoubleDiaC) {
+    if (cageList[icage].type == cage::cageType::DoubleDiaC) {
       *numDDC += 1;
     } // end of updating DDC number
   }   // end of loop through cages
@@ -1275,25 +1275,25 @@ int ring::getStrucNumbers(std::vector<ring::strucType> ringType,
   // Loop through the rings
   for (int iring = 0; iring < ringType.size(); iring++) {
     // Mixed
-    if (ringType[iring] == ring::bothBasal ||
-        ringType[iring] == ring::bothPrismatic) {
+    if (ringType[iring] == ring::strucType::bothBasal ||
+        ringType[iring] == ring::strucType::bothPrismatic) {
       *mixedRings += 1;
       // Also update basal rings
-      if (ringType[iring] == ring::bothBasal) {
+      if (ringType[iring] == ring::strucType::bothBasal) {
         *basalRings += 1;
       } // mixed basal rings
       // Also update prismatic rings
-      if (ringType[iring] == ring::bothPrismatic) {
+      if (ringType[iring] == ring::strucType::bothPrismatic) {
         *prismaticRings += 1;
       } // mixed prismatic rings
     }   // end of updating mixed
     //
     // HCs
-    if (ringType[iring] == ring::HCprismatic) {
+    if (ringType[iring] == ring::strucType::HCprismatic) {
       *prismaticRings += 1;
     } // HC prismatic
     // basal HCs
-    if (ringType[iring] == ring::HCbasal) {
+    if (ringType[iring] == ring::strucType::HCbasal) {
       *basalRings += 1;
     } // HC basal
   }   // end of loop through every ring
@@ -1376,12 +1376,12 @@ int prism3::findBulkPrisms(
       if (isPrism) {
         //
         // Update iring
-        if ((*ringType)[iring] == ring::unclassified) {
-          (*ringType)[iring] = ring::Prism;
+        if ((*ringType)[iring] == ring::strucType::unclassified) {
+          (*ringType)[iring] = ring::strucType::Prism;
         }
         // Update jring
-        if ((*ringType)[jring] == ring::unclassified) {
-          (*ringType)[jring] = ring::Prism;
+        if ((*ringType)[jring] == ring::strucType::unclassified) {
+          (*ringType)[jring] = ring::strucType::Prism;
         }
       } // end of reduced criteria
       // Strict criteria
@@ -1392,12 +1392,12 @@ int prism3::findBulkPrisms(
           continue;
         }
         // Update iring
-        if ((*ringType)[iring] == ring::unclassified) {
-          (*ringType)[iring] = ring::Prism;
+        if ((*ringType)[iring] == ring::strucType::unclassified) {
+          (*ringType)[iring] = ring::strucType::Prism;
         }
         // Update jring
-        if ((*ringType)[jring] == ring::unclassified) {
-          (*ringType)[jring] = ring::Prism;
+        if ((*ringType)[jring] == ring::strucType::unclassified) {
+          (*ringType)[jring] = ring::strucType::Prism;
         }
         //
         // Shape-matching to get the RMSD (if shape-matching is desired)

--- a/src/topo_one_dim.cpp
+++ b/src/topo_one_dim.cpp
@@ -272,18 +272,18 @@ ring::findPrisms(std::vector<std::vector<int>> rings,
           // // Update the number of prism blocks
           *nImperfectPrisms += 1;
           // Update iring
-          if ((*ringType)[iring] == ring::unclassified) {
-            (*ringType)[iring] = ring::deformedPrism;
+          if ((*ringType)[iring] == ring::strucType::unclassified) {
+            (*ringType)[iring] = ring::strucType::deformedPrism;
             listPrism.push_back(iring);
-          } else if ((*ringType)[iring] == ring::Prism) {
-            (*ringType)[iring] = ring::mixedPrismRing;
+          } else if ((*ringType)[iring] == ring::strucType::Prism) {
+            (*ringType)[iring] = ring::strucType::mixedPrismRing;
           } // if it is deformed
           // Update jring
-          if ((*ringType)[jring] == ring::unclassified) {
-            (*ringType)[jring] = ring::deformedPrism;
+          if ((*ringType)[jring] == ring::strucType::unclassified) {
+            (*ringType)[jring] = ring::strucType::deformedPrism;
             listPrism.push_back(jring);
-          } else if ((*ringType)[jring] == ring::Prism) {
-            (*ringType)[jring] = ring::mixedPrismRing;
+          } else if ((*ringType)[jring] == ring::strucType::Prism) {
+            (*ringType)[jring] = ring::strucType::mixedPrismRing;
           } // if it is deformed
         }   // end of update of ring types
 
@@ -297,18 +297,18 @@ ring::findPrisms(std::vector<std::vector<int>> rings,
         // Update the number of prism blocks
         *nPerfectPrisms += 1;
         // Update iring
-        if ((*ringType)[iring] == ring::unclassified) {
-          (*ringType)[iring] = ring::Prism;
+        if ((*ringType)[iring] == ring::strucType::unclassified) {
+          (*ringType)[iring] = ring::strucType::Prism;
           listPrism.push_back(iring);
-        } else if ((*ringType)[iring] == ring::deformedPrism) {
-          (*ringType)[iring] = ring::mixedPrismRing;
+        } else if ((*ringType)[iring] == ring::strucType::deformedPrism) {
+          (*ringType)[iring] = ring::strucType::mixedPrismRing;
         } // if it is deformed
         // Update jring
-        if ((*ringType)[jring] == ring::unclassified) {
-          (*ringType)[jring] = ring::Prism;
+        if ((*ringType)[jring] == ring::strucType::unclassified) {
+          (*ringType)[jring] = ring::strucType::Prism;
           listPrism.push_back(jring);
-        } else if ((*ringType)[jring] == ring::deformedPrism) {
-          (*ringType)[jring] = ring::mixedPrismRing;
+        } else if ((*ringType)[jring] == ring::strucType::deformedPrism) {
+          (*ringType)[jring] = ring::strucType::mixedPrismRing;
         } // if it is deformed
         //
         // Shape-matching to get the RMSD (if shape-matching is desired)
@@ -720,21 +720,21 @@ int ring::assignPrismType(std::vector<std::vector<int>> rings,
       (*atomTypes)[iatom] = ringSize;
       //
       // Update the state of the atom
-      if ((*atomState)[iatom] == ring::unclassified) {
+      if ((*atomState)[iatom] == ring::strucType::unclassified) {
         (*atomState)[iatom] = currentState;
       } // Update the unclassified atom
       else {
         if ((*atomState)[iatom] != currentState) {
           // For mixed, there is a preference
-          if (currentState == ring::mixedPrismRing) {
+          if (currentState == ring::strucType::mixedPrismRing) {
             (*atomState)[iatom] = currentState;
           } // fill
-          else if ((*atomState)[iatom] == ring::deformedPrism &&
-                   currentState == ring::Prism) {
-            (*atomState)[iatom] = ring::mixedPrismRing;
-          } else if ((*atomState)[iatom] == ring::Prism &&
-                     currentState == ring::deformedPrism) {
-            (*atomState)[iatom] = ring::mixedPrismRing;
+          else if ((*atomState)[iatom] == ring::strucType::deformedPrism &&
+                   currentState == ring::strucType::Prism) {
+            (*atomState)[iatom] = ring::strucType::mixedPrismRing;
+          } else if ((*atomState)[iatom] == ring::strucType::Prism &&
+                     currentState == ring::strucType::deformedPrism) {
+            (*atomState)[iatom] = ring::strucType::mixedPrismRing;
           }
         } //
       }   // already filled?
@@ -765,10 +765,10 @@ int ring::deformedPrismTypes(std::vector<ring::strucType> atomState,
   for (int iatom = 0; iatom < nop; iatom++) {
     // Check the atom state
     // Deformed
-    if (atomState[iatom] == ring::deformedPrism) {
+    if (atomState[iatom] == ring::strucType::deformedPrism) {
       (*atomTypes)[iatom] += maxDepth - 2;
     } // type for a deformed prism atom
-    else if (atomState[iatom] == ring::mixedPrismRing) {
+    else if (atomState[iatom] == ring::strucType::mixedPrismRing) {
       (*atomTypes)[iatom] = 2;
     } // type for a mixed prism ring
   }   // end of reassignation


### PR DESCRIPTION
Changing enum to enum class in dseams was important because with just plain enum, enumerator names are in the same scope as the enum and their values implicitly convert to integers and other types i.e., to another enum etc, but with enum class, enumerator names are local to the enum and their values do not implicitly convert to other types i.e., to another enum or int as mentioned [here](http://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#enum4-define-operations-on-enumerations-for-safe-and-simple-use). This prevents accidental misuse of constants. Especially when we are working with python bindings, we do not want the enums to be assigned an integer.
