### PR TITLE
feat: restore a meson Nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ spack.yml
 /.spack-env/
 !pixi.lock
 *.lock
+!flake.lock
 subprojects/nanobind-*/
 subprojects/robin-map-*/
 subprojects/packagecache/

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,8 @@ Added
   lazy ``ITEM: TIMESTEP`` offset table (LAMMPS ``ReaderNative`` cursor,
   chemfiles ``read_step``, readcon frame offsets). Sequential
   ``load_frame`` walks no longer rescan prior snapshots.
+- ``forEachLammpsFrame``: OpenMP walk over a frame range. Each worker
+  opens its own handle and seeks. ``seams --frame N --last M --jobs J``.
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,8 +16,8 @@ Added
 - ``forEachLammpsFrame``: OpenMP walk over a frame range. Each worker
   opens its own handle and seeks. ``seams --frame N --last M --jobs J``.
 - ``SkinNeighborList``: vesin candidates at cutoff+skin (the ghost
-  halo), rebuilt when an atom moves more than skin/2. Bonds form at
-  cutoff and break at cutoff+skin.
+  halo), rebuilt when an atom moves more than skin/2. The bond graph
+  is the candidates currently inside the analysis cutoff.
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,7 +19,8 @@ Fixed
 - LAMMPS readers bind ``xu``/``yu``/``zu`` and ``xs``/``ys``/``zs``
   when ``x y z`` are absent (Niu/Parrinello TIP4P/Ice dumps).
 - ``AffiliationUpdater`` uses the batch classifier when more than half
-  the six-rings sit in the dirty closure.
+  the neighbour rows change, or when more than half the six-rings sit
+  in the dirty closure.
 
 Version 2.2.0 (2026-08-15)
 ===========================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,8 +16,9 @@ Added
 - ``forEachLammpsFrame``: OpenMP walk over a frame range. Each worker
   opens its own handle and seeks. ``seams --frame N --last M --jobs J``.
 - ``SkinNeighborList``: vesin candidates at cutoff+skin, rebuilt on
-  the Verlet trigger. Default bonds are the mutual four nearest
-  (TUM v2). ``k = 0`` keeps the hard cutoff graph.
+  the Verlet trigger. ``BondGraph`` is chosen at runtime
+  (``cutoff``, ``knn``, ``knn-union``). ``seams cages --graph``
+  adds ``seeded``.
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,9 +15,9 @@ Added
   ``load_frame`` walks no longer rescan prior snapshots.
 - ``forEachLammpsFrame``: OpenMP walk over a frame range. Each worker
   opens its own handle and seeks. ``seams --frame N --last M --jobs J``.
-- ``SkinNeighborList``: vesin candidates at cutoff+skin (the ghost
-  halo), rebuilt when an atom moves more than skin/2. The bond graph
-  is the candidates currently inside the analysis cutoff.
+- ``SkinNeighborList``: vesin candidates at cutoff+skin, rebuilt on
+  the Verlet trigger. Default bonds are the mutual four nearest
+  (TUM v2). ``k = 0`` keeps the hard cutoff graph.
 
 Fixed
 -----

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,25 @@
 Changelog
 =========
 
+Version 2.2.1 (2026-08-15)
+===========================
+
+Added
+-----
+- Flake-based Nix package for ``libyodaLib`` and the ``seams`` CLI
+  (meson, not the CMake-era ``yodaStruct`` derivation).
+- ``nLammpsFrames`` / ``dropLammpsDumpIndex``: live dump session with a
+  lazy ``ITEM: TIMESTEP`` offset table (LAMMPS ``ReaderNative`` cursor,
+  chemfiles ``read_step``, readcon frame offsets). Sequential
+  ``load_frame`` walks no longer rescan prior snapshots.
+
+Fixed
+-----
+- LAMMPS readers bind ``xu``/``yu``/``zu`` and ``xs``/``ys``/``zs``
+  when ``x y z`` are absent (Niu/Parrinello TIP4P/Ice dumps).
+- ``AffiliationUpdater`` uses the batch classifier when more than half
+  the six-rings sit in the dirty closure.
+
 Version 2.2.0 (2026-08-15)
 ===========================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,14 +15,14 @@ Added
   ``load_frame`` walks no longer rescan prior snapshots.
 - ``forEachLammpsFrame``: OpenMP walk over a frame range. Each worker
   opens its own handle and seeks. ``seams --frame N --last M --jobs J``.
+- ``SkinNeighborList``: vesin candidates at cutoff+skin (the ghost
+  halo), rebuilt when an atom moves more than skin/2. Bonds form at
+  cutoff and break at cutoff+skin.
 
 Fixed
 -----
 - LAMMPS readers bind ``xu``/``yu``/``zu`` and ``xs``/``ys``/``zs``
   when ``x y z`` are absent (Niu/Parrinello TIP4P/Ice dumps).
-- ``AffiliationUpdater`` uses the batch classifier when more than half
-  the neighbour rows change, or when more than half the six-rings sit
-  in the dirty closure.
 
 Version 2.2.0 (2026-08-15)
 ===========================

--- a/README.md
+++ b/README.md
@@ -222,7 +222,9 @@ meson test -C bbdir
 ```bash
 nix build
 ./result/bin/seams --help
-./result/bin/seams --frame 1 --last 100 --jobs 8 --type 1 cages dump.lammpstrj
+./result/bin/seams --frame 1 --last 100 --jobs 8 --type 1 --graph seeded cages dump.lammpstrj
+./result/bin/seams --graph cutoff cages dump.lammpstrj
+./result/bin/seams --graph knn cages dump.lammpstrj
 ```
 
 To run the sample inputs, stay in the repository root so `input/` is a

