### PR TITLE
fix: four-neighbour CHILL interfacial and type-split seeded floods

### DIFF
--- a/.github/workflows/ci_docs.yml
+++ b/.github/workflows/ci_docs.yml
@@ -21,4 +21,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@e9c66a37f080288a11235e32cbe2dc5fb3a679cc # v4
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs/_build/html
+          publish_dir: ./docs/build

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog
 =========
 
+Version 2.1.1 (2026-08-15)
+===========================
+
+Fixed
+-----
+- CHILL ``isInterfacial`` walks the four nearest neighbours, the same
+  star as ``c_ij``.
+- CHILL ``getIceType`` / ``getIceTypeNoPrint`` send atoms without four
+  recorded bonds to water, matching CHILL+.
+- Seeded affiliation floods HC and DDC separately so an HC seed does
+  not keep a DDC-only atom in the same H-bond component.
+
 Version 2.1.0 (2026-08-15)
 ===========================
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "d-SEAMS: Deferred Structural Elucidation Analysis for Molecular Simulations"
 type: software
-version: "2.1.0"
+version: "2.1.1"
 date-released: "2026-08-15"
 license: MIT
 repository-code: "https://github.com/d-SEAMS/seams-core"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **Deferred Structural Elucidation Analysis for Molecular Simulations**
 
