### PR TITLE
feat: add a seams engine CLI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+Version 2.2.0 (2026-08-15)
+===========================
+
+Added
+-----
+- ``seams`` CLI: ``read``, ``chill``, ``chill-plus``, ``cages``.
+  This is the engine command line. Lua is the ``dseams`` library
+  (yodaStruct repo). Python is ``pydseams``.
+
 Version 2.1.2 (2026-08-15)
 ===========================
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "d-SEAMS: Deferred Structural Elucidation Analysis for Molecular Simulations"
 type: software
-version: "2.1.2"
+version: "2.2.0"
 date-released: "2026-08-15"
 license: MIT
 repository-code: "https://github.com/d-SEAMS/seams-core"

--- a/README.md
+++ b/README.md
@@ -17,15 +17,20 @@
 
 \brief The C++ core of d-SEAMS, a molecular dynamics trajectory analysis engine.
 
-This repository is the C++ engine (`libyodaLib`). It does not install
-`yodaStruct`. Front ends live in their own repos:
+This repository is the C++ engine (`libyodaLib`) and the `seams` CLI.
 
-- Python: [d-SEAMS/PydSEAMSlib](https://github.com/d-SEAMS/PydSEAMSlib)
-- Lua and Fennel CLI: [d-SEAMS/yodaStruct](https://github.com/d-SEAMS/yodaStruct)
+```bash
+seams read water.lammpstrj
+seams chill-plus water.lammpstrj --cutoff 3.5
+seams cages water.lammpstrj
+```
 
-Build the engine with `pixi run setup && pixi run build && pixi run test`.
-Commands below that invoke `yodaStruct -c lua_inputs/...` belong in a
-yodaStruct checkout.
+Scripting front ends are separate packages:
+
+- Python: `pydseams` ([PydSEAMSlib](https://github.com/d-SEAMS/PydSEAMSlib))
+- Lua/Fennel: `dseams` ([yodaStruct](https://github.com/d-SEAMS/yodaStruct))
+
+Build with `pixi run setup && pixi run build && pixi run test`.
 
 \note The <a href="pages.html">related pages</a> describe the examples and how to obtain
 the data-sets (trajectories) <a

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 #-----------------------------------------------------------------------------------
 
 project('seams-core', ['cpp', 'c'],
-  version: '2.1.2',
+  version: '2.2.0',
   default_options: ['warning_level=2', 'cpp_std=c++20'],
   meson_version: '>=1.3.0')
 
@@ -348,14 +348,32 @@ if get_option('with_tests')
 endif
 
 # Python bindings are not in this repository.
-# See https://github.com/d-SEAMS/PydSEAMSlib
 if get_option('with_python')
-  error('Python bindings live in https://github.com/d-SEAMS/PydSEAMSlib')
+  error('Python is pydseams: https://github.com/d-SEAMS/PydSEAMSlib')
 endif
 
-# Front ends are not in this repository.
-# Lua/Fennel: https://github.com/d-SEAMS/yodaStruct
-# Python:     https://github.com/d-SEAMS/PydSEAMSlib
+# Lua is a library in the yodaStruct / luadseams repo, not this one.
 if not get_option('with_lua').disabled()
-  error('The yodaStruct Lua CLI lives in https://github.com/d-SEAMS/yodaStruct')
+  error('Lua/Fennel is the dseams library: https://github.com/d-SEAMS/yodaStruct')
+endif
+
+if get_option('with_cli')
+  seams_cli_link = []
+  if host_machine.system() == 'linux'
+    seams_cli_link += ['-Wl,--enable-new-dtags']
+  endif
+  seams_exe = executable(
+    'seams',
+    files('src/seams_cli.cpp'),
+    dependencies: [yds_dep],
+    include_directories: _incdirs,
+    cpp_args: _args + ['-DSEAMS_VERSION="' + meson.project_version() + '"'],
+    link_args: seams_cli_link,
+    install: true)
+  test(
+    'seams_read',
+    seams_exe,
+    args: ['read', 'input/traj/exampleTraj.lammpstrj'],
+    workdir: meson.project_source_root(),
+    timeout: 60)
 endif

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,7 +1,9 @@
 option('with_tests', type: 'boolean', value: true,
   description: 'Build Catch2 C++ tests')
 option('with_python', type: 'boolean', value: false,
-  description: 'Unused. Python bindings are the PydSEAMSlib repo, not this one')
+  description: 'Unused. Python is the pydseams package (PydSEAMSlib repo)')
+option('with_cli', type: 'boolean', value: true,
+  description: 'Build the seams engine CLI')
 option('with_mpi', type: 'feature', value: 'disabled',
   description: 'Link MPI and split Steinhardt atoms across ranks')
 option('with_openmp_offload', type: 'feature', value: 'disabled',
@@ -15,4 +17,4 @@ option('with_sphericart', type: 'feature', value: 'auto',
 option('with_nauty', type: 'feature', value: 'auto',
   description: 'Canonical cage certificates via nauty')
 option('with_lua', type: 'feature', value: 'disabled',
-  description: 'Unused. The yodaStruct CLI is the yodaStruct repo, not this one')
+  description: 'Unused. Lua is the dseams library in the yodaStruct repo')

--- a/src/seams_cli.cpp
+++ b/src/seams_cli.cpp
@@ -1,0 +1,228 @@
+//-----------------------------------------------------------------------------------
+// d-SEAMS - Deferred Structural Elucidation Analysis for Molecular Simulations
+// SPDX-License-Identifier: MIT
+//-----------------------------------------------------------------------------------
+
+#include <bop.hpp>
+#include <cage_affiliation.hpp>
+#include <cxxopts.hpp>
+#include <franzblau.hpp>
+#include <mol_sys.hpp>
+#include <neighbours.hpp>
+#include <seams_input.hpp>
+
+#include <algorithm>
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <string>
+#include <vector>
+
+namespace {
+
+using Cloud = molSys::PointCloud<molSys::Point<double>, double>;
+
+const char *iceName(molSys::atom_state_type s) {
+  switch (s) {
+  case molSys::atom_state_type::cubic:
+    return "cubic";
+  case molSys::atom_state_type::hexagonal:
+    return "hexagonal";
+  case molSys::atom_state_type::water:
+    return "water";
+  case molSys::atom_state_type::interfacial:
+    return "interfacial";
+  case molSys::atom_state_type::clathrate:
+    return "clathrate";
+  case molSys::atom_state_type::interClathrate:
+    return "interClathrate";
+  case molSys::atom_state_type::reCubic:
+    return "reCubic";
+  case molSys::atom_state_type::reHex:
+    return "reHex";
+  case molSys::atom_state_type::unclassified:
+    break;
+  }
+  return "unclassified";
+}
+
+Cloud load(const std::string &path, int frame, int typeI) {
+  Cloud cloud;
+  const auto ext = path.substr(path.find_last_of('.') + 1);
+  if (ext == "xyz") {
+    return sinp::readXYZ(path);
+  }
+#ifdef SEAMS_HAS_READCON
+  if (ext == "con") {
+    return sinp::readCon(path, frame, cloud);
+  }
+#endif
+#ifdef SEAMS_HAS_CHEMFILES
+  if (ext == "pdb" || ext == "gro" || ext == "dcd") {
+    return sinp::readChemfiles(path, frame, cloud, typeI > 0 ? typeI : -1);
+  }
+#endif
+  if (typeI > 0) {
+    return sinp::readLammpsTrjO(path, frame, cloud, typeI);
+  }
+  cloud = sinp::readLammpsTrjO(path, frame, cloud, 2);
+  if (cloud.nop > 0) {
+    return cloud;
+  }
+  Cloud again;
+  return sinp::readLammpsTrjO(path, frame, again, 1);
+}
+
+int typeOf(const Cloud &cloud, int requested) {
+  if (requested > 0) {
+    return requested;
+  }
+  if (cloud.nop == 0) {
+    return 1;
+  }
+  return cloud.pts[0].type;
+}
+
+void printCounts(const Cloud &cloud) {
+  std::map<std::string, int> hist;
+  for (const auto &pt : cloud.pts) {
+    hist[iceName(pt.iceType)]++;
+  }
+  std::cout << "nop " << cloud.nop;
+  for (const auto &[name, n] : hist) {
+    if (n > 0) {
+      std::cout << " " << name << " " << n;
+    }
+  }
+  std::cout << "\n";
+}
+
+int cmdRead(Cloud &cloud) {
+  const auto box = cloud.box;
+  std::cout << "nop " << cloud.nop << " frame " << cloud.currentFrame
+            << " box " << box[0] << " " << box[1] << " " << box[2] << "\n";
+  return 0;
+}
+
+int cmdChillPlus(Cloud &cloud, double cutoff, int typeI) {
+  const int typ = typeOf(cloud, typeI);
+  auto nList = nneigh::neighListO(cutoff, cloud, typ);
+  chill::getCorrelPlus(cloud, nList, false);
+  chill::getIceTypePlusNoPrint(cloud, nList, false);
+  printCounts(cloud);
+  return 0;
+}
+
+int cmdChill(Cloud &cloud, double cutoff, int typeI) {
+  const int typ = typeOf(cloud, typeI);
+  auto nList = nneigh::neighListO(cutoff, cloud, typ);
+  chill::getCorrel(cloud, nList, false);
+  chill::getIceTypeNoPrint(cloud, nList, false);
+  printCounts(cloud);
+  return 0;
+}
+
+int cmdCages(Cloud &cloud, double cutoff, int typeI, int k) {
+  const int typ = typeOf(cloud, typeI);
+  const double cand = cutoff + 1.5;
+  auto mutual = nneigh::kNearestNeighbourList(cloud, k, cand, typ, true);
+  auto uni = nneigh::kNearestNeighbourList(cloud, k, cand, typ, false);
+  auto idxS = nneigh::neighbourListByIndex(cloud, mutual);
+  auto idxU = nneigh::neighbourListByIndex(cloud, uni);
+  auto ringsS = primitive::ringNetwork(idxS, 6);
+  auto ringsU = primitive::ringNetwork(idxU, 6);
+  std::vector<std::vector<int>> sixS;
+  std::vector<std::vector<int>> sixU;
+  for (const auto &r : ringsS) {
+    if (r.size() == 6) {
+      sixS.push_back(r);
+    }
+  }
+  for (const auto &r : ringsU) {
+    if (r.size() == 6) {
+      sixU.push_back(r);
+    }
+  }
+  const auto aff = ring::seededCageAffiliation(sixS, idxS, sixU, idxU);
+  int ih = 0;
+  int ic = 0;
+  int water = 0;
+  for (size_t i = 0; i < aff.hc.size(); ++i) {
+    if (aff.hc[i]) {
+      ++ih;
+    } else if (aff.ddc[i]) {
+      ++ic;
+    } else {
+      ++water;
+    }
+  }
+  std::cout << "nop " << cloud.nop << " ih " << ih << " ic " << ic << " water "
+            << water << "\n";
+  return 0;
+}
+
+} // namespace
+
+int main(int argc, char *argv[]) {
+  cxxopts::Options opt(
+      argv[0], "d-SEAMS engine CLI. Lua is the luadseams library; Python is pydseams.");
+  opt.add_options()("h,help", "Print help")("v,version", "Print version")(
+      "f,frame", "Frame number (1-based)",
+      cxxopts::value<int>()->default_value("1"))(
+      "t,type", "Atom type (0 guesses oxygen then type 1)",
+      cxxopts::value<int>()->default_value("0"))(
+      "c,cutoff", "Neighbour cutoff (Angstrom)",
+      cxxopts::value<double>()->default_value("3.5"))(
+      "k", "k for seeded cages", cxxopts::value<int>()->default_value("4"))(
+      "command", "read | chill | chill-plus | cages",
+      cxxopts::value<std::string>())("file", "Trajectory file",
+                                     cxxopts::value<std::string>());
+  opt.parse_positional({"command", "file"});
+  opt.positional_help("COMMAND FILE");
+
+  cxxopts::ParseResult args;
+  try {
+    args = opt.parse(argc, argv);
+  } catch (const cxxopts::OptionException &e) {
+    std::cerr << e.what() << "\n";
+    return 2;
+  }
+  if (args.count("help")) {
+    std::cout << opt.help() << "\n";
+    return 0;
+  }
+  if (args.count("version")) {
+#ifdef SEAMS_VERSION
+    std::cout << "seams " << SEAMS_VERSION << "\n";
+#else
+    std::cout << "seams\n";
+#endif
+    return 0;
+  }
+  if (!args.count("command") || !args.count("file")) {
+    std::cerr << opt.help() << "\n";
+    return 2;
+  }
+  const std::string cmd = args["command"].as<std::string>();
+  const std::string file = args["file"].as<std::string>();
+  const int frame = args["frame"].as<int>();
+  const int typeI = args["type"].as<int>();
+  const double cutoff = args["cutoff"].as<double>();
+  const int k = args["k"].as<int>();
+
+  Cloud cloud = load(file, frame, typeI);
+  if (cmd == "read") {
+    return cmdRead(cloud);
+  }
+  if (cmd == "chill-plus" || cmd == "chill_plus") {
+    return cmdChillPlus(cloud, cutoff, typeI);
+  }
+  if (cmd == "chill") {
+    return cmdChill(cloud, cutoff, typeI);
+  }
+  if (cmd == "cages") {
+    return cmdCages(cloud, cutoff, typeI, k);
+  }
+  std::cerr << "unknown command: " << cmd << "\n";
+  return 2;
+}


### PR DESCRIPTION
The engine has a `seams` command. It is not a scripting host.

```
seams read water.lammpstrj
seams chill-plus water.lammpstrj --cutoff 3.5
seams cages water.lammpstrj
```

Lua is `require("dseams")` in the yodaStruct repo. Python is `import pydseams`.