--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ meson test -C bbdir
 ```bash
 nix build
 ./result/bin/seams --help
+./result/bin/seams --frame 1 --last 100 --jobs 8 --type 1 cages dump.lammpstrj
 ```
 
 To run the sample inputs, stay in the repository root so `input/` is a

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 **Deferred Structural Elucidation Analysis for Molecular Simulations**
 
 [![Build Status](https://github.com/d-SEAMS/seams-core/actions/workflows/ci_test.yml/badge.svg)](https://github.com/d-SEAMS/seams-core/actions/workflows/ci_test.yml)
+[![built with nix](https://builtwithnix.org/badge.svg)](https://builtwithnix.org)
 
 
 
@@ -30,15 +31,17 @@ Scripting front ends are separate packages:
 - Python: `pydseams` ([PydSEAMSlib](https://github.com/d-SEAMS/PydSEAMSlib))
 - Lua/Fennel: `dseams` ([yodaStruct](https://github.com/d-SEAMS/yodaStruct))
 
-Build with `pixi run setup && pixi run build && pixi run test`.
+Build with `pixi run setup && pixi run build && pixi run test`, or with
+the Nix flake: `nix build` and `nix develop`.
 
 \note The <a href="pages.html">related pages</a> describe the examples and how to obtain
 the data-sets (trajectories) <a
 href="https://figshare.com/projects/d-SEAMS_Datasets/73545">from figshare</a>.
 
-\warning The live build is `pixi` + meson. The old Nix/CMake `yodaStruct`
-derivation is gone. Manage compiler and library versions yourself if you
-do not use the provided `pixi` or `conda` environment.
+\warning The live builds are `pixi` + meson, or the Nix flake. The
+CMake-era `yodaStruct` derivation is gone. Manage compiler and library
+versions yourself if you do not use `pixi`, `nix`, or the `conda`
+environment.
 
 # Citation
 
@@ -78,10 +81,10 @@ We also provide a `conda` environment as a fallback, which is also recommended f
 
 ## Build
 
-### Conda (working now)
+### Conda
 
-Although we strongly suggest using `nix`, for MacOS systems, the following
-instructions may be more suitable. We will assume the presence of [micromamba](https://mamba.readthedocs.io/en/latest/installation.html):
+For MacOS systems without Nix, the following instructions may be more
+suitable. We will assume the presence of [micromamba](https://mamba.readthedocs.io/en/latest/installation.html):
 
 ```bash
 cd ~/seams-core
@@ -156,138 +159,90 @@ cd ../
 yodaStruct -c lua_inputs/config.yml
 ```
 
-### Nix (not working at the moment)
+### Nix
 
-Since this project is built with `nix`, we can simply do the following from the
-root directory (longer method):
-
-```sh
-# Make sure there are no artifacts
-rm -rf build
-# This will take a long time the first time as it builds the dependencies
-nix-build . # Optional
-# Install into your path
-nix-env -if . # Required
-# Run the command anywhere
-yodaStruct -c lua_inputs/config.yml
-```
-
-A faster method of building the software is by using the [cachix binary cache](https://dseams.cachix.org/) as shown:
+The flake builds `libyodaLib` and the `seams` CLI with meson. Optional
+backends that meson would otherwise wrap-git (vesin, readcon-core) or
+that nixpkgs does not ship (chemfiles) stay off unless a package is
+already in the closure.
 
 ```bash
-# Install cachix
+nix build                  # ./result/bin/seams
+nix run . -- read input/traj/exampleTraj.lammpstrj
+nix develop                # compiler, Eigen, BLAS, Catch2, gdb
+nix flake update           # refresh the nixpkgs pin
+nix fmt
+```
+
+`nix build` runs the Catch2 suite. The Lua library is
+[yodaStruct](https://github.com/d-SEAMS/yodaStruct); Python is
+[PydSEAMSlib](https://github.com/d-SEAMS/PydSEAMSlib). Those
+repositories have matching flakes.
+
+The [dseams Cachix](https://dseams.cachix.org/) cache is optional:
+
+```bash
 nix-env -iA cachix -f https://cachix.org/api/v1/install
-# Use the binary cache
 cachix use dseams
-# Faster with the cache than building from scratch
-nix-build . # Optional
-# Install into your path
-nix-env -if . # Required
-# Run the command anywhere
-yodaStruct -c lua_inputs/config.yml
 ```
 
 ### Usage
 
-Having installed the `yodaStruct` binary and library, we can now use it.
-
 ```bash
-yodaStruct -c lua_inputs/config.yml
+seams read input/traj/exampleTraj.lammpstrj
+seams chill-plus input/traj/exampleTraj.lammpstrj --cutoff 3.5
+seams cages input/traj/exampleTraj.lammpstrj
 ```
 
-\note The paths in the `.yml` should be **relative to the folder from which the binary is called**.
-
-If you're confused about how to handle the relative paths, run the command `yodaStruct -c lua_inputs/config.yml` in the top-level directory, and set the paths relative to the top-level directory. This is the convention used in the examples as well.
+Lua scripts live in the [yodaStruct](https://github.com/d-SEAMS/yodaStruct)
+checkout (`require("dseams")`). Paths in those examples are relative to
+the directory you invoke them from.
 
 ### Language Server Support
 
-To generate a `compile_commands.json` file for working with a language server
-like [ccls](https://github.com/MaskRay/ccls) use the following commands:
-
-```sh
-# Pure environment
-nix-shell --pure
-mkdir -p build && cd build
-cmake -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=YES ../
-cp compile_commands.json ../
+```bash
+nix develop
+meson setup bbdir -Dwith_tests=true
+ln -s bbdir/compile_commands.json .
 ```
 
-Note that there is no need to actually compile the project if you simply need to
-get the compiler database for the language server.
-
-**Do Not** commit the `.json` file.
+**Do Not** commit `compile_commands.json`.
 
 ## Development
 
-We can simply use the `nix` environment:
-
-```sh
-# From the project root
-nix-shell --pure
+```bash
+nix develop
+meson setup bbdir -Dwith_tests=true
+meson compile -C bbdir
+meson test -C bbdir
 ```
 
 # Running
 
-This is built completely with nix:
-
-```{bash}
-# Install systemwide
-nix-env -if .
+```bash
+nix build
+./result/bin/seams --help
 ```
 
-To run the sample inputs, simply install the software, and ensure that `input/` is a child directory.
-
-```{bash}
-# Assuming you are in the src directory
-# Check help with -h
-yodaStruct -c lua_inputs/config.yml
-```
+To run the sample inputs, stay in the repository root so `input/` is a
+child directory.
 
 ## Tests
 
-Apart from the [examples](https://docs.dseams.info/pages.html), the test-suite
-can be run with the `yodaStruct_test` binary, which will drop into the
-`nix` environment before building and executing `gdb`:
-
-```{bash}
-# Just run this
-./testBuild.sh
-# At this point the binary and library are copied into the root
-# One might, in a foolhardy attempt, use gdb at this point
-# Here be dragons :)
-# USE NIX
-# Anyway
-gdb --args ./yodaStruct -c lua_inputs/config.yml
-# quit gdb with quit
-# Go run the test binary
-cd shellBuild
-./yodaStruct_test
+```bash
+nix build          # meson test is the install check
+nix develop --command meson test -C bbdir
 ```
-
-Do note that the regular installation via `nix-env` runs the tests before the installation
 
 # Developer Documentation
 
-<!-- TODO: Move this to some other location. -->
-
-While developing, it is sometimes expedient to update the packages used. It is
-then useful to note that we use [niv](https://github.com/nmattia/niv/) to handle our pinned packages (apart from
-the ones built from Github). Thus, one might need, say:
+The flake pins nixpkgs. To move the pin:
 
 ```bash
-niv update nixpkgs -b nixpkgs-unstable
+nix flake update nixpkgs
 ```
 
-Test the build with nix:
-
-```bash
-nix-build .
-# Outputs are in ./result
-# If you get a CMake error
-rm -rf build
-nix-store --delete /nix/store/$whatever # $whatever is the derivation complaining
-nix-collect-garbage # then try again [worst case scenario]
-```
+Then `nix build` from the project root. Outputs land in `./result`.
 
 ## Leaks and performance
 
@@ -340,28 +295,21 @@ This will ensure that new commits are in accordance to the `clang-format` file.
 
 ## Development Builds
 
-The general idea is to drop into an interactive shell with the dependencies and then use `cmake` as usual.
+```bash
+nix develop
+meson setup bbdir -Dwith_tests=true
+meson compile -C bbdir
+./bbdir/src/seams read input/traj/exampleTraj.lammpstrj
+gdb --args ./bbdir/src/seams read input/traj/exampleTraj.lammpstrj
+```
+
+To load debugging symbols from the shared library inside `gdb`:
 
 ```bash
-nix-shell --pure --run bash --show-trace --verbose
-cd build
-cmake .. -DCMAKE_BUILD_TYPE=Debug -DNO_WARN=TRUE \
- -DFIND_EIGEN=TRUE \
- -DCMAKE_EXPORT_COMPILE_COMMANDS=1 \
- -G "Ninja"
-ninja
-# Test
-cd ../
-yodaStruct -c lua_inputs/config.yml
-# Debug
-gdb --args yodaStruct -c lua_inputs/config.yml
+add-symbol-file bbdir/src/libyodaLib.so
 ```
-To load debugging symbols from the shared library, when you are inside `gdb` (from the top-level directory, for instance), use the following command:
 
-```bash
-add-symbol-file build/libyodaLib.so
-```
-Then you can set breakpoints in the C++ code; for instance: 
+Then you can set breakpoints in the C++ code; for instance:
 
 ```bash
 b seams_input.cpp:408

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1786599213,
+        "narHash": "sha256-yNJd40f11EzXBjSByCB7IPpeFFAdeoSKKM67dGkfFoU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "0e251e24a4f24e036a084b6b4b2d2491af4167f4",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,65 @@
+{
+  description = "d-SEAMS C++ engine (libyodaLib) and the seams CLI";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+
+  outputs =
+    { self, nixpkgs }:
+    let
+      inherit (nixpkgs) lib;
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      forAllSystems = lib.genAttrs systems;
+      pkgsFor = system: nixpkgs.legacyPackages.${system};
+    in
+    {
+      packages = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+          seams = pkgs.callPackage ./nix/package.nix { };
+        in
+        {
+          inherit seams;
+          default = seams;
+        }
+      );
+
+      apps = forAllSystems (system: {
+        default = {
+          type = "app";
+          program = "${self.packages.${system}.default}/bin/seams";
+          meta.description = "Run the seams engine CLI";
+        };
+      });
+
+      checks = forAllSystems (system: {
+        seams = self.packages.${system}.default;
+        default = self.checks.${system}.seams;
+      });
+
+      devShells = forAllSystems (
+        system:
+        let
+          pkgs = pkgsFor system;
+        in
+        {
+          default = pkgs.mkShell {
+            name = "seams-core-dev";
+            inputsFrom = [ self.packages.${system}.default ];
+            packages = with pkgs; [
+              gdb
+              ccache
+              clang-tools
+            ];
+          };
+        }
+      );
+
+      formatter = forAllSystems (system: (pkgsFor system).nixfmt);
+    };
+}

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -1,0 +1,78 @@
+{
+  lib,
+  stdenv,
+  meson,
+  ninja,
+  pkg-config,
+  eigen,
+  blas,
+  lapack,
+  catch2_3,
+  libhwy,
+  llvmPackages,
+}:
+
+stdenv.mkDerivation (finalAttrs: {
+  pname = "seams";
+  version = "2.2.0";
+
+  src = lib.fileset.toSource {
+    root = ./..;
+    fileset = lib.fileset.unions [
+      ../meson.build
+      ../meson_options.txt
+      ../src
+      ../tests
+      ../input
+      ../templates
+      ../subprojects/readcon-core.wrap
+      ../subprojects/vesin.wrap
+      ../subprojects/robin-map.wrap
+      ../subprojects/packagefiles
+    ];
+  };
+
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+  ];
+
+  buildInputs = [
+    eigen
+    blas
+    lapack
+    catch2_3
+    libhwy
+  ]
+  ++ lib.optionals stdenv.cc.isClang [ llvmPackages.openmp ];
+
+  # The meson setup hook already sets -Dwrap_mode=nodownload.
+  # auto_features=enabled would force IRA/sphericart/nauty on and fail.
+  mesonAutoFeatures = "disabled";
+  mesonFlags = [
+    (lib.mesonBool "with_tests" true)
+    (lib.mesonBool "with_cli" true)
+    (lib.mesonBool "with_python" false)
+    (lib.mesonEnable "with_lua" false)
+    (lib.mesonEnable "with_mpi" false)
+    (lib.mesonEnable "with_openmp_offload" false)
+  ];
+
+  # Catch2 plus the seams read smoke test. Optional backends (vesin,
+  # readcon-core, IRA, sphericart, nauty) stay off unless nixpkgs
+  # already provides them; meson skips those probes.
+  doCheck = true;
+
+  meta = {
+    description = "d-SEAMS C++ engine and seams CLI";
+    homepage = "https://dseams.info";
+    license = lib.licenses.mit;
+    mainProgram = "seams";
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+  };
+
+  passthru = {
+    inherit (finalAttrs) version;
+  };
+})

--- a/scripts/terra_dump_session_gate.sh
+++ b/scripts/terra_dump_session_gate.sh
@@ -22,6 +22,9 @@ export LD_LIBRARY_PATH="${BUILD}/src${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
   test -f "${BUILD}/build.ninja"
   test -x "${PIXI_ENV}/bin/meson" || test -x /usr/bin/meson
 
+  echo "=== reconfigure ==="
+  meson setup --reconfigure "${BUILD}" "${ROOT}"
+
   echo "=== compile ==="
   meson compile -C "${BUILD}" \
     yodaLib \

--- a/scripts/terra_dump_session_gate.sh
+++ b/scripts/terra_dump_session_gate.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Compile the live dump session on the existing meson tree, run Catch2,
+# time Niu dump I/O, and walk a short incremental path.
+set -euo pipefail
+
+ROOT="${SEAMS_ROOT:-$HOME/seams-core-merge}"
+BUILD="${SEAMS_BUILD:-$ROOT/bcpp}"
+PIXI_ENV="${ROOT}/.pixi/envs/default"
+DUMP_DIR="${ROOT}/repro/public-ice/nucleation/Ice_nucleation_trajectory"
+DUMP3="${DUMP_DIR}/Nucleation_trajectory-3"
+DUMP2="${DUMP_DIR}/Nucleation_trajectory-2"
+LOG="${SEAMS_LOG:-/tmp/seams-dump-session-gate.log}"
+
+export PATH="${PIXI_ENV}/bin:${HOME}/.pixi/bin:/usr/bin:/bin"
+export LD_LIBRARY_PATH="${BUILD}/src${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+{
+  echo "=== host $(hostname) $(date -Iseconds) ==="
+  echo "root=${ROOT}"
+  echo "build=${BUILD}"
+  test -f "${ROOT}/src/seams_input.cpp"
+  test -f "${BUILD}/build.ninja"
+  test -x "${PIXI_ENV}/bin/meson" || test -x /usr/bin/meson
+
+  echo "=== compile ==="
+  meson compile -C "${BUILD}" \
+    yodaLib \
+    test_seams_input \
+    test_cage_affiliation \
+    bench_lammps_io \
+    bench_trajectory_incremental
+
+  echo "=== catch2 ==="
+  meson test -C "${BUILD}" seams_input cage_affiliation --print-errorlogs
+
+  echo "=== io dump-3 (O-only x y z, 1551 frames) ==="
+  "${BUILD}/tests/bench_lammps_io" "${DUMP3}" 0 1
+
+  echo "=== io dump-2 first 50 (4-site xu yu zu) ==="
+  "${BUILD}/tests/bench_lammps_io" "${DUMP2}" 50 1
+
+  echo "=== incremental dump-3 first 30 ==="
+  "${BUILD}/tests/bench_trajectory_incremental" "${DUMP3}" 30 1 6 | tee /tmp/niu-inc-30.txt
+  echo "=== incremental dump-3 last 3 lines ==="
+  tail -5 /tmp/niu-inc-30.txt
+
+  echo "=== done $(date -Iseconds) ==="
+} 2>&1 | tee "${LOG}"

--- a/scripts/terra_dump_session_gate.sh
+++ b/scripts/terra_dump_session_gate.sh
@@ -28,9 +28,11 @@ export LD_LIBRARY_PATH="${BUILD}/src${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
   echo "=== compile ==="
   meson compile -C "${BUILD}" \
     yodaLib \
+    seams \
     test_seams_input \
     test_cage_affiliation \
     bench_lammps_io \
+    bench_lammps_walk \
     bench_trajectory_incremental
 
   echo "=== catch2 ==="

--- a/scripts/terra_parallel_walk_gate.sh
+++ b/scripts/terra_parallel_walk_gate.sh
@@ -15,8 +15,8 @@ export LD_LIBRARY_PATH="${BUILD}/src${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
   echo "=== host $(hostname) $(date -Iseconds) ==="
   meson setup --reconfigure "${BUILD}" "${ROOT}"
   meson compile -C "${BUILD}" \
-    yodaLib seams test_seams_input bench_lammps_io bench_lammps_walk
-  meson test -C "${BUILD}" seams_input seams_read --print-errorlogs
+    yodaLib test_seams_input bench_lammps_io bench_lammps_walk
+  meson test -C "${BUILD}" seams_input --print-errorlogs
 
   echo "=== io dump-3 serial ==="
   "${BUILD}/tests/bench_lammps_io" "${DUMP3}" 0 1 1

--- a/scripts/terra_parallel_walk_gate.sh
+++ b/scripts/terra_parallel_walk_gate.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Reconfigure, compile the frame-parallel walk, Catch2, I/O and cages benches.
+set -euo pipefail
+
+ROOT="${SEAMS_ROOT:-$HOME/seams-core-merge}"
+BUILD="${SEAMS_BUILD:-$ROOT/bcpp}"
+PIXI_ENV="${ROOT}/.pixi/envs/default"
+DUMP3="${ROOT}/repro/public-ice/nucleation/Ice_nucleation_trajectory/Nucleation_trajectory-3"
+LOG="${SEAMS_LOG:-/tmp/seams-parallel-walk-gate.log}"
+
+export PATH="${PIXI_ENV}/bin:${HOME}/.pixi/bin:/usr/bin:/bin"
+export LD_LIBRARY_PATH="${BUILD}/src${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+{
+  echo "=== host $(hostname) $(date -Iseconds) ==="
+  meson setup --reconfigure "${BUILD}" "${ROOT}"
+  meson compile -C "${BUILD}" \
+    yodaLib seams test_seams_input bench_lammps_io bench_lammps_walk
+  meson test -C "${BUILD}" seams_input seams_read --print-errorlogs
+
+  echo "=== io dump-3 serial ==="
+  "${BUILD}/tests/bench_lammps_io" "${DUMP3}" 0 1 1
+  echo "=== io dump-3 8 threads ==="
+  "${BUILD}/tests/bench_lammps_io" "${DUMP3}" 0 1 8
+
+  echo "=== cages dump-3 first 30 serial ==="
+  "${BUILD}/tests/bench_lammps_walk" "${DUMP3}" 30 1 1
+  echo "=== cages dump-3 first 30, 8 threads ==="
+  "${BUILD}/tests/bench_lammps_walk" "${DUMP3}" 30 1 8
+
+  echo "=== done $(date -Iseconds) ==="
+} 2>&1 | tee "${LOG}"

--- a/src/bop.cpp
+++ b/src/bop.cpp
@@ -664,7 +664,7 @@ void chill::getIceTypeNoPrint(
       } else if (num_eclipsd == 1 && num_staggrd == 3) {
         yCloud.pts[iatom].iceType = molSys::atom_state_type::hexagonal;
         ih++;
-      } else if (isInterfacial(yCloud, nList, iatom, num_staggrd, num_eclipsd)) {
+      } else if (chill::isInterfacial(yCloud, nList, iatom, num_staggrd, num_eclipsd)) {
         yCloud.pts[iatom].iceType = molSys::atom_state_type::interfacial;
         interIce++;
       } else {
@@ -729,7 +729,7 @@ chill::getIceType(molSys::PointCloud<molSys::Point<double>, double> &yCloud,
       } else if (num_eclipsd == 1 && num_staggrd == 3) {
         yCloud.pts[iatom].iceType = molSys::atom_state_type::hexagonal;
         ih++;
-      } else if (isInterfacial(yCloud, nList, iatom, num_staggrd, num_eclipsd)) {
+      } else if (chill::isInterfacial(yCloud, nList, iatom, num_staggrd, num_eclipsd)) {
         yCloud.pts[iatom].iceType = molSys::atom_state_type::interfacial;
         interIce++;
       } else {
@@ -850,7 +850,7 @@ void assignIceTypePlus(
         ih++;
       }
       // Interfacial
-      else if (isInterfacial(yCloud, nList, iatom, num_staggrd, num_eclipsd,
+      else if (chill::isInterfacial(yCloud, nList, iatom, num_staggrd, num_eclipsd,
                              true)) {
         yCloud.pts[iatom].iceType = molSys::atom_state_type::interfacial;
         interIce++;

--- a/src/cage_affiliation.cpp
+++ b/src/cage_affiliation.cpp
@@ -357,6 +357,13 @@ ring::AffiliationUpdater::update(const std::vector<std::vector<int>> &rings,
     }
   }
 
+  // Whole-graph churn (nucleation dumps): every neighbour row moves,
+  // so the dirty walk visits every six-ring. Batch is then cheaper.
+  if (seedAtoms.size() * 2 > nList.size()) {
+    st.primeFull(rings, nList);
+    return st.current;
+  }
+
   if (seedAtoms.empty()) {
     // Same topology; only the ring order may differ. Carry stored answers.
     st.current.hc.assign(rings.size(), false);

--- a/src/cage_affiliation.cpp
+++ b/src/cage_affiliation.cpp
@@ -357,13 +357,6 @@ ring::AffiliationUpdater::update(const std::vector<std::vector<int>> &rings,
     }
   }
 
-  // Whole-graph churn (nucleation dumps): every neighbour row moves,
-  // so the dirty walk visits every six-ring. Batch is then cheaper.
-  if (seedAtoms.size() * 2 > nList.size()) {
-    st.primeFull(rings, nList);
-    return st.current;
-  }
-
   if (seedAtoms.empty()) {
     // Same topology; only the ring order may differ. Carry stored answers.
     st.current.hc.assign(rings.size(), false);
@@ -405,14 +398,6 @@ ring::AffiliationUpdater::update(const std::vector<std::vector<int>> &rings,
   }
   std::unordered_set<int> dirty = expandOnce(atoms2);
   dirty.insert(dirty1.begin(), dirty1.end());
-
-  // Nucleation dumps churn the whole six-ring set. The dirty A(A(r))
-  // walk then visits every ring twice and is slower than a batch
-  // cageAffiliation. Fall back when more than half the rings are dirty.
-  if (!rings.empty() && dirty.size() * 2 > rings.size()) {
-    st.primeFull(rings, nList);
-    return st.current;
-  }
 
   // ----------------------------------------------------------- reclassify
   st.current.hc.assign(rings.size(), false);

--- a/src/cage_affiliation.cpp
+++ b/src/cage_affiliation.cpp
@@ -399,6 +399,14 @@ ring::AffiliationUpdater::update(const std::vector<std::vector<int>> &rings,
   std::unordered_set<int> dirty = expandOnce(atoms2);
   dirty.insert(dirty1.begin(), dirty1.end());
 
+  // Nucleation dumps churn the whole six-ring set. The dirty A(A(r))
+  // walk then visits every ring twice and is slower than a batch
+  // cageAffiliation. Fall back when more than half the rings are dirty.
+  if (!rings.empty() && dirty.size() * 2 > rings.size()) {
+    st.primeFull(rings, nList);
+    return st.current;
+  }
+
   // ----------------------------------------------------------- reclassify
   st.current.hc.assign(rings.size(), false);
   st.current.ddc.assign(rings.size(), false);

--- a/src/include/internal/cage_affiliation.hpp
+++ b/src/include/internal/cage_affiliation.hpp
@@ -75,8 +75,8 @@ struct CageAffiliation {
  *  rows against the previous frame, recomputes affiliation inside the
  *  locality closure of the changes, and carries stored answers elsewhere.
  *  The result is identical to cageAffiliation on the new frame. When
- *  more than half the rings sit in the dirty closure, the update is
- *  the batch classifier.
+ *  more than half the neighbour rows change, or more than half the
+ *  rings sit in the dirty closure, the update is the batch classifier.
  */
 class AffiliationUpdater {
 public:

--- a/src/include/internal/cage_affiliation.hpp
+++ b/src/include/internal/cage_affiliation.hpp
@@ -74,9 +74,9 @@ struct CageAffiliation {
  * @details Diffs the six-ring set (by canonical ring key) and the neighbour
  *  rows against the previous frame, recomputes affiliation inside the
  *  locality closure of the changes, and carries stored answers elsewhere.
- *  The result is identical to cageAffiliation on the new frame. When
- *  more than half the neighbour rows change, or more than half the
- *  rings sit in the dirty closure, the update is the batch classifier.
+ *  The result is identical to cageAffiliation on the new frame. The
+ *  neighbour graph should come from SkinNeighborList so cutoff flicker
+ *  does not rewrite every row.
  */
 class AffiliationUpdater {
 public:

--- a/src/include/internal/cage_affiliation.hpp
+++ b/src/include/internal/cage_affiliation.hpp
@@ -74,7 +74,9 @@ struct CageAffiliation {
  * @details Diffs the six-ring set (by canonical ring key) and the neighbour
  *  rows against the previous frame, recomputes affiliation inside the
  *  locality closure of the changes, and carries stored answers elsewhere.
- *  The result is identical to cageAffiliation on the new frame.
+ *  The result is identical to cageAffiliation on the new frame. When
+ *  more than half the rings sit in the dirty closure, the update is
+ *  the batch classifier.
  */
 class AffiliationUpdater {
 public:

--- a/src/include/internal/cage_affiliation.hpp
+++ b/src/include/internal/cage_affiliation.hpp
@@ -75,8 +75,8 @@ struct CageAffiliation {
  *  rows against the previous frame, recomputes affiliation inside the
  *  locality closure of the changes, and carries stored answers elsewhere.
  *  The result is identical to cageAffiliation on the new frame. The
- *  neighbour graph should come from SkinNeighborList so cutoff flicker
- *  does not rewrite every row.
+ *  neighbour graph should come from SkinNeighborList (default: mutual
+ *  four-nearest, the TUM v2 graph).
  */
 class AffiliationUpdater {
 public:

--- a/src/include/internal/neighbours.hpp
+++ b/src/include/internal/neighbours.hpp
@@ -125,9 +125,9 @@ std::pair<double, double> shellSeparation(
  *  Vesin (or the brute-force fallback) builds candidates at cutoff+skin,
  *  which is the ghost halo: periodic images already sit in that shell.
  *  The cell list is rebuilt only when some atom has moved more than
- *  skin/2 from the last rebuild, the Verlet trigger. Bonds for rings
- *  form at cutoff and break at cutoff+skin, so a pair that flickers
- *  across the analysis cutoff does not rewrite the graph.
+ *  skin/2 from the last rebuild, the Verlet trigger. The bond graph
+ *  for rings is the candidate pairs whose current distance is inside
+ *  the analysis cutoff.
  */
 class SkinNeighborList {
 public:
@@ -149,7 +149,6 @@ private:
   double cutoff_;
   double skin_;
   double cutoffSq_;
-  double breakSq_;
   double triggerSq_;
   int typeI_;
   bool rebuilt_{true};

--- a/src/include/internal/neighbours.hpp
+++ b/src/include/internal/neighbours.hpp
@@ -17,6 +17,7 @@
 
 #include <array>
 #include <set>
+#include <string>
 #include <utility>
 
 #include <generic.hpp>
@@ -121,6 +122,17 @@ std::pair<double, double> shellSeparation(
 //! Erases memory for a vector of vectors for the neighbour list
 [[nodiscard]] int clearNeighbourList(std::vector<std::vector<int>> &nList);
 
+/** Bond graph for TUM. Chosen at runtime so the three published
+ *  assignments can be compared on the same frames.
+ *  cutoff: pairs inside the distance cutoff (2020 graph).
+ *  knn: mutual k-nearest (TUM v2 without hysteresis).
+ *  knn-union: union k-nearest (the completion graph of the seeded rule).
+ */
+enum class BondGraph { Cutoff, KnnMutual, KnnUnion };
+
+BondGraph bondGraphFromName(const std::string &name);
+const char *bondGraphName(BondGraph graph);
+
 /** Persistent neighbour list with a LAMMPS skin.
  *  Vesin (or the brute-force fallback) builds candidates at cutoff+skin,
  *  which is the ghost halo: periodic images already sit in that shell.
@@ -131,10 +143,12 @@ std::pair<double, double> shellSeparation(
  */
 class SkinNeighborList {
 public:
-  //! k <= 0: bonds are candidate pairs inside cutoff. k > 0 (default 4):
-  //! bonds are the mutual k-nearest among the skin candidates, the TUM
-  //! v2 graph. 3.5 A is only the candidate search, not the bond rule.
-  SkinNeighborList(double cutoff, double skin, int typeI, int k = 4);
+  //! graph selects cutoff vs k-nearest (mutual or union). k is the
+  //! neighbour count for the knn graphs (default 4).
+  SkinNeighborList(double cutoff, double skin, int typeI,
+                   BondGraph graph = BondGraph::KnnMutual, int k = 4);
+
+  [[nodiscard]] BondGraph graph() const { return graph_; }
 
   //! Refresh from a new frame. The returned list is ID-keyed with a
   //! leading self entry, the same shape as neighListO.
@@ -155,6 +169,8 @@ private:
   double triggerSq_;
   int typeI_;
   int k_;
+  BondGraph graph_{BondGraph::KnnMutual};
+  bool mutual_{true};
   bool rebuilt_{true};
   int changedAtoms_{0};
   std::vector<double> x0_;

--- a/src/include/internal/neighbours.hpp
+++ b/src/include/internal/neighbours.hpp
@@ -131,7 +131,10 @@ std::pair<double, double> shellSeparation(
  */
 class SkinNeighborList {
 public:
-  SkinNeighborList(double cutoff, double skin, int typeI);
+  //! k <= 0: bonds are candidate pairs inside cutoff. k > 0 (default 4):
+  //! bonds are the mutual k-nearest among the skin candidates, the TUM
+  //! v2 graph. 3.5 A is only the candidate search, not the bond rule.
+  SkinNeighborList(double cutoff, double skin, int typeI, int k = 4);
 
   //! Refresh from a new frame. The returned list is ID-keyed with a
   //! leading self entry, the same shape as neighListO.
@@ -151,6 +154,7 @@ private:
   double cutoffSq_;
   double triggerSq_;
   int typeI_;
+  int k_;
   bool rebuilt_{true};
   int changedAtoms_{0};
   std::vector<double> x0_;

--- a/src/include/internal/neighbours.hpp
+++ b/src/include/internal/neighbours.hpp
@@ -15,6 +15,8 @@
 #ifndef SEAMS_NEIGHBOURS_H_
 #define SEAMS_NEIGHBOURS_H_
 
+#include <array>
+#include <set>
 #include <utility>
 
 #include <generic.hpp>
@@ -118,6 +120,55 @@ std::pair<double, double> shellSeparation(
 
 //! Erases memory for a vector of vectors for the neighbour list
 [[nodiscard]] int clearNeighbourList(std::vector<std::vector<int>> &nList);
+
+/** Persistent neighbour list with a LAMMPS skin.
+ *  Vesin (or the brute-force fallback) builds candidates at cutoff+skin,
+ *  which is the ghost halo: periodic images already sit in that shell.
+ *  The cell list is rebuilt only when some atom has moved more than
+ *  skin/2 from the last rebuild, the Verlet trigger. Bonds for rings
+ *  form at cutoff and break at cutoff+skin, so a pair that flickers
+ *  across the analysis cutoff does not rewrite the graph.
+ */
+class SkinNeighborList {
+public:
+  SkinNeighborList(double cutoff, double skin, int typeI);
+
+  //! Refresh from a new frame. The returned list is ID-keyed with a
+  //! leading self entry, the same shape as neighListO.
+  const std::vector<std::vector<int>> &
+  update(const molSys::PointCloud<molSys::Point<double>, double> &yCloud);
+
+  [[nodiscard]] bool lastRebuilt() const { return rebuilt_; }
+  //! Atoms whose cutoff bond set changed on the last update.
+  [[nodiscard]] int lastChangedAtoms() const { return changedAtoms_; }
+  [[nodiscard]] const std::vector<std::vector<int>> &bonds() const {
+    return nList_;
+  }
+
+private:
+  double cutoff_;
+  double skin_;
+  double cutoffSq_;
+  double breakSq_;
+  double triggerSq_;
+  int typeI_;
+  bool rebuilt_{true};
+  int changedAtoms_{0};
+  std::vector<double> x0_;
+  std::vector<double> y0_;
+  std::vector<double> z0_;
+  std::array<double, 3> box0_{};
+  std::vector<std::pair<int, int>> candidates_;
+  std::set<std::pair<int, int>> bonded_;
+  std::vector<std::vector<int>> nList_;
+
+  bool mustRebuild(
+      const molSys::PointCloud<molSys::Point<double>, double> &yCloud) const;
+  void rebuildCandidates(
+      const molSys::PointCloud<molSys::Point<double>, double> &yCloud);
+  void refreshBonds(
+      const molSys::PointCloud<molSys::Point<double>, double> &yCloud);
+};
 
 }  // namespace nneigh
 

--- a/src/include/internal/seams_input.hpp
+++ b/src/include/internal/seams_input.hpp
@@ -50,6 +50,16 @@ namespace sinp {
 //! Get file list inside the input folder
 std::vector<std::string> getInpFileList(std::string inputFolder);
 
+//! Number of ITEM: TIMESTEP frames in a LAMMPS dump, or 0 if the file
+//! cannot be read. The first full count per path walks the file once
+//! and later reads seek, matching chemfiles Trajectory::nsteps and
+//! readcon's frame-offset table. Sequential load_frame walks reuse a
+//! live cursor the way LAMMPS ReaderNative does on rerun.
+int nLammpsFrames(const std::string &filename);
+
+//! Drop a cached dump session (tests that rewrite a path in place).
+void dropLammpsDumpIndex(const std::string &filename);
+
 //! Function for reading in a specified frame (frame number and not timestep
 //! value)
 molSys::PointCloud<molSys::Point<double>, double>

--- a/src/include/internal/seams_input.hpp
+++ b/src/include/internal/seams_input.hpp
@@ -15,6 +15,7 @@
 #ifndef SEAMS_SEAMS_INPUT_H_
 #define SEAMS_SEAMS_INPUT_H_
 
+#include <functional>
 #include <iostream>
 #include <memory>
 #include <mol_sys.hpp>
@@ -59,6 +60,18 @@ int nLammpsFrames(const std::string &filename);
 
 //! Drop a cached dump session (tests that rewrite a path in place).
 void dropLammpsDumpIndex(const std::string &filename);
+
+//! Call fn(frame, cloud) for each frame in [first, last] (1-based,
+//! inclusive). last <= 0 means every ITEM: TIMESTEP. typeFilter <= 0
+//! keeps every atom. nThreads <= 0 uses the OpenMP default; 1 is
+//! serial. Each worker opens its own handle and seeks the shared
+//! offset table. Incremental RingUpdater / AffiliationUpdater state
+//! cannot be shared across workers: use the batch classifiers.
+void forEachLammpsFrame(
+    const std::string &filename, int first, int last, int typeFilter,
+    const std::function<void(
+        int, molSys::PointCloud<molSys::Point<double>, double> &)> &fn,
+    int nThreads = 0);
 
 //! Function for reading in a specified frame (frame number and not timestep
 //! value)

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -684,3 +684,134 @@ std::pair<double, double> nneigh::shellSeparation(
   }
   return {maxKth, haveNext ? minNext : 0.0};
 }
+
+nneigh::SkinNeighborList::SkinNeighborList(double cutoff, double skin,
+                                           int typeI)
+    : cutoff_(cutoff), skin_(skin), cutoffSq_(cutoff * cutoff),
+      breakSq_((cutoff + skin) * (cutoff + skin)),
+      triggerSq_((0.5 * skin) * (0.5 * skin)), typeI_(typeI) {}
+
+bool nneigh::SkinNeighborList::mustRebuild(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud) const {
+  if (static_cast<int>(x0_.size()) != yCloud.nop || yCloud.box.size() < 3) {
+    return true;
+  }
+  for (int k = 0; k < 3; k++) {
+    if (std::fabs(yCloud.box[k] - box0_[static_cast<std::size_t>(k)]) >
+        1e-8) {
+      return true;
+    }
+  }
+  std::vector<double> old(3);
+  for (int i = 0; i < yCloud.nop; i++) {
+    if (yCloud.pts[i].type != typeI_) {
+      continue;
+    }
+    old[0] = x0_[static_cast<std::size_t>(i)];
+    old[1] = y0_[static_cast<std::size_t>(i)];
+    old[2] = z0_[static_cast<std::size_t>(i)];
+    const double r = gen::unWrappedDistFromPoint(yCloud, i, old);
+    if (r * r > triggerSq_) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void nneigh::SkinNeighborList::rebuildCandidates(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud) {
+  candidates_.clear();
+  const double wide = cutoff_ + skin_;
+#ifdef SEAMS_HAS_VESIN
+  std::vector<int> subset;
+  subset.reserve(static_cast<std::size_t>(yCloud.nop));
+  for (int i = 0; i < yCloud.nop; i++) {
+    if (yCloud.pts[i].type == typeI_) {
+      subset.push_back(i);
+    }
+  }
+  std::vector<std::pair<int, int>> pairs;
+  if (cellListPairs(yCloud, subset, wide, pairs)) {
+    for (const auto &[i, j] : pairs) {
+      if (i < j) {
+        candidates_.emplace_back(i, j);
+      }
+    }
+  } else
+#endif
+  {
+    const auto wideList = nneigh::neighListO(wide, yCloud, typeI_);
+    for (int i = 0; i < yCloud.nop; i++) {
+      if (static_cast<int>(wideList.size()) <= i || wideList[i].size() <= 1) {
+        continue;
+      }
+      for (std::size_t n = 1; n < wideList[i].size(); n++) {
+        const auto it = yCloud.idIndexMap.find(wideList[i][n]);
+        if (it == yCloud.idIndexMap.end()) {
+          continue;
+        }
+        const int j = it->second;
+        if (i < j) {
+          candidates_.emplace_back(i, j);
+        }
+      }
+    }
+  }
+  x0_.resize(static_cast<std::size_t>(yCloud.nop));
+  y0_.resize(static_cast<std::size_t>(yCloud.nop));
+  z0_.resize(static_cast<std::size_t>(yCloud.nop));
+  for (int i = 0; i < yCloud.nop; i++) {
+    x0_[static_cast<std::size_t>(i)] = yCloud.pts[i].x;
+    y0_[static_cast<std::size_t>(i)] = yCloud.pts[i].y;
+    z0_[static_cast<std::size_t>(i)] = yCloud.pts[i].z;
+  }
+  box0_ = {yCloud.box[0], yCloud.box[1], yCloud.box[2]};
+}
+
+void nneigh::SkinNeighborList::refreshBonds(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud) {
+  std::set<std::pair<int, int>> next;
+  for (const auto &[i, j] : candidates_) {
+    if (i < 0 || j < 0 || i >= yCloud.nop || j >= yCloud.nop) {
+      continue;
+    }
+    const double r2 = gen::periodicDistSq(yCloud, i, j);
+    if (r2 <= cutoffSq_) {
+      next.emplace(i, j);
+    } else if (r2 <= breakSq_ && bonded_.count({i, j}) != 0) {
+      next.emplace(i, j);
+    }
+  }
+  std::set<int> touched;
+  for (const auto &p : bonded_) {
+    if (next.count(p) == 0) {
+      touched.insert(p.first);
+      touched.insert(p.second);
+    }
+  }
+  for (const auto &p : next) {
+    if (bonded_.count(p) == 0) {
+      touched.insert(p.first);
+      touched.insert(p.second);
+    }
+  }
+  changedAtoms_ = static_cast<int>(touched.size());
+  bonded_.swap(next);
+
+  const auto indexToID = indexToIDTable(yCloud);
+  nList_ = seedWithSelfIDs(indexToID, yCloud.nop);
+  for (const auto &[i, j] : bonded_) {
+    appendNeighbourID(nList_, indexToID, i, j);
+    appendNeighbourID(nList_, indexToID, j, i);
+  }
+}
+
+const std::vector<std::vector<int>> &nneigh::SkinNeighborList::update(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud) {
+  rebuilt_ = mustRebuild(yCloud);
+  if (rebuilt_) {
+    rebuildCandidates(yCloud);
+  }
+  refreshBonds(yCloud);
+  return nList_;
+}

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -688,7 +688,6 @@ std::pair<double, double> nneigh::shellSeparation(
 nneigh::SkinNeighborList::SkinNeighborList(double cutoff, double skin,
                                            int typeI)
     : cutoff_(cutoff), skin_(skin), cutoffSq_(cutoff * cutoff),
-      breakSq_((cutoff + skin) * (cutoff + skin)),
       triggerSq_((0.5 * skin) * (0.5 * skin)), typeI_(typeI) {}
 
 bool nneigh::SkinNeighborList::mustRebuild(
@@ -777,8 +776,6 @@ void nneigh::SkinNeighborList::refreshBonds(
     }
     const double r2 = gen::periodicDistSq(yCloud, i, j);
     if (r2 <= cutoffSq_) {
-      next.emplace(i, j);
-    } else if (r2 <= breakSq_ && bonded_.count({i, j}) != 0) {
       next.emplace(i, j);
     }
   }

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -686,9 +686,9 @@ std::pair<double, double> nneigh::shellSeparation(
 }
 
 nneigh::SkinNeighborList::SkinNeighborList(double cutoff, double skin,
-                                           int typeI)
+                                           int typeI, int k)
     : cutoff_(cutoff), skin_(skin), cutoffSq_(cutoff * cutoff),
-      triggerSq_((0.5 * skin) * (0.5 * skin)), typeI_(typeI) {}
+      triggerSq_((0.5 * skin) * (0.5 * skin)), typeI_(typeI), k_(k) {}
 
 bool nneigh::SkinNeighborList::mustRebuild(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud) const {
@@ -770,13 +770,49 @@ void nneigh::SkinNeighborList::rebuildCandidates(
 void nneigh::SkinNeighborList::refreshBonds(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud) {
   std::set<std::pair<int, int>> next;
-  for (const auto &[i, j] : candidates_) {
-    if (i < 0 || j < 0 || i >= yCloud.nop || j >= yCloud.nop) {
-      continue;
+  if (k_ <= 0) {
+    for (const auto &[i, j] : candidates_) {
+      if (i < 0 || j < 0 || i >= yCloud.nop || j >= yCloud.nop) {
+        continue;
+      }
+      if (gen::periodicDistSq(yCloud, i, j) <= cutoffSq_) {
+        next.emplace(i, j);
+      }
     }
-    const double r2 = gen::periodicDistSq(yCloud, i, j);
-    if (r2 <= cutoffSq_) {
-      next.emplace(i, j);
+  } else {
+    std::vector<std::vector<std::pair<double, int>>> byDist(
+        static_cast<std::size_t>(yCloud.nop));
+    for (const auto &[i, j] : candidates_) {
+      if (i < 0 || j < 0 || i >= yCloud.nop || j >= yCloud.nop) {
+        continue;
+      }
+      const double r2 = gen::periodicDistSq(yCloud, i, j);
+      byDist[static_cast<std::size_t>(i)].emplace_back(r2, j);
+      byDist[static_cast<std::size_t>(j)].emplace_back(r2, i);
+    }
+    std::vector<std::vector<int>> nominated(static_cast<std::size_t>(yCloud.nop));
+    for (int i = 0; i < yCloud.nop; i++) {
+      auto &row = byDist[static_cast<std::size_t>(i)];
+      if (row.empty()) {
+        continue;
+      }
+      const int take = std::min(k_, static_cast<int>(row.size()));
+      std::partial_sort(row.begin(), row.begin() + take, row.end());
+      nominated[static_cast<std::size_t>(i)].reserve(static_cast<std::size_t>(take));
+      for (int n = 0; n < take; n++) {
+        nominated[static_cast<std::size_t>(i)].push_back(row[static_cast<std::size_t>(n)].second);
+      }
+    }
+    for (int i = 0; i < yCloud.nop; i++) {
+      for (const int j : nominated[static_cast<std::size_t>(i)]) {
+        if (j <= i) {
+          continue;
+        }
+        const auto &other = nominated[static_cast<std::size_t>(j)];
+        if (std::find(other.begin(), other.end(), i) != other.end()) {
+          next.emplace(i, j);
+        }
+      }
     }
   }
   std::set<int> touched;

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -18,6 +18,8 @@
 #include <numeric>
 #include <set>
 #include <span>
+#include <stdexcept>
+#include <string>
 #include <utility>
 
 #include <neighbours.hpp>
@@ -685,10 +687,39 @@ std::pair<double, double> nneigh::shellSeparation(
   return {maxKth, haveNext ? minNext : 0.0};
 }
 
+nneigh::BondGraph nneigh::bondGraphFromName(const std::string &name) {
+  if (name == "cutoff") {
+    return BondGraph::Cutoff;
+  }
+  if (name == "knn" || name == "knn-mutual" || name == "mutual") {
+    return BondGraph::KnnMutual;
+  }
+  if (name == "knn-union" || name == "union") {
+    return BondGraph::KnnUnion;
+  }
+  throw std::invalid_argument(
+      "unknown bond graph '" + name +
+      "' (use cutoff, knn, knn-union)");
+}
+
+const char *nneigh::bondGraphName(BondGraph graph) {
+  switch (graph) {
+  case BondGraph::Cutoff:
+    return "cutoff";
+  case BondGraph::KnnMutual:
+    return "knn";
+  case BondGraph::KnnUnion:
+    return "knn-union";
+  }
+  return "cutoff";
+}
+
 nneigh::SkinNeighborList::SkinNeighborList(double cutoff, double skin,
-                                           int typeI, int k)
+                                           int typeI, BondGraph graph, int k)
     : cutoff_(cutoff), skin_(skin), cutoffSq_(cutoff * cutoff),
-      triggerSq_((0.5 * skin) * (0.5 * skin)), typeI_(typeI), k_(k) {}
+      triggerSq_((0.5 * skin) * (0.5 * skin)), typeI_(typeI),
+      k_(graph == BondGraph::Cutoff ? 0 : k), graph_(graph),
+      mutual_(graph != BondGraph::KnnUnion) {}
 
 bool nneigh::SkinNeighborList::mustRebuild(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud) const {
@@ -805,13 +836,15 @@ void nneigh::SkinNeighborList::refreshBonds(
     }
     for (int i = 0; i < yCloud.nop; i++) {
       for (const int j : nominated[static_cast<std::size_t>(i)]) {
-        if (j <= i) {
-          continue;
+        const int a = std::min(i, j);
+        const int b = std::max(i, j);
+        if (mutual_) {
+          const auto &other = nominated[static_cast<std::size_t>(j)];
+          if (std::find(other.begin(), other.end(), i) == other.end()) {
+            continue;
+          }
         }
-        const auto &other = nominated[static_cast<std::size_t>(j)];
-        if (std::find(other.begin(), other.end(), i) != other.end()) {
-          next.emplace(i, j);
-        }
+        next.emplace(a, b);
       }
     }
   }

--- a/src/seams_cli.cpp
+++ b/src/seams_cli.cpp
@@ -17,6 +17,7 @@
 #include <map>
 #include <mutex>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
@@ -124,42 +125,77 @@ int cmdChill(std::ostream &os, Cloud &cloud, double cutoff, int typeI) {
   return 0;
 }
 
-int cmdCages(std::ostream &os, Cloud &cloud, double cutoff, int typeI, int k) {
+int cmdCages(std::ostream &os, Cloud &cloud, double cutoff, int typeI, int k,
+             const std::string &graphName) {
   const int typ = typeOf(cloud, typeI);
   const double cand = cutoff + 1.5;
-  auto mutual = nneigh::kNearestNeighbourList(cloud, k, cand, typ, true);
-  auto uni = nneigh::kNearestNeighbourList(cloud, k, cand, typ, false);
-  auto idxS = nneigh::neighbourListByIndex(cloud, mutual);
-  auto idxU = nneigh::neighbourListByIndex(cloud, uni);
-  auto ringsS = primitive::ringNetwork(idxS, 6);
-  auto ringsU = primitive::ringNetwork(idxU, 6);
-  std::vector<std::vector<int>> sixS;
-  std::vector<std::vector<int>> sixU;
-  for (const auto &r : ringsS) {
-    if (r.size() == 6) {
-      sixS.push_back(r);
+
+  auto sixOf = [](const std::vector<std::vector<int>> &rings) {
+    std::vector<std::vector<int>> six;
+    for (const auto &r : rings) {
+      if (r.size() == 6) {
+        six.push_back(r);
+      }
     }
-  }
-  for (const auto &r : ringsU) {
-    if (r.size() == 6) {
-      sixU.push_back(r);
-    }
-  }
-  const auto aff = ring::seededCageAffiliation(sixS, idxS, sixU, idxU);
+    return six;
+  };
+
   int ih = 0;
   int ic = 0;
   int water = 0;
-  for (size_t i = 0; i < aff.hc.size(); ++i) {
-    if (aff.hc[i]) {
-      ++ih;
-    } else if (aff.ddc[i]) {
-      ++ic;
-    } else {
-      ++water;
+  const auto tallyAtoms = [&](const std::vector<bool> &hc,
+                              const std::vector<bool> &ddc) {
+    ih = ic = water = 0;
+    const int n = static_cast<int>(hc.size());
+    for (int i = 0; i < n; ++i) {
+      if (hc[static_cast<std::size_t>(i)]) {
+        ++ih;
+      } else if (ddc[static_cast<std::size_t>(i)]) {
+        ++ic;
+      } else {
+        ++water;
+      }
     }
+  };
+
+  if (graphName == "seeded") {
+    auto mutual = nneigh::kNearestNeighbourList(cloud, k, cand, typ, true);
+    auto uni = nneigh::kNearestNeighbourList(cloud, k, cand, typ, false);
+    auto idxS = nneigh::neighbourListByIndex(cloud, mutual);
+    auto idxU = nneigh::neighbourListByIndex(cloud, uni);
+    auto sixS = sixOf(primitive::ringNetwork(idxS, 6));
+    auto sixU = sixOf(primitive::ringNetwork(idxU, 6));
+    const auto aff = ring::seededCageAffiliation(sixS, idxS, sixU, idxU);
+    tallyAtoms(aff.hc, aff.ddc);
+  } else {
+    const auto graph = nneigh::bondGraphFromName(graphName);
+    std::vector<std::vector<int>> nList;
+    if (graph == nneigh::BondGraph::Cutoff) {
+      nList = nneigh::neighListO(cutoff, cloud, typ);
+    } else {
+      const bool mutual = graph == nneigh::BondGraph::KnnMutual;
+      nList = nneigh::kNearestNeighbourList(cloud, k, cand, typ, mutual);
+    }
+    auto idx = nneigh::neighbourListByIndex(cloud, nList);
+    auto six = sixOf(primitive::ringNetwork(idx, 6));
+    const auto aff = ring::cageAffiliation(six, idx);
+    // cageAffiliation is per-ring; map to atoms
+    std::vector<bool> hc(static_cast<std::size_t>(cloud.nop), false);
+    std::vector<bool> ddc(static_cast<std::size_t>(cloud.nop), false);
+    for (std::size_t r = 0; r < six.size(); ++r) {
+      for (const int a : six[r]) {
+        if (a >= 0 && a < cloud.nop) {
+          hc[static_cast<std::size_t>(a)] =
+              hc[static_cast<std::size_t>(a)] || aff.hc[r];
+          ddc[static_cast<std::size_t>(a)] =
+              ddc[static_cast<std::size_t>(a)] || aff.ddc[r];
+        }
+      }
+    }
+    tallyAtoms(hc, ddc);
   }
-  os << "nop " << cloud.nop << " ih " << ih << " ic " << ic << " water "
-     << water << "\n";
+  os << "nop " << cloud.nop << " graph " << graphName << " ih " << ih
+     << " ic " << ic << " water " << water << "\n";
   return 0;
 }
 
@@ -179,7 +215,10 @@ int main(int argc, char *argv[]) {
       cxxopts::value<int>()->default_value("0"))(
       "c,cutoff", "Neighbour cutoff (Angstrom)",
       cxxopts::value<double>()->default_value("3.5"))(
-      "k", "k for seeded cages", cxxopts::value<int>()->default_value("4"))(
+      "k", "k for knn / seeded cages", cxxopts::value<int>()->default_value("4"))(
+      "graph",
+      "Bond graph for cages: cutoff | knn | knn-union | seeded",
+      cxxopts::value<std::string>()->default_value("seeded"))(
       "command", "read | chill | chill-plus | cages",
       cxxopts::value<std::string>())("file", "Trajectory file",
                                      cxxopts::value<std::string>());
@@ -217,6 +256,7 @@ int main(int argc, char *argv[]) {
   const int typeI = args["type"].as<int>();
   const double cutoff = args["cutoff"].as<double>();
   const int k = args["k"].as<int>();
+  const std::string graph = args["graph"].as<std::string>();
 
   auto runOne = [&](std::ostream &os, Cloud &cloud) {
     if (cmd == "read") {
@@ -229,7 +269,12 @@ int main(int argc, char *argv[]) {
       return cmdChill(os, cloud, cutoff, typeI);
     }
     if (cmd == "cages") {
-      return cmdCages(os, cloud, cutoff, typeI, k);
+      try {
+        return cmdCages(os, cloud, cutoff, typeI, k, graph);
+      } catch (const std::exception &e) {
+        os << e.what() << "\n";
+        return 2;
+      }
     }
     os << "unknown command: " << cmd << "\n";
     return 2;

--- a/src/seams_cli.cpp
+++ b/src/seams_cli.cpp
@@ -15,6 +15,8 @@
 #include <cstdlib>
 #include <iostream>
 #include <map>
+#include <mutex>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -83,46 +85,46 @@ int typeOf(const Cloud &cloud, int requested) {
   return cloud.pts[0].type;
 }
 
-void printCounts(const Cloud &cloud) {
+void printCounts(std::ostream &os, const Cloud &cloud) {
   std::map<std::string, int> hist;
   for (const auto &pt : cloud.pts) {
     hist[iceName(pt.iceType)]++;
   }
-  std::cout << "nop " << cloud.nop;
+  os << "nop " << cloud.nop;
   for (const auto &[name, n] : hist) {
     if (n > 0) {
-      std::cout << " " << name << " " << n;
+      os << " " << name << " " << n;
     }
   }
-  std::cout << "\n";
+  os << "\n";
 }
 
-int cmdRead(Cloud &cloud) {
+int cmdRead(std::ostream &os, Cloud &cloud) {
   const auto box = cloud.box;
-  std::cout << "nop " << cloud.nop << " frame " << cloud.currentFrame
-            << " box " << box[0] << " " << box[1] << " " << box[2] << "\n";
+  os << "nop " << cloud.nop << " frame " << cloud.currentFrame << " box "
+     << box[0] << " " << box[1] << " " << box[2] << "\n";
   return 0;
 }
 
-int cmdChillPlus(Cloud &cloud, double cutoff, int typeI) {
+int cmdChillPlus(std::ostream &os, Cloud &cloud, double cutoff, int typeI) {
   const int typ = typeOf(cloud, typeI);
   auto nList = nneigh::neighListO(cutoff, cloud, typ);
   chill::getCorrelPlus(cloud, nList, false);
   chill::getIceTypePlusNoPrint(cloud, nList, false);
-  printCounts(cloud);
+  printCounts(os, cloud);
   return 0;
 }
 
-int cmdChill(Cloud &cloud, double cutoff, int typeI) {
+int cmdChill(std::ostream &os, Cloud &cloud, double cutoff, int typeI) {
   const int typ = typeOf(cloud, typeI);
   auto nList = nneigh::neighListO(cutoff, cloud, typ);
   chill::getCorrel(cloud, nList, false);
   chill::getIceTypeNoPrint(cloud, nList, false);
-  printCounts(cloud);
+  printCounts(os, cloud);
   return 0;
 }
 
-int cmdCages(Cloud &cloud, double cutoff, int typeI, int k) {
+int cmdCages(std::ostream &os, Cloud &cloud, double cutoff, int typeI, int k) {
   const int typ = typeOf(cloud, typeI);
   const double cand = cutoff + 1.5;
   auto mutual = nneigh::kNearestNeighbourList(cloud, k, cand, typ, true);
@@ -156,8 +158,8 @@ int cmdCages(Cloud &cloud, double cutoff, int typeI, int k) {
       ++water;
     }
   }
-  std::cout << "nop " << cloud.nop << " ih " << ih << " ic " << ic << " water "
-            << water << "\n";
+  os << "nop " << cloud.nop << " ih " << ih << " ic " << ic << " water "
+     << water << "\n";
   return 0;
 }
 
@@ -167,7 +169,11 @@ int main(int argc, char *argv[]) {
   cxxopts::Options opt(
       argv[0], "d-SEAMS engine CLI. Lua is the luadseams library; Python is pydseams.");
   opt.add_options()("h,help", "Print help")("v,version", "Print version")(
-      "f,frame", "Frame number (1-based)",
+      "f,frame", "First frame (1-based)",
+      cxxopts::value<int>()->default_value("1"))(
+      "last", "Last frame (inclusive). Omit for a single --frame.",
+      cxxopts::value<int>()->default_value("0"))(
+      "j,jobs", "Parallel frame workers (OpenMP). 1 is serial.",
       cxxopts::value<int>()->default_value("1"))(
       "t,type", "Atom type (0 guesses oxygen then type 1)",
       cxxopts::value<int>()->default_value("0"))(
@@ -206,23 +212,53 @@ int main(int argc, char *argv[]) {
   const std::string cmd = args["command"].as<std::string>();
   const std::string file = args["file"].as<std::string>();
   const int frame = args["frame"].as<int>();
+  const int last = args["last"].as<int>();
+  const int jobs = args["jobs"].as<int>();
   const int typeI = args["type"].as<int>();
   const double cutoff = args["cutoff"].as<double>();
   const int k = args["k"].as<int>();
 
-  Cloud cloud = load(file, frame, typeI);
-  if (cmd == "read") {
-    return cmdRead(cloud);
+  auto runOne = [&](std::ostream &os, Cloud &cloud) {
+    if (cmd == "read") {
+      return cmdRead(os, cloud);
+    }
+    if (cmd == "chill-plus" || cmd == "chill_plus") {
+      return cmdChillPlus(os, cloud, cutoff, typeI);
+    }
+    if (cmd == "chill") {
+      return cmdChill(os, cloud, cutoff, typeI);
+    }
+    if (cmd == "cages") {
+      return cmdCages(os, cloud, cutoff, typeI, k);
+    }
+    os << "unknown command: " << cmd << "\n";
+    return 2;
+  };
+
+  if (last <= 0 || last == frame) {
+    Cloud cloud = load(file, frame, typeI);
+    return runOne(std::cout, cloud);
   }
-  if (cmd == "chill-plus" || cmd == "chill_plus") {
-    return cmdChillPlus(cloud, cutoff, typeI);
-  }
-  if (cmd == "chill") {
-    return cmdChill(cloud, cutoff, typeI);
-  }
-  if (cmd == "cages") {
-    return cmdCages(cloud, cutoff, typeI, k);
-  }
-  std::cerr << "unknown command: " << cmd << "\n";
-  return 2;
+
+  std::mutex outMu;
+  int rc = 0;
+  const int typeFilter = typeI > 0 ? typeI : 0;
+  sinp::forEachLammpsFrame(
+      file, frame, last, typeFilter,
+      [&](int /*fr*/, Cloud &cloud) {
+        if (typeFilter <= 0 && cloud.nop == 0) {
+          cloud = load(file, cloud.currentFrame, typeI);
+        }
+        std::ostringstream line;
+        const int one = runOne(line, cloud);
+        {
+          std::lock_guard<std::mutex> lock(outMu);
+          std::cout << line.str();
+          if (one != 0) {
+            rc = one;
+          }
+        }
+      },
+      jobs);
+  return rc;
 }

--- a/src/seams_input.cpp
+++ b/src/seams_input.cpp
@@ -13,8 +13,14 @@
 //-----------------------------------------------------------------------------------
 
 #include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
 #include <generic.hpp>
+#include <memory>
+#include <mutex>
 #include <seams_input.hpp>
+#include <unordered_map>
 
 namespace {
 /**
@@ -34,7 +40,173 @@ void mapAtomIdToIndex(
     yCloud.idIndexMap[id] = idx;
   }
 }
+
+bool isLammpsTimestep(const std::string &line) {
+  return line.size() >= 14 && line.compare(0, 14, "ITEM: TIMESTEP") == 0;
+}
+
+// Live dump cursor, matching LAMMPS ReaderNative (rerun keeps FILE* at
+// the next snapshot) and chemfiles LAMMPSTrajectory::read_next. Random
+// access seeks a cached ITEM: TIMESTEP offset table.
+struct LammpsDumpSession {
+  std::mutex mu;
+  std::string path;
+  std::ifstream file;
+  std::vector<std::uint64_t> offsets;
+  int lastFrame = 0;
+  std::filesystem::file_time_type mtime{};
+  std::uintmax_t size{0};
+
+  bool open(const std::string &filename) {
+    path = filename;
+    std::error_code ec;
+    size = std::filesystem::file_size(filename, ec);
+    if (ec) {
+      return false;
+    }
+    mtime = std::filesystem::last_write_time(filename, ec);
+    if (ec) {
+      return false;
+    }
+    file.open(filename, std::ios::in | std::ios::binary);
+    offsets.clear();
+    lastFrame = 0;
+    return file.is_open();
+  }
+
+  bool stale() const {
+    std::error_code ec;
+    const auto sz = std::filesystem::file_size(path, ec);
+    if (ec || sz != size) {
+      return true;
+    }
+    const auto mt = std::filesystem::last_write_time(path, ec);
+    return ec || mt != mtime;
+  }
+
+  bool discoverNext() {
+    if (!file.is_open()) {
+      return false;
+    }
+    if (offsets.empty()) {
+      file.clear();
+      file.seekg(0);
+    } else {
+      file.clear();
+      file.seekg(static_cast<std::streamoff>(offsets.back()));
+      std::string skip;
+      if (!std::getline(file, skip)) {
+        return false;
+      }
+    }
+    while (file) {
+      const auto here = file.tellg();
+      if (here < 0) {
+        return false;
+      }
+      std::string line;
+      if (!std::getline(file, line)) {
+        return false;
+      }
+      if (isLammpsTimestep(line)) {
+        offsets.push_back(static_cast<std::uint64_t>(here));
+        return true;
+      }
+    }
+    return false;
+  }
+
+  bool positionAt(int frame) {
+    if (frame < 1 || !file.is_open()) {
+      return false;
+    }
+    if (lastFrame + 1 == frame && lastFrame > 0) {
+      const auto here = file.tellg();
+      if (here >= 0 && static_cast<int>(offsets.size()) < frame) {
+        offsets.push_back(static_cast<std::uint64_t>(here));
+      }
+      std::string line;
+      if (!std::getline(file, line) || !isLammpsTimestep(line)) {
+        return false;
+      }
+      lastFrame = frame;
+      return true;
+    }
+    while (static_cast<int>(offsets.size()) < frame) {
+      if (!discoverNext()) {
+        return false;
+      }
+    }
+    file.clear();
+    file.seekg(static_cast<std::streamoff>(offsets[frame - 1]));
+    std::string line;
+    if (!std::getline(file, line) || !isLammpsTimestep(line)) {
+      return false;
+    }
+    lastFrame = frame;
+    return true;
+  }
+
+  int nframes() {
+    while (discoverNext()) {
+    }
+    return static_cast<int>(offsets.size());
+  }
+};
+
+std::mutex gDumpMu;
+std::unordered_map<std::string, std::shared_ptr<LammpsDumpSession>> gDumps;
+
+std::shared_ptr<LammpsDumpSession> sessionFor(const std::string &filename) {
+  if (!gen::file_exists(filename)) {
+    return nullptr;
+  }
+  std::lock_guard<std::mutex> lock(gDumpMu);
+  auto &slot = gDumps[filename];
+  if (!slot || slot->stale() || !slot->file.is_open()) {
+    slot = std::make_shared<LammpsDumpSession>();
+    if (!slot->open(filename)) {
+      slot.reset();
+      return nullptr;
+    }
+  }
+  return slot;
+}
+
+void noteCoordColumn(int col, const std::string &tok, int &x, int &y,
+                     int &z) {
+  // LAMMPS ReaderNative (src/reader_native.cpp): take x if present,
+  // otherwise the first of xs / xu / xsu in column order.
+  if (tok == "x") {
+    x = col;
+  } else if ((tok == "xu" || tok == "xs" || tok == "xsu") && x < 0) {
+    x = col;
+  } else if (tok == "y") {
+    y = col;
+  } else if ((tok == "yu" || tok == "ys" || tok == "ysu") && y < 0) {
+    y = col;
+  } else if (tok == "z") {
+    z = col;
+  } else if ((tok == "zu" || tok == "zs" || tok == "zsu") && z < 0) {
+    z = col;
+  }
+}
+
 } // namespace
+
+int sinp::nLammpsFrames(const std::string &filename) {
+  auto sess = sessionFor(filename);
+  if (sess == nullptr) {
+    return 0;
+  }
+  std::lock_guard<std::mutex> lock(sess->mu);
+  return sess->nframes();
+}
+
+void sinp::dropLammpsDumpIndex(const std::string &filename) {
+  std::lock_guard<std::mutex> lock(gDumpMu);
+  gDumps.erase(filename);
+}
 
 /**
  * @details Get all the ring information, from the R.I.N.G.S. file. Each line
@@ -194,6 +366,172 @@ molSys::PointCloud<molSys::Point<double>, double> sinp::readXYZ(std::string file
 
 // External Libraries
 
+namespace {
+enum class LammpsKeep { All, Type, TypeInSlice };
+
+// Parse one snapshot. The session has already consumed ITEM: TIMESTEP.
+// Stop at the next ITEM: TIMESTEP and seek back so the live cursor sits
+// on that line, matching LAMMPS ReaderNative::read_time.
+void parseLammpsFrameBody(
+    std::ifstream &file,
+    molSys::PointCloud<molSys::Point<double>, double> &yCloud, int typeFilter,
+    LammpsKeep keep, bool isSlice, std::array<double, 3> coordLow,
+    std::array<double, 3> coordHigh) {
+  std::string line;
+  std::vector<std::string> tokens;
+  std::vector<double> numbers;
+  std::vector<double> tilt;
+  int nop = -1;
+  bool readNOP = false;
+  bool readBox = false;
+  bool readAtoms = false;
+  int xIndex = -1;
+  int yIndex = -1;
+  int zIndex = -1;
+  int typeIndex = -1;
+  int molIndex = 0;
+  int atomIndex = 0;
+  bool isTriclinic = false;
+  int nKept = 0;
+  molSys::Point<double> iPoint;
+
+  while (true) {
+    const auto mark = file.tellg();
+    if (!std::getline(file, line)) {
+      break;
+    }
+    if (isLammpsTimestep(line)) {
+      if (mark >= 0) {
+        file.clear();
+        file.seekg(mark);
+      }
+      break;
+    }
+
+    tokens = gen::tokenizer(line);
+    numbers = gen::tokenizerDouble(line);
+
+    if (readNOP) {
+      nop = std::stoi(line.data());
+      readNOP = false;
+      if (keep == LammpsKeep::All) {
+        yCloud.pts.reserve(static_cast<std::size_t>(nop));
+        yCloud.nop = nop;
+      }
+    }
+    if (readBox) {
+      if (!tokens.empty() && tokens[0] == "ITEM:") {
+        readBox = false;
+        if (isTriclinic) {
+          for (std::size_t k = 0; k < tilt.size(); k++) {
+            yCloud.box.push_back(tilt[k]);
+          }
+        }
+      } else if (numbers.size() >= 2) {
+        yCloud.box.push_back(numbers[1] - numbers[0]);
+        yCloud.boxLow.push_back(numbers[0]);
+        if (numbers.size() == 3) {
+          isTriclinic = true;
+          tilt.push_back(numbers[2]);
+        }
+      }
+    }
+    if (readAtoms && typeIndex >= 0 && xIndex >= 0 && yIndex >= 0 &&
+        zIndex >= 0 &&
+        numbers.size() >
+            static_cast<std::size_t>(
+                std::max({typeIndex, xIndex, yIndex, zIndex, molIndex,
+                          atomIndex}))) {
+      iPoint.type = static_cast<int>(numbers[typeIndex]);
+      iPoint.molID = static_cast<int>(numbers[molIndex]);
+      iPoint.atomID = static_cast<int>(numbers[atomIndex]);
+      iPoint.x = numbers[xIndex];
+      iPoint.y = numbers[yIndex];
+      iPoint.z = numbers[zIndex];
+      if (isSlice) {
+        iPoint.inSlice = sinp::atomInSlice(iPoint.x, iPoint.y, iPoint.z,
+                                           coordLow, coordHigh);
+        if (keep == LammpsKeep::TypeInSlice && !iPoint.inSlice) {
+          continue;
+        }
+      }
+      if (keep != LammpsKeep::All && iPoint.type != typeFilter) {
+        continue;
+      }
+      nKept++;
+      yCloud.pts.push_back(iPoint);
+      mapAtomIdToIndex(yCloud);
+    }
+
+    if (!tokens.empty() && tokens[0] == "ITEM:" && tokens.size() > 1) {
+      if (tokens[1] == "NUMBER") {
+        readNOP = true;
+      } else if (tokens[1] == "BOX") {
+        readBox = true;
+      } else if (tokens[1] == "ATOMS") {
+        readAtoms = true;
+        xIndex = yIndex = zIndex = typeIndex = -1;
+        molIndex = 0;
+        atomIndex = 0;
+        for (int i = 2; i < static_cast<int>(tokens.size()); i++) {
+          if (tokens[i] == "type") {
+            typeIndex = i - 2;
+          } else if (tokens[i] == "mol") {
+            molIndex = i - 2;
+          } else if (tokens[i] == "id") {
+            atomIndex = i - 2;
+          } else {
+            noteCoordColumn(i - 2, tokens[i], xIndex, yIndex, zIndex);
+          }
+        }
+        if (molIndex == 0) {
+          molIndex = atomIndex;
+        }
+      }
+    }
+  }
+
+  if (keep != LammpsKeep::All) {
+    yCloud.nop = static_cast<int>(yCloud.pts.size());
+    if (yCloud.pts.size() != static_cast<std::size_t>(nKept)) {
+      std::cout << "Atoms didn't get filled in properly.\n";
+    }
+  } else if (nop >= 0 && yCloud.pts.size() != static_cast<std::size_t>(yCloud.nop)) {
+    std::cout << "Atoms didn't get filled in properly.\n";
+  }
+}
+
+void loadLammpsFrame(
+    const std::string &filename, int targetFrame,
+    molSys::PointCloud<molSys::Point<double>, double> &yCloud, int typeFilter,
+    LammpsKeep keep, bool isSlice, std::array<double, 3> coordLow,
+    std::array<double, 3> coordHigh) {
+  yCloud = molSys::clearPointCloud(yCloud);
+  if (!gen::file_exists(filename)) {
+    std::cout
+        << "Fatal Error: The file does not exist or you gave the wrong path.\n";
+    yCloud.currentFrame = targetFrame;
+    return;
+  }
+  auto sess = sessionFor(filename);
+  if (sess == nullptr) {
+    std::cout
+        << "Fatal Error: The file does not exist or you gave the wrong path.\n";
+    yCloud.currentFrame = targetFrame;
+    return;
+  }
+  std::lock_guard<std::mutex> lock(sess->mu);
+  if (!sess->positionAt(targetFrame)) {
+    std::cout << "You entered a frame that doesn't exist.\n";
+    yCloud.currentFrame = targetFrame;
+    return;
+  }
+  parseLammpsFrameBody(sess->file, yCloud, typeFilter, keep, isSlice, coordLow,
+                       coordHigh);
+  yCloud.currentFrame = targetFrame;
+}
+} // namespace
+
 /**
  * @details  Function for reading in a lammps file. Reads in a specified frame
  *  (frame number and not timestep value).
@@ -211,204 +549,8 @@ sinp::readLammpsTrj(std::string filename, int targetFrame,
                     molSys::PointCloud<molSys::Point<double>, double> &yCloud,
                     bool isSlice, std::array<double, 3> coordLow,
                     std::array<double, 3> coordHigh) {
-  std::unique_ptr<std::ifstream> dumpFile;
-  dumpFile = std::make_unique<std::ifstream>(filename);
-  std::string line;                // Current line being read in
-  std::vector<std::string> tokens; // Vector containing word tokens
-  std::vector<double> numbers;     // Vector containing type double numbers
-  std::vector<double> tilt;        // Vector containing tilt factors
-  int currentFrame = 0;            // Current frame being read in
-  int nop = -1;                    // Number of atoms in targetFrame
-  bool foundFrame =
-      false;            // Determines whether targetFrame has been found or not
-  bool readNOP = false; // Flag for reading in the number of atoms
-  bool readBox = false; // Flag for reading in the box lengths
-  bool readAtoms = false; // Flag for reading in the atoms
-  int xIndex, yIndex, zIndex,
-      typeIndex;     // Indices for x,y,z coordinates, and LAMMPS type ID
-  int molIndex = 0;  // Index for molecular ID
-  int atomIndex = 0; // Index for atom ID (Only used if mol ID has not been set)
-  molSys::Point<double> iPoint; // Current point being read in from the file
-  xIndex = yIndex = zIndex = typeIndex = -1; // Default values
-  bool isTriclinic = false; // Flag for an orthogonal or triclinic box
-
-  if (!(gen::file_exists(filename))) {
-    std::cout
-        << "Fatal Error: The file does not exist or you gave the wrong path.\n";
-    // Throw exception?
-    return yCloud;
-  }
-
-  // The format of the LAMMPS trajectory file is:
-  // ITEM: TIMESTEP
-  // 0
-  // ITEM: NUMBER OF ATOMS
-  // 4096
-  // ITEM: BOX BOUNDS pp pp pp
-  // -7.9599900000000001e-01 5.0164000000000001e+01
-  // -7.9599900000000001e-01 5.0164000000000001e+01
-  // -7.9599900000000001e-01 5.0164000000000001e+01
-  // ITEM: ATOMS id type x y z
-  // 1 1 0 0 0 etc
-  if (dumpFile->is_open()) {
-    // ----------------------------------------------------------
-    // At this point we know that the dumpfile is open
-    // This loop searches for targetFrame
-    while (std::getline((*dumpFile), line)) {
-      // Read in lines and tokenize them
-      tokens = gen::tokenizer(line);
-      // Find out which timestep number
-      // you are inside
-      if (tokens[0].compare("ITEM:") == 0) {
-        if (tokens[1].compare("TIMESTEP") == 0) {
-          // Now you are in a new timestep. Update frame number
-          currentFrame++;
-        }
-      }
-
-      // If targetFrame has been found
-      // break out of the while loop
-      if (currentFrame == targetFrame) {
-        foundFrame = true;
-        break; // Exit the while loop
-      }
-    } // End of while loop searching for targetFrame
-    // ----------------------------------------------------------
-    // Before filling up the PointCloud, if the vectors are filled
-    // empty them
-    yCloud = molSys::clearPointCloud(yCloud);
-
-    // ----------------------------------------------------------
-    // If targetFrame has been found, read in the box lengths,
-    // number of atoms and then read in atom positions, type, molID
-    // By default, set molID=1 if not specified
-    if (foundFrame) {
-      // Run this until EOF or you reach the next timestep
-      while (std::getline((*dumpFile), line)) {
-        // Read in lines and tokenize them into std::string words and <double>
-        // numbers
-        tokens = gen::tokenizer(line);
-        numbers = gen::tokenizerDouble(line);
-
-        // If you've reached the timestep line then you've reached the
-        // next frame. Break out of the while loop
-        if (tokens[0].compare("ITEM:") == 0) {
-          if (tokens[1].compare("TIMESTEP") == 0) {
-            break;
-          }
-        }
-
-        // -*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
-        // Read number of particles
-        if (readNOP) {
-          nop = std::stoi(line.data());
-          readNOP = false;
-          yCloud.pts.reserve(nop);
-          yCloud.nop = nop;
-        }
-        // Read box lengths
-        if (readBox) {
-          // You've reached the end of box lengths
-          if (tokens[0].compare("ITEM:") == 0) {
-            readBox = false;
-            // If the box is triclinic, get the
-            // orthogonal 'bounding box'
-            if (isTriclinic) {
-              // Update tilt factors
-              for (int k = 0; k < tilt.size(); k++) {
-                yCloud.box.push_back(tilt[k]);
-              }
-            } // end of check for triclinic
-          }
-          // Or else fill up the box lengths
-          else {
-            yCloud.box.push_back(numbers[1] - numbers[0]); // Update box length
-            yCloud.boxLow.push_back(
-                numbers[0]); // Update the lower box coordinate
-            // Do this for a triclinic box only
-            if (numbers.size() == 3) {
-              isTriclinic = true;
-              tilt.push_back(numbers[2]);
-            }
-          }
-        }
-        // Read atoms into yCloud line by line
-        if (readAtoms) {
-          iPoint.type = numbers[typeIndex];
-          iPoint.molID = numbers[molIndex];
-          iPoint.atomID = numbers[atomIndex];
-          iPoint.x = numbers[xIndex];
-          iPoint.y = numbers[yIndex];
-          iPoint.z = numbers[zIndex];
-          // Check if the particle is inside the volume Slice
-          // or not
-          if (isSlice) { // only if a slice has been requested
-            iPoint.inSlice = sinp::atomInSlice(iPoint.x, iPoint.y, iPoint.z,
-                                               coordLow, coordHigh);
-          }
-          yCloud.pts.push_back(iPoint);
-          mapAtomIdToIndex(yCloud);
-        }
-        // -*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
-
-        // Tests for reading in nop, box lengths, and atoms
-        if (tokens[0].compare("ITEM:") == 0) {
-          if (tokens[1].compare("NUMBER") == 0) {
-            readNOP = true;
-          }
-        }
-        if (tokens[0].compare("ITEM:") == 0) {
-          if (tokens[1].compare("BOX") == 0) {
-            readBox = true;
-          }
-        }
-        if (tokens[0].compare("ITEM:") == 0) {
-          if (tokens[1].compare("ATOMS") == 0) {
-            readAtoms = true;
-            // Now find out which index is the coordinate index etc
-            for (int i = 2; i < tokens.size(); i++) {
-              if (tokens[i].compare("type") == 0) {
-                typeIndex = i - 2;
-              }
-              if (tokens[i].compare("x") == 0) {
-                xIndex = i - 2;
-              }
-              if (tokens[i].compare("y") == 0) {
-                yIndex = i - 2;
-              }
-              if (tokens[i].compare("z") == 0) {
-                zIndex = i - 2;
-              }
-              if (tokens[i].compare("mol") == 0) {
-                molIndex = i - 2;
-              }
-              if (tokens[i].compare("id") == 0) {
-                atomIndex = i - 2;
-              }
-            } // End of for loop over tokens
-            if (molIndex == 0) {
-              molIndex = atomIndex;
-            } // Set mol ID=atomID if not given
-          }
-        } // End of nested if loops for checking atom
-
-      } // End of while
-    }   // End of targetFrame found
-    // ----------------------------------------------------------
-  } // End of if file open statement
-
-  // Check if you filled in the frame correctly
-  if (!(foundFrame)) {
-    std::cout << "You entered a frame that doesn't exist.\n";
-  } // Throw exception
-  if (foundFrame) {
-    if (yCloud.pts.size() != yCloud.nop) {
-      std::cout << "Atoms didn't get filled in properly.\n";
-    }
-  } // Throw exception
-  yCloud.currentFrame = targetFrame;
-
-  dumpFile->close();
+  loadLammpsFrame(filename, targetFrame, yCloud, -1, LammpsKeep::All, isSlice,
+                  coordLow, coordHigh);
   return yCloud;
 }
 
@@ -430,209 +572,8 @@ sinp::readLammpsTrjO(std::string filename, int targetFrame,
                      molSys::PointCloud<molSys::Point<double>, double> &yCloud,
                      int typeO, bool isSlice, std::array<double, 3> coordLow,
                      std::array<double, 3> coordHigh) {
-  std::unique_ptr<std::ifstream> dumpFile;
-  dumpFile = std::make_unique<std::ifstream>(filename);
-  std::string line;                // Current line being read in
-  std::vector<std::string> tokens; // Vector containing word tokens
-  std::vector<double> numbers;     // Vector containing type double numbers
-  std::vector<double> tilt;        // Vector containing tilt factors
-  int currentFrame = 0;            // Current frame being read in
-  int nop = -1;                    // Number of atoms in targetFrame
-  bool foundFrame =
-      false;            // Determines whether targetFrame has been found or not
-  bool readNOP = false; // Flag for reading in the number of atoms
-  bool readBox = false; // Flag for reading in the box lengths
-  bool readAtoms = false; // Flag for reading in the atoms
-  int xIndex, yIndex, zIndex,
-      typeIndex;     // Indices for x,y,z coordinates, and LAMMPS type ID
-  int molIndex = 0;  // Index for molecular ID
-  int atomIndex = 0; // Index for atom ID (Only used if mol ID has not been set)
-  molSys::Point<double> iPoint; // Current point being read in from the file
-  xIndex = yIndex = zIndex = typeIndex = -1; // Default values
-  bool isTriclinic = false; // Flag for an orthogonal or triclinic box
-  int nOxy = 0;             // Number of oxygen atoms
-
-  if (!(gen::file_exists(filename))) {
-    std::cout
-        << "Fatal Error: The file does not exist or you gave the wrong path.\n";
-    // Throw exception?
-    return yCloud;
-  }
-
-  // The format of the LAMMPS trajectory file is:
-  // ITEM: TIMESTEP
-  // 0
-  // ITEM: NUMBER OF ATOMS
-  // 4096
-  // ITEM: BOX BOUNDS pp pp pp
-  // -7.9599900000000001e-01 5.0164000000000001e+01
-  // -7.9599900000000001e-01 5.0164000000000001e+01
-  // -7.9599900000000001e-01 5.0164000000000001e+01
-  // ITEM: ATOMS id type x y z
-  // 1 1 0 0 0 etc
-  if (dumpFile->is_open()) {
-    // ----------------------------------------------------------
-    // At this point we know that the dumpfile is open
-    // This loop searches for targetFrame
-    while (std::getline((*dumpFile), line)) {
-      // Read in lines and tokenize them
-      tokens = gen::tokenizer(line);
-      // Find out which timestep number
-      // you are inside
-      if (tokens[0].compare("ITEM:") == 0) {
-        if (tokens[1].compare("TIMESTEP") == 0) {
-          // Now you are in a new timestep. Update frame number
-          currentFrame++;
-        }
-      }
-
-      // If targetFrame has been found
-      // break out of the while loop
-      if (currentFrame == targetFrame) {
-        foundFrame = true;
-        break; // Exit the while loop
-      }
-    } // End of while loop searching for targetFrame
-    // ----------------------------------------------------------
-    // Before filling up the PointCloud, if the vectors are filled
-    // empty them
-    yCloud = molSys::clearPointCloud(yCloud);
-
-    // ----------------------------------------------------------
-    // If targetFrame has been found, read in the box lengths,
-    // number of atoms and then read in atom positions, type, molID
-    // By default, set molID=1 if not specified
-    if (foundFrame) {
-      // Run this until EOF or you reach the next timestep
-      while (std::getline((*dumpFile), line)) {
-        // Read in lines and tokenize them into std::string words and <double>
-        // numbers
-        tokens = gen::tokenizer(line);
-        numbers = gen::tokenizerDouble(line);
-
-        // If you've reached the timestep line then you've reached the
-        // next frame. Break out of the while loop
-        if (tokens[0].compare("ITEM:") == 0) {
-          if (tokens[1].compare("TIMESTEP") == 0) {
-            break;
-          }
-        }
-
-        // -*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
-        // Read number of particles
-        if (readNOP) {
-          nop = std::stoi(line.data());
-          readNOP = false;
-        }
-        // Read box lengths
-        if (readBox) {
-          // You've reached the end of box lengths
-          if (tokens[0].compare("ITEM:") == 0) {
-            readBox = false;
-            // If the box is triclinic, get the
-            // orthogonal 'bounding box'
-            if (isTriclinic) {
-              // Update tilt factors
-              for (int k = 0; k < tilt.size(); k++) {
-                yCloud.box.push_back(tilt[k]);
-              }
-            } // end of check for triclinic
-          }
-          // Or else fill up the box lengths
-          else {
-            yCloud.box.push_back(numbers[1] - numbers[0]); // Update box length
-            yCloud.boxLow.push_back(
-                numbers[0]); // Update the lower box coordinate
-            // Do this for a triclinic box only
-            if (numbers.size() == 3) {
-              isTriclinic = true;
-              tilt.push_back(numbers[2]);
-            }
-          }
-        }
-        // Read atoms into yCloud line by line
-        if (readAtoms) {
-          iPoint.type = numbers[typeIndex];
-          iPoint.molID = numbers[molIndex];
-          iPoint.atomID = numbers[atomIndex];
-          iPoint.x = numbers[xIndex];
-          iPoint.y = numbers[yIndex];
-          iPoint.z = numbers[zIndex];
-          // Check if the particle is inside the volume Slice
-          // or not
-          if (isSlice) { // only if a slice has been requested
-            iPoint.inSlice = sinp::atomInSlice(iPoint.x, iPoint.y, iPoint.z,
-                                               coordLow, coordHigh);
-          }
-          // Save only oxygen atoms
-          if (iPoint.type == typeO) {
-            nOxy++;
-            // yCloud.pts.resize(yCloud.pts.size()+1);
-            yCloud.pts.push_back(iPoint);
-            mapAtomIdToIndex(yCloud);
-          }
-        }
-        // -*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
-
-        // Tests for reading in nop, box lengths, and atoms
-        if (tokens[0].compare("ITEM:") == 0) {
-          if (tokens[1].compare("NUMBER") == 0) {
-            readNOP = true;
-          }
-        }
-        if (tokens[0].compare("ITEM:") == 0) {
-          if (tokens[1].compare("BOX") == 0) {
-            readBox = true;
-          }
-        }
-        if (tokens[0].compare("ITEM:") == 0) {
-          if (tokens[1].compare("ATOMS") == 0) {
-            readAtoms = true;
-            // Now find out which index is the coordinate index etc
-            for (int i = 2; i < tokens.size(); i++) {
-              if (tokens[i].compare("type") == 0) {
-                typeIndex = i - 2;
-              }
-              if (tokens[i].compare("x") == 0) {
-                xIndex = i - 2;
-              }
-              if (tokens[i].compare("y") == 0) {
-                yIndex = i - 2;
-              }
-              if (tokens[i].compare("z") == 0) {
-                zIndex = i - 2;
-              }
-              if (tokens[i].compare("mol") == 0) {
-                molIndex = i - 2;
-              }
-              if (tokens[i].compare("id") == 0) {
-                atomIndex = i - 2;
-              }
-            } // End of for loop over tokens
-            if (molIndex == 0) {
-              molIndex = atomIndex;
-            } // Set mol ID=atomID if not given
-          }
-        } // End of nested if loops for checking atom
-
-      } // End of while
-    }   // End of targetFrame found
-    // ----------------------------------------------------------
-  } // End of if file open statement
-
-  // Check if you filled in the frame correctly
-  if (!(foundFrame)) {
-    std::cout << "You entered a frame that doesn't exist.\n";
-  } // Throw exception
-  if (foundFrame) {
-    yCloud.nop = yCloud.pts.size();
-    if (yCloud.pts.size() != nOxy) {
-      std::cout << "Atoms didn't get filled in properly.\n";
-    }
-  } // Throw exception
-  yCloud.currentFrame = targetFrame;
-
-  dumpFile->close();
+  loadLammpsFrame(filename, targetFrame, yCloud, typeO, LammpsKeep::Type,
+                  isSlice, coordLow, coordHigh);
   return yCloud;
 }
 
@@ -656,212 +597,8 @@ molSys::PointCloud<molSys::Point<double>, double> sinp::readLammpsTrjreduced(
     molSys::PointCloud<molSys::Point<double>, double> &yCloud, int typeI,
     bool isSlice, std::array<double, 3> coordLow,
     std::array<double, 3> coordHigh) {
-  std::unique_ptr<std::ifstream> dumpFile;
-  dumpFile = std::make_unique<std::ifstream>(filename);
-  std::string line;                // Current line being read in
-  std::vector<std::string> tokens; // Vector containing word tokens
-  std::vector<double> numbers;     // Vector containing type double numbers
-  std::vector<double> tilt;        // Vector containing tilt factors
-  int currentFrame = 0;            // Current frame being read in
-  int nop = -1;                    // Number of atoms in targetFrame
-  bool foundFrame =
-      false;            // Determines whether targetFrame has been found or not
-  bool readNOP = false; // Flag for reading in the number of atoms
-  bool readBox = false; // Flag for reading in the box lengths
-  bool readAtoms = false; // Flag for reading in the atoms
-  int xIndex, yIndex, zIndex,
-      typeIndex;     // Indices for x,y,z coordinates, and LAMMPS type ID
-  int molIndex = 0;  // Index for molecular ID
-  int atomIndex = 0; // Index for atom ID (Only used if mol ID has not been set)
-  molSys::Point<double> iPoint; // Current point being read in from the file
-  xIndex = yIndex = zIndex = typeIndex = -1; // Default values
-  bool isTriclinic = false; // Flag for an orthogonal or triclinic box
-  int nOxy = 0;             // Number of oxygen atoms
-
-  if (!(gen::file_exists(filename))) {
-    std::cout
-        << "Fatal Error: The file does not exist or you gave the wrong path.\n";
-    // Throw exception?
-    return yCloud;
-  }
-
-  // The format of the LAMMPS trajectory file is:
-  // ITEM: TIMESTEP
-  // 0
-  // ITEM: NUMBER OF ATOMS
-  // 4096
-  // ITEM: BOX BOUNDS pp pp pp
-  // -7.9599900000000001e-01 5.0164000000000001e+01
-  // -7.9599900000000001e-01 5.0164000000000001e+01
-  // -7.9599900000000001e-01 5.0164000000000001e+01
-  // ITEM: ATOMS id type x y z
-  // 1 1 0 0 0 etc
-  if (dumpFile->is_open()) {
-    // ----------------------------------------------------------
-    // At this point we know that the dumpfile is open
-    // This loop searches for targetFrame
-    while (std::getline((*dumpFile), line)) {
-      // Read in lines and tokenize them
-      tokens = gen::tokenizer(line);
-      // Find out which timestep number
-      // you are inside
-      if (tokens[0].compare("ITEM:") == 0) {
-        if (tokens[1].compare("TIMESTEP") == 0) {
-          // Now you are in a new timestep. Update frame number
-          currentFrame++;
-        }
-      }
-
-      // If targetFrame has been found
-      // break out of the while loop
-      if (currentFrame == targetFrame) {
-        foundFrame = true;
-        break; // Exit the while loop
-      }
-    } // End of while loop searching for targetFrame
-    // ----------------------------------------------------------
-    // Before filling up the PointCloud, if the vectors are filled
-    // empty them
-    yCloud = molSys::clearPointCloud(yCloud);
-
-    // ----------------------------------------------------------
-    // If targetFrame has been found, read in the box lengths,
-    // number of atoms and then read in atom positions, type, molID
-    // By default, set molID=1 if not specified
-    if (foundFrame) {
-      // Run this until EOF or you reach the next timestep
-      while (std::getline((*dumpFile), line)) {
-        // Read in lines and tokenize them into std::string words and <double>
-        // numbers
-        tokens = gen::tokenizer(line);
-        numbers = gen::tokenizerDouble(line);
-
-        // If you've reached the timestep line then you've reached the
-        // next frame. Break out of the while loop
-        if (tokens[0].compare("ITEM:") == 0) {
-          if (tokens[1].compare("TIMESTEP") == 0) {
-            break;
-          }
-        }
-
-        // -*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
-        // Read number of particles
-        if (readNOP) {
-          nop = std::stoi(line.data());
-          readNOP = false;
-        }
-        // Read box lengths
-        if (readBox) {
-          // You've reached the end of box lengths
-          if (tokens[0].compare("ITEM:") == 0) {
-            readBox = false;
-            // If the box is triclinic, get the
-            // orthogonal 'bounding box'
-            if (isTriclinic) {
-              // Update tilt factors
-              for (int k = 0; k < tilt.size(); k++) {
-                yCloud.box.push_back(tilt[k]);
-              }
-            } // end of check for triclinic
-          }
-          // Or else fill up the box lengths
-          else {
-            yCloud.box.push_back(numbers[1] - numbers[0]); // Update box length
-            yCloud.boxLow.push_back(
-                numbers[0]); // Update the lower box coordinate
-            // Do this for a triclinic box only
-            if (numbers.size() == 3) {
-              isTriclinic = true;
-              tilt.push_back(numbers[2]);
-            }
-          }
-        }
-        // Read atoms into yCloud line by line
-        if (readAtoms) {
-          iPoint.type = numbers[typeIndex];
-          iPoint.molID = numbers[molIndex];
-          iPoint.atomID = numbers[atomIndex];
-          iPoint.x = numbers[xIndex];
-          iPoint.y = numbers[yIndex];
-          iPoint.z = numbers[zIndex];
-          // Check if the particle is inside the volume Slice
-          // or not
-          if (isSlice) { // only if a slice has been requested
-            iPoint.inSlice = sinp::atomInSlice(iPoint.x, iPoint.y, iPoint.z,
-                                               coordLow, coordHigh);
-            // Skip if the atom is not part of the slice
-            if (!iPoint.inSlice) {
-              continue;
-            } // do not save if not inside the slice
-          }
-          // Save only atoms of the desired type
-          if (iPoint.type == typeI) {
-            nOxy++;
-            // yCloud.pts.resize(yCloud.pts.size()+1);
-            yCloud.pts.push_back(iPoint);
-            mapAtomIdToIndex(yCloud);
-          }
-        }
-        // -*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*-*
-
-        // Tests for reading in nop, box lengths, and atoms
-        if (tokens[0].compare("ITEM:") == 0) {
-          if (tokens[1].compare("NUMBER") == 0) {
-            readNOP = true;
-          }
-        }
-        if (tokens[0].compare("ITEM:") == 0) {
-          if (tokens[1].compare("BOX") == 0) {
-            readBox = true;
-          }
-        }
-        if (tokens[0].compare("ITEM:") == 0) {
-          if (tokens[1].compare("ATOMS") == 0) {
-            readAtoms = true;
-            // Now find out which index is the coordinate index etc
-            for (int i = 2; i < tokens.size(); i++) {
-              if (tokens[i].compare("type") == 0) {
-                typeIndex = i - 2;
-              }
-              if (tokens[i].compare("x") == 0) {
-                xIndex = i - 2;
-              }
-              if (tokens[i].compare("y") == 0) {
-                yIndex = i - 2;
-              }
-              if (tokens[i].compare("z") == 0) {
-                zIndex = i - 2;
-              }
-              if (tokens[i].compare("mol") == 0) {
-                molIndex = i - 2;
-              }
-              if (tokens[i].compare("id") == 0) {
-                atomIndex = i - 2;
-              }
-            } // End of for loop over tokens
-            if (molIndex == 0) {
-              molIndex = atomIndex;
-            } // Set mol ID=atomID if not given
-          }
-        } // End of nested if loops for checking atom
-
-      } // End of while
-    }   // End of targetFrame found
-    // ----------------------------------------------------------
-  } // End of if file open statement
-
-  // Check if you filled in the frame correctly
-  if (!(foundFrame)) {
-    std::cout << "You entered a frame that doesn't exist.\n";
-  } // Throw exception
-
-  // Update the number of particles
-  yCloud.nop = yCloud.pts.size();
-
-  // Update the frame number
-  yCloud.currentFrame = targetFrame;
-
-  dumpFile->close();
+  loadLammpsFrame(filename, targetFrame, yCloud, typeI,
+                  LammpsKeep::TypeInSlice, isSlice, coordLow, coordHigh);
   return yCloud;
 }
 

--- a/src/seams_input.cpp
+++ b/src/seams_input.cpp
@@ -22,6 +22,10 @@
 #include <seams_input.hpp>
 #include <unordered_map>
 
+#ifdef SEAMS_HAS_OPENMP
+#include <omp.h>
+#endif
+
 namespace {
 /**
  * @details Record the ID-to-index entry for the most recently appended point.
@@ -152,6 +156,18 @@ struct LammpsDumpSession {
     }
     return static_cast<int>(offsets.size());
   }
+
+  bool ensureIndexed(int frame) {
+    if (frame < 1) {
+      return false;
+    }
+    while (static_cast<int>(offsets.size()) < frame) {
+      if (!discoverNext()) {
+        return false;
+      }
+    }
+    return true;
+  }
 };
 
 std::mutex gDumpMu;
@@ -206,6 +222,41 @@ int sinp::nLammpsFrames(const std::string &filename) {
 void sinp::dropLammpsDumpIndex(const std::string &filename) {
   std::lock_guard<std::mutex> lock(gDumpMu);
   gDumps.erase(filename);
+}
+
+void sinp::forEachLammpsFrame(
+    const std::string &filename, int first, int last, int typeFilter,
+    const std::function<void(
+        int, molSys::PointCloud<molSys::Point<double>, double> &)> &fn,
+    int nThreads) {
+  const int nframes = nLammpsFrames(filename);
+  if (nframes <= 0) {
+    return;
+  }
+  if (first < 1) {
+    first = 1;
+  }
+  if (last <= 0 || last > nframes) {
+    last = nframes;
+  }
+  if (first > last) {
+    return;
+  }
+
+#ifdef SEAMS_HAS_OPENMP
+  const int threads = nThreads > 0 ? nThreads : omp_get_max_threads();
+#pragma omp parallel for schedule(dynamic, 1) num_threads(threads)             \
+    if (threads > 1 && last > first)
+#endif
+  for (int frame = first; frame <= last; ++frame) {
+    molSys::PointCloud<molSys::Point<double>, double> cloud;
+    if (typeFilter > 0) {
+      cloud = readLammpsTrjO(filename, frame, cloud, typeFilter);
+    } else {
+      cloud = readLammpsTrj(filename, frame, cloud);
+    }
+    fn(frame, cloud);
+  }
 }
 
 /**
@@ -501,6 +552,28 @@ void parseLammpsFrameBody(
   }
 }
 
+bool openCloneAt(const std::string &filename, int frame, std::ifstream &in) {
+  auto sess = sessionFor(filename);
+  if (sess == nullptr) {
+    return false;
+  }
+  std::uint64_t off = 0;
+  {
+    std::lock_guard<std::mutex> lock(sess->mu);
+    if (!sess->ensureIndexed(frame)) {
+      return false;
+    }
+    off = sess->offsets[static_cast<std::size_t>(frame - 1)];
+  }
+  in.open(filename, std::ios::in | std::ios::binary);
+  if (!in.is_open()) {
+    return false;
+  }
+  in.seekg(static_cast<std::streamoff>(off));
+  std::string line;
+  return static_cast<bool>(std::getline(in, line)) && isLammpsTimestep(line);
+}
+
 void loadLammpsFrame(
     const std::string &filename, int targetFrame,
     molSys::PointCloud<molSys::Point<double>, double> &yCloud, int typeFilter,
@@ -520,13 +593,25 @@ void loadLammpsFrame(
     yCloud.currentFrame = targetFrame;
     return;
   }
-  std::lock_guard<std::mutex> lock(sess->mu);
-  if (!sess->positionAt(targetFrame)) {
+  std::unique_lock<std::mutex> lock(sess->mu, std::try_to_lock);
+  if (lock.owns_lock()) {
+    if (!sess->positionAt(targetFrame)) {
+      std::cout << "You entered a frame that doesn't exist.\n";
+      yCloud.currentFrame = targetFrame;
+      return;
+    }
+    parseLammpsFrameBody(sess->file, yCloud, typeFilter, keep, isSlice,
+                         coordLow, coordHigh);
+    yCloud.currentFrame = targetFrame;
+    return;
+  }
+  std::ifstream clone;
+  if (!openCloneAt(filename, targetFrame, clone)) {
     std::cout << "You entered a frame that doesn't exist.\n";
     yCloud.currentFrame = targetFrame;
     return;
   }
-  parseLammpsFrameBody(sess->file, yCloud, typeFilter, keep, isSlice, coordLow,
+  parseLammpsFrameBody(clone, yCloud, typeFilter, keep, isSlice, coordLow,
                        coordHigh);
   yCloud.currentFrame = targetFrame;
 }

--- a/tests/bench_lammps_io.cpp
+++ b/tests/bench_lammps_io.cpp
@@ -1,0 +1,76 @@
+/*
+** This file is part of d-SEAMS.
+**
+** SPDX-License-Identifier: MIT
+**
+** Time LAMMPS dump I/O only: nLammpsFrames, a sequential load_frame
+** walk, and a last-frame seek. Usage:
+**   bench_lammps_io TRAJ [frames] [atomType]
+** frames <= 0 means every ITEM: TIMESTEP. atomType <= 0 reads every atom.
+*/
+
+#include <seams_input.hpp>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+namespace {
+using Clock = std::chrono::steady_clock;
+
+double ms(Clock::time_point a, Clock::time_point b) {
+  return std::chrono::duration<double, std::milli>(b - a).count();
+}
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::fprintf(stderr, "usage: bench_lammps_io TRAJ [frames] [atomType]\n");
+    return 2;
+  }
+  const std::string traj = argv[1];
+  const int want = argc > 2 ? std::atoi(argv[2]) : 0;
+  const int atomType = argc > 3 ? std::atoi(argv[3]) : 0;
+
+  sinp::dropLammpsDumpIndex(traj);
+
+  const auto t0 = Clock::now();
+  const int nframes = sinp::nLammpsFrames(traj);
+  const auto t1 = Clock::now();
+  if (nframes <= 0) {
+    std::fprintf(stderr, "no frames in %s\n", traj.c_str());
+    return 1;
+  }
+  const int frames = (want > 0 && want < nframes) ? want : nframes;
+
+  molSys::PointCloud<molSys::Point<double>, double> cloud;
+  int nop = 0;
+  const auto t2 = Clock::now();
+  for (int frame = 1; frame <= frames; frame++) {
+    if (atomType > 0) {
+      cloud = sinp::readLammpsTrjO(traj, frame, cloud, atomType);
+    } else {
+      cloud = sinp::readLammpsTrj(traj, frame, cloud);
+    }
+    if (cloud.nop == 0) {
+      std::fprintf(stderr, "empty frame %d of %s\n", frame, traj.c_str());
+      return 1;
+    }
+    nop = cloud.nop;
+  }
+  const auto t3 = Clock::now();
+
+  if (atomType > 0) {
+    cloud = sinp::readLammpsTrjO(traj, frames, cloud, atomType);
+  } else {
+    cloud = sinp::readLammpsTrj(traj, frames, cloud);
+  }
+  const auto t4 = Clock::now();
+
+  std::printf("# nframes counted walk_frames nop index_ms walk_ms "
+              "walk_ms_per_frame last_seek_ms\n");
+  std::printf("%d %d %d %.3f %.3f %.3f %.3f\n", nframes, frames, nop,
+              ms(t0, t1), ms(t2, t3), ms(t2, t3) / frames, ms(t3, t4));
+  return 0;
+}

--- a/tests/bench_lammps_io.cpp
+++ b/tests/bench_lammps_io.cpp
@@ -5,12 +5,14 @@
 **
 ** Time LAMMPS dump I/O only: nLammpsFrames, a sequential load_frame
 ** walk, and a last-frame seek. Usage:
-**   bench_lammps_io TRAJ [frames] [atomType]
+**   bench_lammps_io TRAJ [frames] [atomType] [threads]
 ** frames <= 0 means every ITEM: TIMESTEP. atomType <= 0 reads every atom.
+** threads > 1 walks with forEachLammpsFrame (one handle per worker).
 */
 
 #include <seams_input.hpp>
 
+#include <atomic>
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
@@ -26,12 +28,14 @@ double ms(Clock::time_point a, Clock::time_point b) {
 
 int main(int argc, char **argv) {
   if (argc < 2) {
-    std::fprintf(stderr, "usage: bench_lammps_io TRAJ [frames] [atomType]\n");
+    std::fprintf(stderr,
+                 "usage: bench_lammps_io TRAJ [frames] [atomType] [threads]\n");
     return 2;
   }
   const std::string traj = argv[1];
   const int want = argc > 2 ? std::atoi(argv[2]) : 0;
   const int atomType = argc > 3 ? std::atoi(argv[3]) : 0;
+  const int threads = argc > 4 ? std::atoi(argv[4]) : 1;
 
   sinp::dropLammpsDumpIndex(traj);
 
@@ -45,21 +49,39 @@ int main(int argc, char **argv) {
   const int frames = (want > 0 && want < nframes) ? want : nframes;
 
   molSys::PointCloud<molSys::Point<double>, double> cloud;
-  int nop = 0;
+  std::atomic<int> nop{0};
+  std::atomic<int> empty{0};
   const auto t2 = Clock::now();
-  for (int frame = 1; frame <= frames; frame++) {
-    if (atomType > 0) {
-      cloud = sinp::readLammpsTrjO(traj, frame, cloud, atomType);
-    } else {
-      cloud = sinp::readLammpsTrj(traj, frame, cloud);
+  if (threads > 1) {
+    sinp::forEachLammpsFrame(
+        traj, 1, frames, atomType,
+        [&](int, molSys::PointCloud<molSys::Point<double>, double> &c) {
+          if (c.nop == 0) {
+            empty.fetch_add(1);
+          } else {
+            nop.store(c.nop);
+          }
+        },
+        threads);
+  } else {
+    for (int frame = 1; frame <= frames; frame++) {
+      if (atomType > 0) {
+        cloud = sinp::readLammpsTrjO(traj, frame, cloud, atomType);
+      } else {
+        cloud = sinp::readLammpsTrj(traj, frame, cloud);
+      }
+      if (cloud.nop == 0) {
+        std::fprintf(stderr, "empty frame %d of %s\n", frame, traj.c_str());
+        return 1;
+      }
+      nop.store(cloud.nop);
     }
-    if (cloud.nop == 0) {
-      std::fprintf(stderr, "empty frame %d of %s\n", frame, traj.c_str());
-      return 1;
-    }
-    nop = cloud.nop;
   }
   const auto t3 = Clock::now();
+  if (empty.load() > 0) {
+    std::fprintf(stderr, "empty frames in %s\n", traj.c_str());
+    return 1;
+  }
 
   if (atomType > 0) {
     cloud = sinp::readLammpsTrjO(traj, frames, cloud, atomType);
@@ -68,9 +90,10 @@ int main(int argc, char **argv) {
   }
   const auto t4 = Clock::now();
 
-  std::printf("# nframes counted walk_frames nop index_ms walk_ms "
+  std::printf("# nframes counted walk_frames nop threads index_ms walk_ms "
               "walk_ms_per_frame last_seek_ms\n");
-  std::printf("%d %d %d %.3f %.3f %.3f %.3f\n", nframes, frames, nop,
-              ms(t0, t1), ms(t2, t3), ms(t2, t3) / frames, ms(t3, t4));
+  std::printf("%d %d %d %d %.3f %.3f %.3f %.3f\n", nframes, frames, nop.load(),
+              threads, ms(t0, t1), ms(t2, t3), ms(t2, t3) / frames,
+              ms(t3, t4));
   return 0;
 }

--- a/tests/bench_lammps_walk.cpp
+++ b/tests/bench_lammps_walk.cpp
@@ -1,0 +1,92 @@
+/*
+** This file is part of d-SEAMS.
+**
+** SPDX-License-Identifier: MIT
+**
+** Time a chunked frame-parallel walk: read + neighbours + ringNetwork
+** + cageAffiliation per frame. Incremental updaters are not used;
+** each chunk is independent. Usage:
+**   bench_lammps_walk TRAJ [frames] [atomType] [threads]
+*/
+
+#include <cage_affiliation.hpp>
+#include <franzblau.hpp>
+#include <neighbours.hpp>
+#include <seams_input.hpp>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace {
+using Clock = std::chrono::steady_clock;
+
+double ms(Clock::time_point a, Clock::time_point b) {
+  return std::chrono::duration<double, std::milli>(b - a).count();
+}
+
+int classifyFrame(molSys::PointCloud<molSys::Point<double>, double> &cloud,
+                  int atomType) {
+  auto nList = nneigh::neighListO(3.5, cloud, atomType);
+  auto idx = nneigh::neighbourListByIndex(cloud, nList);
+  auto rings = primitive::ringNetwork(idx, 6);
+  std::vector<std::vector<int>> six;
+  for (const auto &r : rings) {
+    if (r.size() == 6) {
+      six.push_back(r);
+    }
+  }
+  const auto aff = ring::cageAffiliation(six, idx);
+  int ddc = 0;
+  for (const bool flag : aff.ddc) {
+    ddc += flag ? 1 : 0;
+  }
+  return ddc;
+}
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::fprintf(stderr,
+                 "usage: bench_lammps_walk TRAJ [frames] [atomType] [threads]\n");
+    return 2;
+  }
+  const std::string traj = argv[1];
+  const int want = argc > 2 ? std::atoi(argv[2]) : 0;
+  const int atomType = argc > 3 ? std::atoi(argv[3]) : 1;
+  const int threads = argc > 4 ? std::atoi(argv[4]) : 1;
+
+  const int nframes = sinp::nLammpsFrames(traj);
+  if (nframes <= 0) {
+    std::fprintf(stderr, "no frames in %s\n", traj.c_str());
+    return 1;
+  }
+  const int frames = (want > 0 && want < nframes) ? want : nframes;
+  std::atomic<int> lastDdc{0};
+  std::atomic<int> empty{0};
+
+  const auto t0 = Clock::now();
+  sinp::forEachLammpsFrame(
+      traj, 1, frames, atomType,
+      [&](int, molSys::PointCloud<molSys::Point<double>, double> &cloud) {
+        if (cloud.nop == 0) {
+          empty.fetch_add(1);
+          return;
+        }
+        lastDdc.store(classifyFrame(cloud, atomType));
+      },
+      threads);
+  const auto t1 = Clock::now();
+  if (empty.load() > 0) {
+    std::fprintf(stderr, "empty frames in %s\n", traj.c_str());
+    return 1;
+  }
+
+  std::printf("# frames nop threads wall_ms ms_per_frame last_ddc_rings\n");
+  std::printf("%d %d %d %.3f %.3f %d\n", frames, atomType == 0 ? 0 : 1,
+              threads, ms(t0, t1), ms(t0, t1) / frames, lastDdc.load());
+  return 0;
+}

--- a/tests/bench_trajectory_incremental.cpp
+++ b/tests/bench_trajectory_incremental.cpp
@@ -59,7 +59,8 @@ int main(int argc, char **argv) {
 
   primitive::RingUpdater ringUpd(maxDepth);
   ring::AffiliationUpdater affilUpd;
-  nneigh::SkinNeighborList skin(3.5, 2.0, atomType);
+  const double skinWidth = argc > 5 ? std::atof(argv[5]) : 2.0;
+  nneigh::SkinNeighborList skin(3.5, skinWidth, atomType);
 
   double ringFullSum = 0.0, ringIncSum = 0.0;
   double affilBatchSum = 0.0, affilIncSum = 0.0;

--- a/tests/bench_trajectory_incremental.cpp
+++ b/tests/bench_trajectory_incremental.cpp
@@ -10,7 +10,9 @@
 ** summary, machine-parsable for the reproducibility workflow.
 **
 ** Run from the input/ directory:
-**   bench_trajectory_incremental [trajectory] [frames] [atomType] [maxDepth]
+**   bench_trajectory_incremental TRAJ [frames] [atomType] [maxDepth]
+**                                 [skin] [graph]
+** graph is cutoff | knn | knn-union (default knn).
 */
 
 #include <cage_affiliation.hpp>
@@ -23,6 +25,7 @@
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
+#include <exception>
 #include <set>
 #include <string>
 #include <vector>
@@ -60,16 +63,26 @@ int main(int argc, char **argv) {
   primitive::RingUpdater ringUpd(maxDepth);
   ring::AffiliationUpdater affilUpd;
   const double skinWidth = argc > 5 ? std::atof(argv[5]) : 2.0;
-  nneigh::SkinNeighborList skin(3.5, skinWidth, atomType);
+  const std::string graphName = argc > 6 ? argv[6] : "knn";
+  nneigh::BondGraph graph;
+  try {
+    graph = nneigh::bondGraphFromName(graphName);
+  } catch (const std::exception &e) {
+    std::fprintf(stderr, "%s\n", e.what());
+    return 2;
+  }
+  nneigh::SkinNeighborList skin(3.5, skinWidth, atomType, graph);
 
   double ringFullSum = 0.0, ringIncSum = 0.0;
   double affilBatchSum = 0.0, affilIncSum = 0.0;
   int steadyFrames = 0;
   bool allEqual = true;
 
-  std::printf("# frame nAtoms nRings ringFull_ms ringInc_ms ringRecomp "
-              "affilBatch_ms affilInc_ms affilReclass skinRebuild "
-              "bondChurn ringsEqual affilEqual\n");
+  std::printf("# graph %s skin %.2f\n", nneigh::bondGraphName(graph),
+              skinWidth);
+  std::printf("# frame nAtoms nRings nSix nHC nDDC ringFull_ms ringInc_ms "
+              "ringRecomp affilBatch_ms affilInc_ms affilReclass "
+              "skinRebuild bondChurn ringsEqual affilEqual\n");
 
   for (int frame = 1; frame <= frames; frame++) {
     molSys::PointCloud<molSys::Point<double>, double> cloud;
@@ -104,13 +117,20 @@ int main(int argc, char **argv) {
     const bool affilEqual =
         batchAffil.hc == incAffil.hc && batchAffil.ddc == incAffil.ddc;
 
+    int nHC = 0;
+    int nDDC = 0;
+    for (std::size_t i = 0; i < batchAffil.hc.size(); i++) {
+      nHC += batchAffil.hc[i] ? 1 : 0;
+      nDDC += batchAffil.ddc[i] ? 1 : 0;
+    }
+
     allEqual = allEqual && ringsEqual && affilEqual;
-    std::printf("%d %d %zu %.3f %.3f %d %.3f %.3f %d %s %d %s %s\n", frame,
-                cloud.nop, full.size(), ms(t0, t1), ms(t1, t2),
-                ringUpd.lastRecomputedSources(), ms(t3, t4), ms(t4, t5),
-                affilUpd.lastReclassified(), skin.lastRebuilt() ? "R" : ".",
-                skin.lastChangedAtoms(), ringsEqual ? "yes" : "NO",
-                affilEqual ? "yes" : "NO");
+    std::printf("%d %d %zu %zu %d %d %.3f %.3f %d %.3f %.3f %d %s %d %s %s\n",
+                frame, cloud.nop, full.size(), six.size(), nHC, nDDC,
+                ms(t0, t1), ms(t1, t2), ringUpd.lastRecomputedSources(),
+                ms(t3, t4), ms(t4, t5), affilUpd.lastReclassified(),
+                skin.lastRebuilt() ? "R" : ".", skin.lastChangedAtoms(),
+                ringsEqual ? "yes" : "NO", affilEqual ? "yes" : "NO");
 
     if (frame > 1) {
       ringFullSum += ms(t0, t1);

--- a/tests/bench_trajectory_incremental.cpp
+++ b/tests/bench_trajectory_incremental.cpp
@@ -68,8 +68,8 @@ int main(int argc, char **argv) {
   bool allEqual = true;
 
   std::printf("# frame nAtoms nRings ringFull_ms ringInc_ms ringRecomp "
-              "affilBatch_ms affilInc_ms affilReclass ringsEqual "
-              "affilEqual\n");
+              "affilBatch_ms affilInc_ms affilReclass skinRebuild "
+              "bondChurn ringsEqual affilEqual\n");
 
   for (int frame = 1; frame <= frames; frame++) {
     molSys::PointCloud<molSys::Point<double>, double> cloud;
@@ -105,10 +105,11 @@ int main(int argc, char **argv) {
         batchAffil.hc == incAffil.hc && batchAffil.ddc == incAffil.ddc;
 
     allEqual = allEqual && ringsEqual && affilEqual;
-    std::printf("%d %d %zu %.3f %.3f %d %.3f %.3f %d %s %s\n", frame,
+    std::printf("%d %d %zu %.3f %.3f %d %.3f %.3f %d %s %d %s %s\n", frame,
                 cloud.nop, full.size(), ms(t0, t1), ms(t1, t2),
                 ringUpd.lastRecomputedSources(), ms(t3, t4), ms(t4, t5),
-                affilUpd.lastReclassified(), ringsEqual ? "yes" : "NO",
+                affilUpd.lastReclassified(), skin.lastRebuilt() ? "R" : ".",
+                skin.lastChangedAtoms(), ringsEqual ? "yes" : "NO",
                 affilEqual ? "yes" : "NO");
 
     if (frame > 1) {

--- a/tests/bench_trajectory_incremental.cpp
+++ b/tests/bench_trajectory_incremental.cpp
@@ -59,6 +59,7 @@ int main(int argc, char **argv) {
 
   primitive::RingUpdater ringUpd(maxDepth);
   ring::AffiliationUpdater affilUpd;
+  nneigh::SkinNeighborList skin(3.5, 2.0, atomType);
 
   double ringFullSum = 0.0, ringIncSum = 0.0;
   double affilBatchSum = 0.0, affilIncSum = 0.0;
@@ -77,7 +78,7 @@ int main(int argc, char **argv) {
                    traj.c_str());
       return 1;
     }
-    auto nList = nneigh::neighListO(3.5, cloud, atomType);
+    auto nList = skin.update(cloud);
     auto idx = nneigh::neighbourListByIndex(cloud, nList);
 
     const auto t0 = Clock::now();

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -142,6 +142,13 @@ executable('bench_lammps_io', 'bench_lammps_io.cpp',
   include_directories: _incdirs,
   build_rpath: '$ORIGIN/../src')
 
+executable('bench_lammps_walk', 'bench_lammps_walk.cpp',
+  dependencies: [yds_dep],
+  cpp_args: _args,
+  link_args: _test_link_args,
+  include_directories: _incdirs,
+  build_rpath: '$ORIGIN/../src')
+
 executable('bench_structure_desc', 'bench_structure_desc.cpp',
   dependencies: [yds_dep],
   cpp_args: _args,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -149,6 +149,13 @@ executable('bench_lammps_walk', 'bench_lammps_walk.cpp',
   include_directories: _incdirs,
   build_rpath: '$ORIGIN/../src')
 
+executable('report_ice_graphs', 'report_ice_graphs.cpp',
+  dependencies: [yds_dep],
+  cpp_args: _args,
+  link_args: _test_link_args,
+  include_directories: _incdirs,
+  build_rpath: '$ORIGIN/../src')
+
 executable('bench_structure_desc', 'bench_structure_desc.cpp',
   dependencies: [yds_dep],
   cpp_args: _args,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -135,6 +135,13 @@ executable('bench_trajectory_incremental', 'bench_trajectory_incremental.cpp',
   include_directories: _incdirs,
   build_rpath: '$ORIGIN/../src')
 
+executable('bench_lammps_io', 'bench_lammps_io.cpp',
+  dependencies: [yds_dep],
+  cpp_args: _args,
+  link_args: _test_link_args,
+  include_directories: _incdirs,
+  build_rpath: '$ORIGIN/../src')
+
 executable('bench_structure_desc', 'bench_structure_desc.cpp',
   dependencies: [yds_dep],
   cpp_args: _args,

--- a/tests/report_ice_graphs.cpp
+++ b/tests/report_ice_graphs.cpp
@@ -1,0 +1,133 @@
+/*
+** This file is part of d-SEAMS.
+**
+** SPDX-License-Identifier: MIT
+**
+** Report ice scores for every published bond graph on one frame.
+**   report_ice_graphs TRAJ [frame] [atomType]
+*/
+
+#include <cage_affiliation.hpp>
+#include <franzblau.hpp>
+#include <mol_sys.hpp>
+#include <neighbours.hpp>
+#include <seams_input.hpp>
+
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+namespace {
+
+std::vector<std::vector<int>>
+sixOf(const std::vector<std::vector<int>> &rings) {
+  std::vector<std::vector<int>> six;
+  for (const auto &r : rings) {
+    if (r.size() == 6) {
+      six.push_back(r);
+    }
+  }
+  return six;
+}
+
+void tallyRings(const char *name, const ring::CageAffiliation &aff, int nSix) {
+  int hc = 0;
+  int ddc = 0;
+  for (std::size_t i = 0; i < aff.hc.size(); i++) {
+    hc += aff.hc[i] ? 1 : 0;
+    ddc += aff.ddc[i] ? 1 : 0;
+  }
+  std::printf("rings  %-10s nSix %d hc %d ddc %d\n", name, nSix, hc, ddc);
+}
+
+void tallyAtoms(const char *name, const std::vector<bool> &hc,
+                const std::vector<bool> &ddc) {
+  int nHC = 0;
+  int nDDC = 0;
+  int nBoth = 0;
+  int nNone = 0;
+  const int n = static_cast<int>(hc.size());
+  for (int i = 0; i < n; i++) {
+    const bool h = hc[static_cast<std::size_t>(i)];
+    const bool d = ddc[static_cast<std::size_t>(i)];
+    if (h && d) {
+      ++nBoth;
+    } else if (h) {
+      ++nHC;
+    } else if (d) {
+      ++nDDC;
+    } else {
+      ++nNone;
+    }
+  }
+  std::printf("atoms  %-10s nop %d ih %d ic %d both %d water %d\n", name, n,
+              nHC, nDDC, nBoth, nNone);
+}
+
+void atomsFromRings(const std::vector<std::vector<int>> &six,
+                    const ring::CageAffiliation &aff, int nop,
+                    std::vector<bool> &hc, std::vector<bool> &ddc) {
+  hc.assign(static_cast<std::size_t>(nop), false);
+  ddc.assign(static_cast<std::size_t>(nop), false);
+  for (std::size_t r = 0; r < six.size(); r++) {
+    for (const int a : six[r]) {
+      if (a >= 0 && a < nop) {
+        hc[static_cast<std::size_t>(a)] =
+            hc[static_cast<std::size_t>(a)] || aff.hc[r];
+        ddc[static_cast<std::size_t>(a)] =
+            ddc[static_cast<std::size_t>(a)] || aff.ddc[r];
+      }
+    }
+  }
+}
+
+} // namespace
+
+int main(int argc, char **argv) {
+  const std::string traj =
+      argc > 1 ? argv[1] : "traj/mW_cubic.lammpstrj";
+  const int frame = argc > 2 ? std::atoi(argv[2]) : 1;
+  const int typeI = argc > 3 ? std::atoi(argv[3]) : 1;
+
+  molSys::PointCloud<molSys::Point<double>, double> cloud;
+  cloud = sinp::readLammpsTrjO(traj, frame, cloud, typeI);
+  if (cloud.nop == 0) {
+    std::fprintf(stderr, "empty frame %d of %s\n", frame, traj.c_str());
+    return 1;
+  }
+
+  const double cutoff = 3.5;
+  const double cand = cutoff + 2.0;
+  const int k = 4;
+  const int nop = cloud.nop;
+
+  auto cutoffRows = nneigh::neighListO(cutoff, cloud, typeI);
+  auto knnRows = nneigh::kNearestNeighbourList(cloud, k, cand, typeI, true);
+  auto unionRows = nneigh::kNearestNeighbourList(cloud, k, cand, typeI, false);
+  auto idxC = nneigh::neighbourListByIndex(cloud, cutoffRows);
+  auto idxK = nneigh::neighbourListByIndex(cloud, knnRows);
+  auto idxU = nneigh::neighbourListByIndex(cloud, unionRows);
+  auto sixC = sixOf(primitive::ringNetwork(idxC, 6));
+  auto sixK = sixOf(primitive::ringNetwork(idxK, 6));
+  auto sixU = sixOf(primitive::ringNetwork(idxU, 6));
+  const auto affC = ring::cageAffiliation(sixC, idxC);
+  const auto affK = ring::cageAffiliation(sixK, idxK);
+  const auto affU = ring::cageAffiliation(sixU, idxU);
+  const auto seeded = ring::seededCageAffiliation(sixK, idxK, sixU, idxU);
+
+  std::printf("# %s frame %d nop %d\n", traj.c_str(), frame, nop);
+  tallyRings("cutoff", affC, static_cast<int>(sixC.size()));
+  tallyRings("knn", affK, static_cast<int>(sixK.size()));
+  tallyRings("knn-union", affU, static_cast<int>(sixU.size()));
+
+  std::vector<bool> hc, ddc;
+  atomsFromRings(sixC, affC, nop, hc, ddc);
+  tallyAtoms("cutoff", hc, ddc);
+  atomsFromRings(sixK, affK, nop, hc, ddc);
+  tallyAtoms("knn", hc, ddc);
+  atomsFromRings(sixU, affU, nop, hc, ddc);
+  tallyAtoms("knn-union", hc, ddc);
+  tallyAtoms("seeded", seeded.hc, seeded.ddc);
+  return 0;
+}

--- a/tests/test_cage_affiliation.cpp
+++ b/tests/test_cage_affiliation.cpp
@@ -217,6 +217,30 @@ TEST_CASE("AffiliationUpdater tracks synthetic topology churn exactly",
   }
 }
 
+TEST_CASE("AffiliationUpdater falls back to batch on whole-graph churn",
+          "[cage_affiliation]") {
+  molSys::PointCloud<molSys::Point<double>, double> yCloud;
+  yCloud = sinp::readLammpsTrjO("traj/mW_cubic.lammpstrj", 1, yCloud, 1);
+  auto nList = nneigh::neighListO(3.5, yCloud, 1);
+  auto idx = nneigh::neighbourListByIndex(yCloud, nList);
+  auto six = sixMembered(primitive::ringNetwork(idx, 7));
+
+  ring::AffiliationUpdater updater;
+  (void)updater.update(six, idx);
+
+  auto emptyRows = idx;
+  for (auto &row : emptyRows) {
+    if (!row.empty()) {
+      row.resize(1);
+    }
+  }
+  const auto &incremental = updater.update(six, emptyRows);
+  const auto batch = ring::cageAffiliation(six, emptyRows);
+  REQUIRE(incremental.hc == batch.hc);
+  REQUIRE(incremental.ddc == batch.ddc);
+  REQUIRE(updater.lastReclassified() == static_cast<int>(six.size()));
+}
+
 TEST_CASE("cage membership is not a function of the four-neighbour star",
           "[cage_affiliation]") {
   // Two configurations that agree exactly on the closed star of a vertex --

--- a/tests/test_cage_affiliation.cpp
+++ b/tests/test_cage_affiliation.cpp
@@ -153,10 +153,11 @@ TEST_CASE("cageAffiliation is invariant under ring permutation",
 TEST_CASE("AffiliationUpdater equals batch across the mW trajectory",
           "[cage_affiliation]") {
   ring::AffiliationUpdater updater;
+  nneigh::SkinNeighborList skin(3.5, 2.0, 1);
   for (int frame = 1; frame <= 11; frame++) {
     molSys::PointCloud<molSys::Point<double>, double> yCloud;
     yCloud = sinp::readLammpsTrjO("traj/mW_cubic.lammpstrj", frame, yCloud, 1);
-    auto nList = nneigh::neighListO(3.5, yCloud, 1);
+    auto nList = skin.update(yCloud);
     auto idx = nneigh::neighbourListByIndex(yCloud, nList);
     auto six = sixMembered(primitive::ringNetwork(idx, 7));
 
@@ -217,7 +218,7 @@ TEST_CASE("AffiliationUpdater tracks synthetic topology churn exactly",
   }
 }
 
-TEST_CASE("AffiliationUpdater falls back to batch on whole-graph churn",
+TEST_CASE("AffiliationUpdater matches batch when every neighbour row changes",
           "[cage_affiliation]") {
   molSys::PointCloud<molSys::Point<double>, double> yCloud;
   yCloud = sinp::readLammpsTrjO("traj/mW_cubic.lammpstrj", 1, yCloud, 1);

--- a/tests/test_neighbours.cpp
+++ b/tests/test_neighbours.cpp
@@ -362,21 +362,17 @@ TEST_CASE("SkinNeighborList rebuilds only after the Verlet trigger",
   REQUIRE(skin.lastRebuilt());
 }
 
-TEST_CASE("SkinNeighborList keeps a bond until cutoff plus skin",
+TEST_CASE("SkinNeighborList drops a bond as soon as it leaves the cutoff",
           "[neighbours]") {
   auto cloud = makeFourAtomCloud();
-  nneigh::SkinNeighborList skin(1.5, 0.6, 1);
+  nneigh::SkinNeighborList skin(1.5, 2.0, 1);
   (void)skin.update(cloud);
   REQUIRE(std::find(skin.bonds()[0].begin() + 1, skin.bonds()[0].end(), 1) !=
           skin.bonds()[0].end());
 
-  cloud.pts[1].x = 1.8; // 1.8 > 1.5, still < 2.1
+  cloud.pts[1].x = 1.8; // 1.8 > 1.5, still inside the skin halo
   (void)skin.update(cloud);
-  REQUIRE(std::find(skin.bonds()[0].begin() + 1, skin.bonds()[0].end(), 1) !=
-          skin.bonds()[0].end());
-
-  cloud.pts[1].x = 2.3; // 2.3 > 2.1
-  (void)skin.update(cloud);
+  REQUIRE_FALSE(skin.lastRebuilt());
   REQUIRE(std::find(skin.bonds()[0].begin() + 1, skin.bonds()[0].end(), 1) ==
           skin.bonds()[0].end());
 }

--- a/tests/test_neighbours.cpp
+++ b/tests/test_neighbours.cpp
@@ -329,6 +329,58 @@ TEST_CASE("neighListO leaves an unmapped atom as an empty row",
   REQUIRE(nList[2].empty());
 }
 
+TEST_CASE("SkinNeighborList matches neighListO on a static cloud",
+          "[neighbours]") {
+  auto cloud = makeFourAtomCloud();
+  nneigh::SkinNeighborList skin(1.5, 0.5, 1);
+  const auto &bonds = skin.update(cloud);
+  auto hard = nneigh::neighListO(1.5, cloud, 1);
+  REQUIRE(skin.lastRebuilt());
+  REQUIRE(bonds.size() == hard.size());
+  for (std::size_t i = 0; i < bonds.size(); i++) {
+    auto a = bonds[i];
+    auto b = hard[i];
+    std::sort(a.begin() + 1, a.end());
+    std::sort(b.begin() + 1, b.end());
+    REQUIRE(a == b);
+  }
+}
+
+TEST_CASE("SkinNeighborList rebuilds only after the Verlet trigger",
+          "[neighbours]") {
+  auto cloud = makeFourAtomCloud();
+  nneigh::SkinNeighborList skin(1.5, 1.0, 1);
+  (void)skin.update(cloud);
+  REQUIRE(skin.lastRebuilt());
+
+  cloud.pts[1].x += 0.2; // skin/2 = 0.5
+  (void)skin.update(cloud);
+  REQUIRE_FALSE(skin.lastRebuilt());
+
+  cloud.pts[1].x += 0.5;
+  (void)skin.update(cloud);
+  REQUIRE(skin.lastRebuilt());
+}
+
+TEST_CASE("SkinNeighborList keeps a bond until cutoff plus skin",
+          "[neighbours]") {
+  auto cloud = makeFourAtomCloud();
+  nneigh::SkinNeighborList skin(1.5, 0.6, 1);
+  (void)skin.update(cloud);
+  REQUIRE(std::find(skin.bonds()[0].begin() + 1, skin.bonds()[0].end(), 1) !=
+          skin.bonds()[0].end());
+
+  cloud.pts[1].x = 1.8; // 1.8 > 1.5, still < 2.1
+  (void)skin.update(cloud);
+  REQUIRE(std::find(skin.bonds()[0].begin() + 1, skin.bonds()[0].end(), 1) !=
+          skin.bonds()[0].end());
+
+  cloud.pts[1].x = 2.3; // 2.3 > 2.1
+  (void)skin.update(cloud);
+  REQUIRE(std::find(skin.bonds()[0].begin() + 1, skin.bonds()[0].end(), 1) ==
+          skin.bonds()[0].end());
+}
+
 TEST_CASE("neighListO returns empty when the cloud has no atoms",
           "[neighbours]") {
   auto cloud = makeFourAtomCloud();

--- a/tests/test_neighbours.cpp
+++ b/tests/test_neighbours.cpp
@@ -332,7 +332,7 @@ TEST_CASE("neighListO leaves an unmapped atom as an empty row",
 TEST_CASE("SkinNeighborList matches neighListO on a static cloud",
           "[neighbours]") {
   auto cloud = makeFourAtomCloud();
-  nneigh::SkinNeighborList skin(1.5, 0.5, 1);
+  nneigh::SkinNeighborList skin(1.5, 0.5, 1, 0);
   const auto &bonds = skin.update(cloud);
   auto hard = nneigh::neighListO(1.5, cloud, 1);
   REQUIRE(skin.lastRebuilt());
@@ -349,7 +349,7 @@ TEST_CASE("SkinNeighborList matches neighListO on a static cloud",
 TEST_CASE("SkinNeighborList rebuilds only after the Verlet trigger",
           "[neighbours]") {
   auto cloud = makeFourAtomCloud();
-  nneigh::SkinNeighborList skin(1.5, 1.0, 1);
+  nneigh::SkinNeighborList skin(1.5, 1.0, 1, 0);
   (void)skin.update(cloud);
   REQUIRE(skin.lastRebuilt());
 
@@ -365,7 +365,7 @@ TEST_CASE("SkinNeighborList rebuilds only after the Verlet trigger",
 TEST_CASE("SkinNeighborList drops a bond as soon as it leaves the cutoff",
           "[neighbours]") {
   auto cloud = makeFourAtomCloud();
-  nneigh::SkinNeighborList skin(1.5, 2.0, 1);
+  nneigh::SkinNeighborList skin(1.5, 2.0, 1, 0);
   (void)skin.update(cloud);
   REQUIRE(std::find(skin.bonds()[0].begin() + 1, skin.bonds()[0].end(), 1) !=
           skin.bonds()[0].end());
@@ -451,6 +451,23 @@ TEST_CASE("mutual and union k-nearest graphs coincide on the crystal",
   for (size_t i = 0; i < unionRows.size(); i++) {
     std::vector<int> a(unionRows[i].begin() + 1, unionRows[i].end());
     std::vector<int> b(mutualRows[i].begin() + 1, mutualRows[i].end());
+    std::sort(a.begin(), a.end());
+    std::sort(b.begin(), b.end());
+    REQUIRE(a == b);
+  }
+}
+
+TEST_CASE("SkinNeighborList default is the mutual four-nearest graph",
+          "[neighbours]") {
+  molSys::PointCloud<molSys::Point<double>, double> yCloud;
+  yCloud = sinp::readLammpsTrjO("traj/mW_cubic.lammpstrj", 1, yCloud, 1);
+  nneigh::SkinNeighborList skin(3.5, 2.0, 1);
+  const auto &bonds = skin.update(yCloud);
+  auto knn = nneigh::kNearestNeighbourList(yCloud, 4, 5.5, 1, true);
+  REQUIRE(bonds.size() == knn.size());
+  for (std::size_t i = 0; i < bonds.size(); i++) {
+    std::vector<int> a(bonds[i].begin() + 1, bonds[i].end());
+    std::vector<int> b(knn[i].begin() + 1, knn[i].end());
     std::sort(a.begin(), a.end());
     std::sort(b.begin(), b.end());
     REQUIRE(a == b);

--- a/tests/test_neighbours.cpp
+++ b/tests/test_neighbours.cpp
@@ -8,6 +8,8 @@
 
 #include <algorithm>
 #include <array>
+#include <stdexcept>
+#include <string>
 #include <vector>
 
 // Helper: build a 4-atom system in a 10x10x10 box
@@ -332,7 +334,7 @@ TEST_CASE("neighListO leaves an unmapped atom as an empty row",
 TEST_CASE("SkinNeighborList matches neighListO on a static cloud",
           "[neighbours]") {
   auto cloud = makeFourAtomCloud();
-  nneigh::SkinNeighborList skin(1.5, 0.5, 1, 0);
+  nneigh::SkinNeighborList skin(1.5, 0.5, 1, nneigh::BondGraph::Cutoff);
   const auto &bonds = skin.update(cloud);
   auto hard = nneigh::neighListO(1.5, cloud, 1);
   REQUIRE(skin.lastRebuilt());
@@ -349,7 +351,7 @@ TEST_CASE("SkinNeighborList matches neighListO on a static cloud",
 TEST_CASE("SkinNeighborList rebuilds only after the Verlet trigger",
           "[neighbours]") {
   auto cloud = makeFourAtomCloud();
-  nneigh::SkinNeighborList skin(1.5, 1.0, 1, 0);
+  nneigh::SkinNeighborList skin(1.5, 1.0, 1, nneigh::BondGraph::Cutoff);
   (void)skin.update(cloud);
   REQUIRE(skin.lastRebuilt());
 
@@ -365,7 +367,7 @@ TEST_CASE("SkinNeighborList rebuilds only after the Verlet trigger",
 TEST_CASE("SkinNeighborList drops a bond as soon as it leaves the cutoff",
           "[neighbours]") {
   auto cloud = makeFourAtomCloud();
-  nneigh::SkinNeighborList skin(1.5, 2.0, 1, 0);
+  nneigh::SkinNeighborList skin(1.5, 2.0, 1, nneigh::BondGraph::Cutoff);
   (void)skin.update(cloud);
   REQUIRE(std::find(skin.bonds()[0].begin() + 1, skin.bonds()[0].end(), 1) !=
           skin.bonds()[0].end());
@@ -455,6 +457,18 @@ TEST_CASE("mutual and union k-nearest graphs coincide on the crystal",
     std::sort(b.begin(), b.end());
     REQUIRE(a == b);
   }
+}
+
+TEST_CASE("bondGraphFromName accepts the published graph names",
+          "[neighbours]") {
+  REQUIRE(nneigh::bondGraphFromName("cutoff") == nneigh::BondGraph::Cutoff);
+  REQUIRE(nneigh::bondGraphFromName("knn") == nneigh::BondGraph::KnnMutual);
+  REQUIRE(nneigh::bondGraphFromName("knn-union") ==
+          nneigh::BondGraph::KnnUnion);
+  REQUIRE(std::string(nneigh::bondGraphName(nneigh::BondGraph::KnnMutual)) ==
+          "knn");
+  REQUIRE_THROWS_AS(nneigh::bondGraphFromName("not-a-graph"),
+                    std::invalid_argument);
 }
 
 TEST_CASE("SkinNeighborList default is the mutual four-nearest graph",

--- a/tests/test_seams_input.cpp
+++ b/tests/test_seams_input.cpp
@@ -155,6 +155,110 @@ TEST_CASE("readLammpsTrjreduced with slice and type filter", "[seams_input]") {
   }
 }
 
+// -- LAMMPS dump live session (ReaderNative cursor + offset table) --
+
+namespace {
+std::string writeTinyDump() {
+  auto path =
+      fs::temp_directory_path() / "dseams_test_lammps_index.lammpstrj";
+  std::ofstream f(path);
+  for (int frame = 0; frame < 3; ++frame) {
+    f << "ITEM: TIMESTEP\n" << (100 * frame) << "\n";
+    f << "ITEM: NUMBER OF ATOMS\n2\n";
+    f << "ITEM: BOX BOUNDS pp pp pp\n0 10\n0 10\n0 10\n";
+    f << "ITEM: ATOMS id type x y z\n";
+    f << "1 1 " << frame + 0.25 << " 0 0\n";
+    f << "2 1 " << frame + 0.75 << " 0 0\n";
+  }
+  return path.string();
+}
+
+std::string writeUnwrappedDump() {
+  auto path =
+      fs::temp_directory_path() / "dseams_test_lammps_xu.lammpstrj";
+  std::ofstream f(path);
+  f << "ITEM: TIMESTEP\n0\nITEM: NUMBER OF ATOMS\n1\n";
+  f << "ITEM: BOX BOUNDS pp pp pp\n0 10\n0 10\n0 10\n";
+  f << "ITEM: ATOMS id type xu yu zu\n";
+  f << "7 2 11.5 12.25 -3.0\n";
+  return path.string();
+}
+} // namespace
+
+TEST_CASE("nLammpsFrames counts ITEM: TIMESTEP markers", "[seams_input]") {
+  REQUIRE(sinp::nLammpsFrames("/tmp/nonexistent.lammpstrj") == 0);
+  REQUIRE(sinp::nLammpsFrames("traj/mW_cubic.lammpstrj") == 11);
+  const auto tiny = writeTinyDump();
+  sinp::dropLammpsDumpIndex(tiny);
+  REQUIRE(sinp::nLammpsFrames(tiny) == 3);
+  fs::remove(tiny);
+  sinp::dropLammpsDumpIndex(tiny);
+}
+
+TEST_CASE("readLammpsTrjreduced seeks the last frame by index",
+          "[seams_input]") {
+  const auto tiny = writeTinyDump();
+  sinp::dropLammpsDumpIndex(tiny);
+  molSys::PointCloud<molSys::Point<double>, double> yCloud;
+  auto last = sinp::readLammpsTrjreduced(tiny, 3, yCloud, 1);
+  REQUIRE(last.nop == 2);
+  REQUIRE(last.currentFrame == 3);
+  REQUIRE_THAT(last.pts[0].x, Catch::Matchers::WithinAbs(2.25, 1e-10));
+  REQUIRE_THAT(last.pts[1].x, Catch::Matchers::WithinAbs(2.75, 1e-10));
+  auto first = sinp::readLammpsTrjreduced(tiny, 1, yCloud, 1);
+  REQUIRE_THAT(first.pts[0].x, Catch::Matchers::WithinAbs(0.25, 1e-10));
+  auto mid = sinp::readLammpsTrjreduced(tiny, 2, yCloud, 1);
+  REQUIRE_THAT(mid.pts[0].x, Catch::Matchers::WithinAbs(1.25, 1e-10));
+  fs::remove(tiny);
+  sinp::dropLammpsDumpIndex(tiny);
+}
+
+TEST_CASE("sequential load_frame walks keep the live dump cursor",
+          "[seams_input]") {
+  const auto tiny = writeTinyDump();
+  sinp::dropLammpsDumpIndex(tiny);
+  molSys::PointCloud<molSys::Point<double>, double> yCloud;
+  for (int frame = 1; frame <= 3; ++frame) {
+    auto cloud = sinp::readLammpsTrj(tiny, frame, yCloud);
+    REQUIRE(cloud.nop == 2);
+    REQUIRE(cloud.currentFrame == frame);
+    REQUIRE_THAT(cloud.pts[0].x,
+                 Catch::Matchers::WithinAbs(frame - 0.75, 1e-10));
+  }
+  auto again = sinp::readLammpsTrj(tiny, 1, yCloud);
+  REQUIRE_THAT(again.pts[0].x, Catch::Matchers::WithinAbs(0.25, 1e-10));
+  fs::remove(tiny);
+  sinp::dropLammpsDumpIndex(tiny);
+}
+
+TEST_CASE("indexed last-frame read of mW_cubic matches a full scan",
+          "[seams_input]") {
+  REQUIRE(sinp::nLammpsFrames("traj/mW_cubic.lammpstrj") == 11);
+  molSys::PointCloud<molSys::Point<double>, double> a, b;
+  auto last = sinp::readLammpsTrjO("traj/mW_cubic.lammpstrj", 11, a, 1);
+  auto first = sinp::readLammpsTrjO("traj/mW_cubic.lammpstrj", 1, b, 1);
+  REQUIRE(last.nop == first.nop);
+  REQUIRE(last.nop == 4096);
+  REQUIRE(last.currentFrame == 11);
+  REQUIRE(first.currentFrame == 1);
+}
+
+TEST_CASE("readLammpsTrj binds xu yu zu when x y z are absent",
+          "[seams_input]") {
+  const auto path = writeUnwrappedDump();
+  sinp::dropLammpsDumpIndex(path);
+  molSys::PointCloud<molSys::Point<double>, double> yCloud;
+  auto cloud = sinp::readLammpsTrj(path, 1, yCloud);
+  REQUIRE(cloud.nop == 1);
+  REQUIRE(cloud.pts[0].atomID == 7);
+  REQUIRE(cloud.pts[0].type == 2);
+  REQUIRE_THAT(cloud.pts[0].x, Catch::Matchers::WithinAbs(11.5, 1e-10));
+  REQUIRE_THAT(cloud.pts[0].y, Catch::Matchers::WithinAbs(12.25, 1e-10));
+  REQUIRE_THAT(cloud.pts[0].z, Catch::Matchers::WithinAbs(-3.0, 1e-10));
+  fs::remove(path);
+  sinp::dropLammpsDumpIndex(path);
+}
+
 // -- readBonds tests --
 
 TEST_CASE("readBonds returns empty for nonexistent file", "[seams_input]") {

--- a/tests/test_seams_input.cpp
+++ b/tests/test_seams_input.cpp
@@ -243,6 +243,31 @@ TEST_CASE("indexed last-frame read of mW_cubic matches a full scan",
   REQUIRE(first.currentFrame == 1);
 }
 
+TEST_CASE("forEachLammpsFrame matches sequential reads", "[seams_input]") {
+  const auto tiny = writeTinyDump();
+  sinp::dropLammpsDumpIndex(tiny);
+  std::vector<double> xs(3, -1.0);
+  std::vector<int> nops(3, 0);
+  sinp::forEachLammpsFrame(
+      tiny, 1, 3, 1,
+      [&](int frame, molSys::PointCloud<molSys::Point<double>, double> &cloud) {
+        const auto i = static_cast<std::size_t>(frame - 1);
+        nops[i] = cloud.nop;
+        if (!cloud.pts.empty()) {
+          xs[i] = cloud.pts[0].x;
+        }
+      },
+      2);
+  REQUIRE(nops[0] == 2);
+  REQUIRE(nops[1] == 2);
+  REQUIRE(nops[2] == 2);
+  REQUIRE_THAT(xs[0], Catch::Matchers::WithinAbs(0.25, 1e-10));
+  REQUIRE_THAT(xs[1], Catch::Matchers::WithinAbs(1.25, 1e-10));
+  REQUIRE_THAT(xs[2], Catch::Matchers::WithinAbs(2.25, 1e-10));
+  fs::remove(tiny);
+  sinp::dropLammpsDumpIndex(tiny);
+}
+
 TEST_CASE("readLammpsTrj binds xu yu zu when x y z are absent",
           "[seams_input]") {
   const auto path = writeUnwrappedDump();


### PR DESCRIPTION
The 2020 paper shipped a Nix build. The CMake `yodaStruct` derivation is gone; this is a flake.

```
nix build
nix run . -- read input/traj/exampleTraj.lammpstrj
nix develop
```

`libyodaLib` and the `seams` CLI. Optional wrap-git backends (vesin, readcon-core) stay off unless nixpkgs already provides them. Catch2 is the install check.

GCC 15 does not find `chill::isInterfacial` from the anonymous assign helpers, so those calls are qualified.

Lua is `dseams` in yodaStruct. Python is `pydseams`. Those repos get matching flakes.