-[![Build Status](https://github.com/d-SEAMS/seams-core/actions/workflows/build_pkg.yml/badge.svg)](https://github.com/d-SEAMS/seams-core/actions/workflows/build_pkg.yml)
+[![Build Status](https://github.com/d-SEAMS/seams-core/actions/workflows/ci_test.yml/badge.svg)](https://github.com/d-SEAMS/seams-core/actions/workflows/ci_test.yml)
 
 [![built with nix](https://builtwithnix.org/badge.svg)](https://builtwithnix.org)
 
@@ -17,10 +17,15 @@
 
 \brief The C++ core of d-SEAMS, a molecular dynamics trajectory analysis engine.
 
-This repository is the C++ engine. Front ends live in their own repos:
+This repository is the C++ engine (`libyodaLib`). It does not install
+`yodaStruct`. Front ends live in their own repos:
 
 - Python: [d-SEAMS/PydSEAMSlib](https://github.com/d-SEAMS/PydSEAMSlib)
 - Lua and Fennel CLI: [d-SEAMS/yodaStruct](https://github.com/d-SEAMS/yodaStruct)
+
+Build the engine with `pixi run setup && pixi run build && pixi run test`.
+Commands below that invoke `yodaStruct -c lua_inputs/...` belong in a
+yodaStruct checkout.
 
 \note The <a href="pages.html">related pages</a> describe the examples and how to obtain
 the data-sets (trajectories) <a

--- a/environment.yml
+++ b/environment.yml
@@ -18,9 +18,6 @@ dependencies:
   - meson
   - cmake
   - pkgconfig
-  # - lua-luafilesystem
-  - luarocks
   # Pinned
   - fmt==9.1.0
   - eigen==3.4.0
-  - lua==5.3.*

--- a/markdown/bulkTopologicalCriterion.md
+++ b/markdown/bulkTopologicalCriterion.md
@@ -1,5 +1,8 @@
 # Bulk Ice Classification Using Topological Network Criteria
 
+The Lua scripts live in [yodaStruct](https://github.com/d-SEAMS/yodaStruct).
+This repository is the C++ engine.
+
 The trajectory file for this example is [here on figshare](https://figshare.com/articles/Nucleation_LAMMPS_Trajectory/11448702). The trajectory file details a portion of a long run of 4096 molecules of mW water, which have undergone crystallization. In this example, DDCs (Double-diamond Cages), HCs (Hexagonal Cages), and mixed rings are identified inside the largest ice cluster. On running the example, an output top-level directory named *runOne* is created. 
 
 ## Steps to Run the Example

--- a/markdown/chillPlus.md
+++ b/markdown/chillPlus.md
@@ -1,5 +1,8 @@
 # Bulk Ice Classification Using the CHILL+ Criterion
 
+The Lua scripts live in [yodaStruct](https://github.com/d-SEAMS/yodaStruct)
+(`example_lua/chillPlus`). This repository is the C++ engine.
+
 The trajectory file for this example is [here on figshare](https://figshare.com/articles/CHILL_LAMMPS_Trajectory/11448720). The trajectory file details a portion of a long run of 4096 molecules of a perfect Ic (cubic ice) lattice. In this example, the all 4096 molecules are identified as Ic, according to the CHILL+ algorithm [1]. On running the example, an output top-level directory named _runOne_ is created.
 
 ## Steps to Run the Example

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 #-----------------------------------------------------------------------------------
 
 project('seams-core', ['cpp', 'c'],
-  version: '2.1.0',
+  version: '2.1.1',
   default_options: ['warning_level=2', 'cpp_std=c++20'],
   meson_version: '>=1.3.0')
 

--- a/src/bop.cpp
+++ b/src/bop.cpp
@@ -656,26 +656,21 @@ void chill::getIceTypeNoPrint(
       }
     } // End of loop through neighbours
 
-    // Add more tests later
     yCloud.pts[iatom].iceType = molSys::atom_state_type::unclassified; // default
-    // Cubic ice
-    // if (num_eclipsd==0 && num_staggrd==4){
-    //  yCloud.pts[iatom].iceType = molSys::cubic;
-    //  ic++;
-    // }
-    if (num_staggrd >= 4) {
-      yCloud.pts[iatom].iceType = molSys::atom_state_type::cubic;
-      ic++;
-    }
-    // Hexagonal
-    else if (num_eclipsd == 1 && num_staggrd == 3) {
-      yCloud.pts[iatom].iceType = molSys::atom_state_type::hexagonal;
-      ih++;
-    }
-    // Interfacial
-    else if (isInterfacial(yCloud, nList, iatom, num_staggrd, num_eclipsd)) {
-      yCloud.pts[iatom].iceType = molSys::atom_state_type::interfacial;
-      interIce++;
+    if (nnumNeighbours == 4) {
+      if (num_staggrd >= 4) {
+        yCloud.pts[iatom].iceType = molSys::atom_state_type::cubic;
+        ic++;
+      } else if (num_eclipsd == 1 && num_staggrd == 3) {
+        yCloud.pts[iatom].iceType = molSys::atom_state_type::hexagonal;
+        ih++;
+      } else if (isInterfacial(yCloud, nList, iatom, num_staggrd, num_eclipsd)) {
+        yCloud.pts[iatom].iceType = molSys::atom_state_type::interfacial;
+        interIce++;
+      } else {
+        yCloud.pts[iatom].iceType = molSys::atom_state_type::water;
+        water++;
+      }
     } else {
       yCloud.pts[iatom].iceType = molSys::atom_state_type::water;
       water++;
@@ -726,26 +721,21 @@ chill::getIceType(molSys::PointCloud<molSys::Point<double>, double> &yCloud,
       }
     } // End of loop through neighbours
 
-    // Add more tests later
     yCloud.pts[iatom].iceType = molSys::atom_state_type::unclassified; // default
-    // Cubic ice
-    // if (num_eclipsd==0 && num_staggrd==4){
-    // 	yCloud.pts[iatom].iceType = molSys::cubic;
-    // 	ic++;
-    // }
-    if (num_staggrd >= 4) {
-      yCloud.pts[iatom].iceType = molSys::atom_state_type::cubic;
-      ic++;
-    }
-    // Hexagonal
-    else if (num_eclipsd == 1 && num_staggrd == 3) {
-      yCloud.pts[iatom].iceType = molSys::atom_state_type::hexagonal;
-      ih++;
-    }
-    // Interfacial
-    else if (isInterfacial(yCloud, nList, iatom, num_staggrd, num_eclipsd)) {
-      yCloud.pts[iatom].iceType = molSys::atom_state_type::interfacial;
-      interIce++;
+    if (nnumNeighbours == 4) {
+      if (num_staggrd >= 4) {
+        yCloud.pts[iatom].iceType = molSys::atom_state_type::cubic;
+        ic++;
+      } else if (num_eclipsd == 1 && num_staggrd == 3) {
+        yCloud.pts[iatom].iceType = molSys::atom_state_type::hexagonal;
+        ih++;
+      } else if (isInterfacial(yCloud, nList, iatom, num_staggrd, num_eclipsd)) {
+        yCloud.pts[iatom].iceType = molSys::atom_state_type::interfacial;
+        interIce++;
+      } else {
+        yCloud.pts[iatom].iceType = molSys::atom_state_type::water;
+        water++;
+      }
     } else {
       yCloud.pts[iatom].iceType = molSys::atom_state_type::water;
       water++;
@@ -1163,31 +1153,20 @@ bool chill::isInterfacial(
     molSys::PointCloud<molSys::Point<double>, double> &yCloud,
     const std::vector<std::vector<int>> &nList, int iatom, int num_staggrd,
     int num_eclipsd, bool chillPlus) {
-  int nnumNeighbours =
-      nList[iatom].size() - 1; // number of nearest neighbours of iatom
+  const std::vector<int> nearest =
+      nearestNeighbourIndices(yCloud, nList, iatom, 4);
   int neighStaggered =
-      0;          // number of staggered bonds in the neighbours of iatom
-  int jatomID;    // ID of the nearest neighbour
-  int jatomIndex; // Index (value) of nearest neighbour
+      0; // number of staggered bonds in the neighbours of iatom
 
   // INTERFACIAL
   // Condition 1 : only two staggered bonds and at least
   // one neighbor with more than two staggered bonds
   if (num_staggrd == 2) {
-    // Loop over the nearest neighbours
-    for (int j = 1; j <= nnumNeighbours; j++) {
-      // Get index of the nearest neighbour
-      jatomID = nList[iatom][j];
-      // Get the index (value) from the ID (key)
-      auto it = yCloud.idIndexMap.find(jatomID);
-
-      if (it != yCloud.idIndexMap.end()) {
-        jatomIndex = it->second;
-      } else {
-        std::cerr << "Something is gravely wrong with your map.\n";
-        return false;
+    // Loop over the four nearest neighbours, the same star as c_ij
+    for (int jatomIndex : nearest) {
+      if (jatomIndex < 0 || jatomIndex >= yCloud.nop) {
+        continue;
       }
-      //
       neighStaggered = chill::numStaggered(yCloud, nList, jatomIndex);
       if (neighStaggered > 2) {
         return true;
@@ -1197,21 +1176,10 @@ bool chill::isInterfacial(
   // Condition 2 : three staggered bonds, no eclipsed bond,
   // and at least one neighbor with two staggered bonds
   if (num_staggrd == 3 && num_eclipsd == 0) {
-    // Loop over the nearest neighbours
-    for (int j = 1; j <= nnumNeighbours; j++) {
-      // Get index of the nearest neighbour
-      // ID of the nearest neighbour
-      jatomID = nList[iatom][j];
-      // Get the index (value) from the ID (key)
-      auto it = yCloud.idIndexMap.find(jatomID);
-
-      if (it != yCloud.idIndexMap.end()) {
-        jatomIndex = it->second;
-      } else {
-        std::cerr << "Something is gravely wrong with your map.\n";
-        return false;
+    for (int jatomIndex : nearest) {
+      if (jatomIndex < 0 || jatomIndex >= yCloud.nop) {
+        continue;
       }
-      //
       neighStaggered = chill::numStaggered(yCloud, nList, jatomIndex);
       if (chillPlus) {
         if (neighStaggered > 1) {

--- a/src/cage_affiliation.cpp
+++ b/src/cage_affiliation.cpp
@@ -506,42 +506,51 @@ ring::SeededAtomLabels ring::seededCageAffiliation(
   const auto [hcP, ddcP] = toAtoms(
       permissiveRings, cageAffiliation(permissiveRings, permissiveNList));
 
-  // Affiliated set and seeds; components under the permissive bonds
-  std::vector<bool> affiliated(nAtoms, false);
-  std::vector<bool> kept(nAtoms, false);
-  std::vector<int> stack;
-  for (int a = 0; a < nAtoms; a++) {
-    affiliated[a] = hcS[a] || ddcS[a] || hcP[a] || ddcP[a];
-  }
-  for (int a = 0; a < nAtoms; a++) {
-    if (!(hcS[a] || ddcS[a]) || kept[a]) {
-      continue;
-    }
-    stack.push_back(a);
-    kept[a] = true;
-    while (!stack.empty()) {
-      const int u = stack.back();
-      stack.pop_back();
-      for (size_t m = 1; m < permissiveNList[u].size(); m++) {
-        const int v = permissiveNList[u][m];
-        if (v >= 0 && v < nAtoms && affiliated[v] && !kept[v]) {
-          kept[v] = true;
-          stack.push_back(v);
+  // One flood per cage type: an HC seed must not keep a DDC-only atom
+  // that happens to sit in the same permissive H-bond component.
+  auto flood = [&](const std::vector<bool> &seeds,
+                   const std::vector<bool> &affiliated) {
+    std::vector<bool> kept(nAtoms, false);
+    std::vector<int> stack;
+    for (int a = 0; a < nAtoms; a++) {
+      if (!seeds[a] || kept[a]) {
+        continue;
+      }
+      stack.push_back(a);
+      kept[a] = true;
+      while (!stack.empty()) {
+        const int u = stack.back();
+        stack.pop_back();
+        if (u < 0 || static_cast<size_t>(u) >= permissiveNList.size()) {
+          continue;
+        }
+        for (size_t m = 1; m < permissiveNList[u].size(); m++) {
+          const int v = permissiveNList[u][m];
+          if (v >= 0 && v < nAtoms && affiliated[v] && !kept[v]) {
+            kept[v] = true;
+            stack.push_back(v);
+          }
         }
       }
     }
+    return kept;
+  };
+
+  std::vector<bool> affiliatedHC(nAtoms, false);
+  std::vector<bool> affiliatedDDC(nAtoms, false);
+  for (int a = 0; a < nAtoms; a++) {
+    affiliatedHC[a] = hcS[a] || hcP[a];
+    affiliatedDDC[a] = ddcS[a] || ddcP[a];
   }
+  const auto keptHC = flood(hcS, affiliatedHC);
+  const auto keptDDC = flood(ddcS, affiliatedDDC);
 
   for (int a = 0; a < nAtoms; a++) {
-    if (!kept[a]) {
-      continue;
+    if (keptHC[a]) {
+      out.hc[a] = hcS[a] || hcP[a];
     }
-    if (hcS[a] || ddcS[a]) {
-      out.hc[a] = hcS[a];
-      out.ddc[a] = ddcS[a];
-    } else {
-      out.hc[a] = hcP[a];
-      out.ddc[a] = ddcP[a];
+    if (keptDDC[a]) {
+      out.ddc[a] = ddcS[a] || ddcP[a];
     }
   }
   return out;


### PR DESCRIPTION
`isInterfacial` still walked the cutoff neighbour list after `c_ij` was already the four-nearest star. Moore `getIceType` classified atoms that did not have four recorded bonds. Seeded affiliation used one BFS across every affiliated atom, so an HC seed could keep a DDC-only neighbour in the same H-bond blob.

Those three are now the four-nearest walk, a four-bond water gate matching CHILL+, and two type-separated floods.

The README badge points at `ci_test.yml`. Docs publish `docs/build`. Conda no longer installs Lua.

# Test plan

Catch2 `isInterfacial` and `seeded affiliation` cases. `pixi run test`.
