### PR TITLE
feat: periodic k-nearest graphs and a faster dump walk

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,8 @@ yodaStruct -c lua_inputs/config.yml
 ### Nix
 
 The flake builds `libyodaLib` and the `seams` CLI with meson. Optional
-backends that meson would otherwise wrap-git (vesin, readcon-core) or
+backends that meson would otherwise wrap-git (vesin, readcon-core,
+linkcell) or
 that nixpkgs does not ship (chemfiles) stay off unless a package is
 already in the closure.
 

--- a/docs/export.el
+++ b/docs/export.el
@@ -1,9 +1,10 @@
-;; Setup Package Manager (to fetch ox-rst automatically)
+;; Batch export org-mode files to RST for Sphinx.
+;; Usage (cwd = docs/): emacs --batch --load export.el
+;; Org under orgmode/ is the source. RST under ./source/ is generated.
 (require 'package)
 (add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/") t)
 (package-initialize)
 
-;; Ensure ox-rst is present
 (unless (package-installed-p 'ox-rst)
   (package-refresh-contents)
   (package-install 'ox-rst))
@@ -11,14 +12,19 @@
 (require 'ox-rst)
 (require 'ox-publish)
 
-;; ox-rst 2025-04 needs org-element-type-p (Org 9.7+).
+;; ox-rst 2025-04 needs org-element-type-p (Org 9.7+). Ubuntu emacs-nox is 29/9.6.
 (require 'org-element)
 (unless (fboundp 'org-element-type-p)
   (defun org-element-type-p (node types)
     (memq (org-element-type node)
           (if (listp types) types (list types)))))
 
-;; Define the Publishing Project
+(setq org-export-with-section-numbers nil)
+(setq org-export-with-toc nil)
+(setq org-export-with-author nil)
+(setq org-export-with-timestamps nil)
+(setq org-rst-headline-underline ?-)
+
 (setq org-publish-project-alist
       '(("sphinx-rst"
          :base-directory "./orgmode/"
@@ -26,7 +32,10 @@
          :publishing-directory "./source/"
          :publishing-function org-rst-publish-to-rst
          :recursive t
-         :headline-levels 4)
+         :headline-levels 4
+         :with-toc nil
+         :section-numbers nil
+         :with-author nil)
         ("sphinx-images"
          :base-directory "./orgmode/"
          :base-extension "svg\\|png\\|jpg"
@@ -35,5 +44,4 @@
          :recursive t)
         ("sphinx" :components ("sphinx-rst" "sphinx-images"))))
 
-;; Run the publish
 (org-publish "sphinx" t)

--- a/docs/newsfragments/linkcell-knn.feature
+++ b/docs/newsfragments/linkcell-knn.feature
@@ -1,0 +1,1 @@
+k-nearest graphs use the linkcell library (periodic linked-cell walk, Meson wrap).

--- a/docs/orgmode/changelog.org
+++ b/docs/orgmode/changelog.org
@@ -1,18 +1,76 @@
 #+TITLE: Changelog
 #+OPTIONS: toc:nil num:nil
 
+The C++ engine is this repository. Python is ~pydseams~
+([[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]]). Lua is
+~require("dseams")~ ([[https://github.com/d-SEAMS/yodaStruct][yodaStruct]]).
+
+* 2.2.4
+
+Docs orgmode covers the ~seams~ CLI, the Nix flake, and the
+three-repo split.
+
+* 2.2.3
+
+The ~seams~ CLI uses Argum. Help, errors, ice-type counts, and
+~--features~ are colorized. ~NO_COLOR~ turns the colors off.
+
+* 2.2.2
+
+The compiled Python surface is ~pydseams.yoda~. ~_core~ remains an
+alias.
+
+* 2.2.1
+
+- Flake package for ~libyodaLib~ and ~seams~ (Meson, not the
+  CMake-era ~yodaStruct~ derivation).
+- Live LAMMPS dump session (~nLammpsFrames~,
+  ~forEachLammpsFrame~): ~seams --frame N --last M --jobs J~.
+- ~BondGraph~ at runtime: ~cutoff~, ~knn~, ~knn-union~. ~seams cages
+  --graph~ adds ~seeded~.
+- LAMMPS readers bind ~xu~/~yu~/~zu~ and ~xs~/~ys~/~zs~ when ~x y z~
+  are absent.
+
+* 2.2.0
+
+~seams~ CLI: ~read~, ~chill~, ~chill-plus~, ~cages~. This is the
+engine command line.
+
+* 2.1.2
+
+Removed CMake-era Nix entrypoints that still named the product
+~yodaStruct~. Build with pixi or ~nix build~.
+
+* 2.1.1
+
+CHILL interfacial walk uses the same four-neighbour star as ~c_ij~.
+Atoms without four recorded bonds go to water. Seeded affiliation
+floods HC and DDC separately.
+
+* 2.1.0
+
+The C++ engine is this repository. Front ends are not.
+
+- The ~yodaStruct~ Lua/Fennel CLI moved to
+  https://github.com/d-SEAMS/yodaStruct . ~-Dwith_lua=enabled~ is an
+  error that names that repository.
+- Python bindings remain in
+  https://github.com/d-SEAMS/PydSEAMSlib (moved in 2.0.1).
+- C++ ~getCorrel~ / ~getIceType~ family and ~reclassifyWater~ return
+  ~void~.
+
+* 2.0.1
+
+Python bindings moved to PydSEAMSlib. This repository is the C++
+engine.
+
 * 2.0.0
 
-- Modernized build system: Meson replaces CMake
-- Python bindings via nanobind (replacing pybind11)
-- New pixi-based development environment
-- ASE adapter for converting ASE Atoms to d-SEAMS point clouds
-- Comprehensive Python test suite (pytest)
+Meson replaces CMake. License is MIT. Optional vesin neighbour lists,
+Highway SIMD, chemfiles, and readcon-core. Catch2 suite for the
+engine.
 
 * 1.0.0
 
-- Initial release with Lua scripting interface
-- CHILL and CHILL+ ice classification
-- Franzblau ring analysis
-- Topological unit matching (TUM) for bulk ice
-- LAMMPS trajectory reader
+Initial release. See Goswami et al., J. Chem. Inf. Model. 2020, 60,
+2169-2177.

--- a/docs/orgmode/contributing/index.org
+++ b/docs/orgmode/contributing/index.org
@@ -1,18 +1,28 @@
 #+TITLE: Contributing
 #+OPTIONS: toc:nil num:nil
 
+This repository is the C++ engine (~libyodaLib~) and the ~seams~ CLI.
+Python bindings are [[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]].
+Lua/Fennel is [[https://github.com/d-SEAMS/yodaStruct][yodaStruct]].
+Do not add a language binding here.
+
 * Prerequisites
 
-d-SEAMS uses [[https://pixi.sh][pixi]] for environment and task management. Install pixi first:
+Two supported compiler shells:
+
+- [[https://pixi.sh][pixi]] (locked conda-forge toolchain)
+- ~nix develop~ (flake inputs: compiler, Eigen, BLAS, Catch2, gdb)
 
 #+begin_src bash
 curl -fsSL https://pixi.sh/install.sh | bash
 #+end_src
 
-The pixi environment provides the C++ toolchain: a compiler, Eigen,
-BLAS/LAPACK, Catch2, Meson and Ninja. Python bindings are
-[[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]], not this
-tree. ~nix develop~ is the other supported compiler shell.
+pixi provides a compiler, Eigen, BLAS/LAPACK, Catch2, Meson, Ninja,
+Highway and chemfiles. Optional pixi features add IRA, sphericart,
+nauty, MPI, the docs stack, and the Coq/SymPy proofs.
+
+~-Dwith_python=true~ and ~-Dwith_lua=enabled~ are Meson errors that
+name the front-end repositories.
 
 * Clone and build
 
@@ -21,77 +31,96 @@ git clone https://github.com/d-SEAMS/seams-core.git
 cd seams-core
 #+end_src
 
-Set up the Meson build directory and compile:
+pixi:
 
 #+begin_src bash
 pixi run setup
 pixi run build
-#+end_src
-
-~pixi run setup~ configures a Meson build directory at ~bbdir/~ with
-tests and the ~seams~ CLI. ~pixi run build~ compiles ~libyodaLib~ and
-~seams~.
-
-* Running tests
-
-C++ tests (Catch2):
-
-#+begin_src bash
 pixi run test
 #+end_src
 
-~pixi run test~ runs the Catch2 suite. Python tests live in
-[[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]].
+~pixi run setup~ configures ~bbdir/~ with tests and the ~seams~ CLI
+(~-Dwith_tests=true -Dwith_python=false~). ~pixi run build~ compiles
+~libyodaLib~ and ~seams~. ~pixi run test~ runs the Catch2 suite.
+
+Nix:
+
+#+begin_src bash
+nix develop
+meson setup bbdir -Dwith_tests=true
+meson compile -C bbdir
+meson test -C bbdir
+./bbdir/seams read input/traj/exampleTraj.lammpstrj
+#+end_src
+
+~nix build~ is the same package plus the install check.
 
 * Project structure
 
 #+begin_src text
 seams-core/
-  src/                   C++ source files
-    include/
-      internal/          Internal headers (mol_sys, neighbours, bond, ...)
-      external/          Vendored headers (backward, argum, cxxopts, rang, ...)
-    mol_sys.cpp          Molecular system data structures
-    neighbours.cpp       Neighbour list construction
-    bond.cpp             Hydrogen bond detection
-    bop.cpp              Bond order parameters (CHILL/CHILL+)
-    ring.cpp             Ring analysis and classification
-    franzblau.cpp        Franzblau shortest-path ring finder
-    bulkTUM.cpp          Topological unit matching for bulk ice
-    topo_one_dim.cpp     1D topology (nanotubes)
-    topo_two_dim.cpp     2D topology (sheets)
-    ...
-  tests/
-    *.cpp                C++ test files (Catch2)
-  input/
-    traj/                Example LAMMPS trajectories
-  meson.build            Top-level Meson build definition
-  pixi.toml              pixi workspace configuration
-#+end_src
-
-Python bindings: [[https://github.com/d-SEAMS/PydSEAMSlib][d-SEAMS/PydSEAMSlib]].
+  src/                   C++ engine
+    seams_cli.cpp        seams (Argum)
+    include/internal/    engine headers
+    include/external/    vendored headers (argum, backward, ...)
+    mol_sys.cpp          PointCloud
+    neighbours.cpp       cutoff / knn / knn-union lists
+    bond.cpp             hydrogen bonds
+    bop.cpp              CHILL / CHILL+
+    ring.cpp             ring classification
+    franzblau.cpp        Franzblau shortest-path rings
+    cage_affiliation.cpp HC / DDC ice score
+    bulkTUM.cpp          topological unit matching
+    topo_one_dim.cpp     nanotubes
+    topo_two_dim.cpp     sheets
+  tests/                 Catch2 binaries
+  input/traj/            example LAMMPS dumps
+  input/xyz/             fixtures
+  input/con/             eOn .con fixture
+  meson.build            Meson project
+  meson_options.txt      with_tests, with_cli, optional backends
+  flake.nix              nix build / nix develop
+  pixi.toml              pixi workspace
 #+end_src
 
 * Core concepts
 
-- ~PointCloud~ :: The central data structure. Holds atom positions, types, box
-  dimensions, and per-atom properties (ice type, bond-order correlations).
+- ~PointCloud~ :: Atom positions, types, box, and per-atom ice labels.
 
-- ~neighListO~ :: Builds distance-based neighbour lists for oxygen atoms. Returns
-  a vector of vectors where each inner vector starts with the atom's own ID
-  followed by its neighbours.
+- ~neighListO~ / ~kNearestNeighbourList~ :: Cutoff and k-nearest
+  graphs. ~bondGraphFromName~ accepts ~cutoff~, ~knn~, ~knn-union~.
 
-- ~populateHbonds~ :: Re-reads the trajectory to find hydrogen positions, then
-  applies geometric criteria to determine hydrogen bonds between oxygen pairs.
+- ~populateHbonds~ :: Geometric hydrogen bonds. Needs hydrogens
+  (re-read from a dump, or an explicit H cloud).
 
-- ~getCorrelPlus~ / ~getIceTypePlus~ :: The CHILL+ algorithm. First computes
-  bond-order correlations (~c_ij~) between neighbours, then classifies each atom
-  as cubic ice, hexagonal ice, interfacial, clathrate, or liquid water.
+- ~getCorrelPlus~ / ~getIceTypePlus~ :: CHILL+. Four-neighbour
+  ~c_ij~, then cubic / hexagonal / interfacial / clathrate / water.
 
-- ~ringNetwork~ :: Franzblau shortest-path ring analysis. Finds primitive rings
-  in the hydrogen bond or neighbour network up to a specified depth.
+- ~cageAffiliation~ / ~seededCageAffiliation~ :: Ice score on
+  six-rings. HC = Ih, DDC = Ic, neither = water. Not the CHILL+ star.
 
-* Commit style
+- ~ringNetwork~ :: Franzblau primitive rings up to a depth.
 
-Follow the pattern ~fileName: description of change~. See ~CONTRIBUTING.md~ in the
-repository root for full details.
+* Tests
+
+#+begin_src bash
+pixi run test
+nix develop --command meson test -C bbdir
+#+end_src
+
+C++ tests are Catch2. Python tests live in
+[[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]].
+
+Optional pixi environments: ~pixi run -e ira ...~, ~sphericart~,
+~nauty~, ~mpi~, ~docs~, ~formalanalysis~, ~repro~.
+
+* Style
+
+Install the clang-format hook:
+
+#+begin_src bash
+./scripts/git-pre-commit-format install
+#+end_src
+
+Commit subjects follow ~fileName: description of change~. See
+~CONTRIBUTING.md~ in the repository root.

--- a/docs/orgmode/contributing/index.org
+++ b/docs/orgmode/contributing/index.org
@@ -6,6 +6,10 @@ Python bindings are [[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]].
 Lua/Fennel is [[https://github.com/d-SEAMS/yodaStruct][yodaStruct]].
 Do not add a language binding here.
 
+Documentation is authored in ~docs/orgmode/~ and exported with
+~docs/export.el~ (ox-rst) before Sphinx. Run ~pixi run -e docs docbld~
+to export, run doxyrest, and build the Shibuya site.
+
 * Prerequisites
 
 Two supported compiler shells:

--- a/docs/orgmode/explanation/architecture.org
+++ b/docs/orgmode/explanation/architecture.org
@@ -1,7 +1,8 @@
 #+TITLE: Three repositories
 #+OPTIONS: toc:nil num:nil
 
-d-SEAMS 2 is not a monolith.
+d-SEAMS 2 is not a monolith. The classifier is one C++ library. Each
+language ships its own package against that library.
 
 | repository | product | role |
 |------------+---------+------|
@@ -12,12 +13,21 @@ d-SEAMS 2 is not a monolith.
 The front ends take seams-core as a Meson subproject (static library)
 or as a flake input. They do not vendor a second engine.
 
+A language binding that lived in the engine tree would force every
+C++ user to take that language's toolchain, and every wheel or rock
+to rebuild the same library. Splitting the repos keeps the Catch2
+suite, the ~seams~ CLI, and the optional backends on one Meson
+project, while Python and Lua version and release on their own
+schedules.
+
 * Why ~yoda~
 
-The 2020 executable was ~yodaStruct~. The compiled Python module is
-~pydseams.yoda~ so that name stays on the C++ surface.
-~_core~ and ~cyoda~ are aliases of ~yoda~. Lua helpers are
+The 2020 product was a single executable named ~yodaStruct~. That
+binary is gone. The compiled C++ surface kept the name so existing
+registrations stay findable: the Python module is ~pydseams.yoda~
+(~_core~ and ~cyoda~ are aliases of ~yoda~). Lua helpers are
 ~require("dseams")~; ~require("yoda")~ still resolves to that table.
+There is no ~yodaStruct~ executable in any of the three repositories.
 
 * Builds
 
@@ -27,9 +37,43 @@ The 2020 executable was ~yodaStruct~. The compiled Python module is
 - *Wheels*: cibuildwheel on PydSEAMSlib, CPython 3.12 limited ABI.
 
 The 2020 CMake Nix derivation of ~yodaStruct~ is gone.
+~-Dwith_python=true~ and ~-Dwith_lua=enabled~ are Meson errors that
+name PydSEAMSlib and yodaStruct.
 
-* Ice score
+* Ice score and the CHILL+ star
 
-A molecule in an HC is ice Ih. A molecule in a DDC is ice Ic. A
-molecule in neither is water. That is cage membership, not the
-four-neighbour CHILL+ star. Both live in ~libyodaLib~.
+Two classifiers live in ~libyodaLib~. They answer different questions
+and they do not imply each other.
+
+CHILL and CHILL+ look at the *four-neighbour star*. They compute
+bond-order correlations ~c_ij~ on the four nearest neighbours of each
+oxygen (or each mW site) and label the atom cubic, hexagonal,
+interfacial, clathrate, or water from the staggered and eclipsed
+pattern of that star. ~seams chill~ / ~seams chill-plus~ and
+~Frame.chill~ / ~Frame.chill_plus~ are this path.
+
+The *ice score* is cage membership. A molecule in a hexagonal cage
+(HC) is ice Ih. A molecule in a double-diamond cage (DDC) is ice Ic.
+A molecule in neither is water. The cages are assembled from
+six-membered primitive rings on a chosen bond graph, not from the
+four-neighbour star. ~seams cages~ and ~Frame.cages~ are this path.
+
+A configuration can agree exactly on the closed star of a vertex
+(same induced graph, same coordinates on those five atoms) and still
+disagree on that vertex's cage label, because the cage predicates
+read a larger neighbourhood of six-rings. The Catch2 suite encodes
+that fact: cage membership is not a function of the four-neighbour
+star.
+
+~seams cages --graph~ chooses the bond graph those rings are found
+on:
+
+| value | graph |
+|-------+-------|
+| ~cutoff~ | pairs inside the distance cutoff (2020 graph) |
+| ~knn~ | mutual k-nearest (default ~k=4~) |
+| ~knn-union~ | union k-nearest (completion graph of the seeded rule) |
+| ~seeded~ | mutual seeds, union completions (CLI default) |
+
+On a perfect cubic crystal the four graphs coincide. On a mixed
+nucleation dump they do not.

--- a/docs/orgmode/explanation/architecture.org
+++ b/docs/orgmode/explanation/architecture.org
@@ -20,6 +20,24 @@ suite, the ~seams~ CLI, and the optional backends on one Meson
 project, while Python and Lua version and release on their own
 schedules.
 
+#+begin_export rst
+.. mermaid::
+
+   flowchart TB
+     subgraph engine["seams-core"]
+       LIB[libyodaLib]
+       CLI[seams CLI]
+     end
+     subgraph fronts["Front ends"]
+       PY[pydseams Frame]
+       LUA["require(\"dseams\")"]
+     end
+     DUMP[LAMMPS / XYZ / chemfiles / con] --> LIB
+     LIB --> CLI
+     LIB --> PY
+     LIB --> LUA
+#+end_export
+
 * Why ~yoda~
 
 The 2020 product was a single executable named ~yodaStruct~. That
@@ -43,37 +61,10 @@ name PydSEAMSlib and yodaStruct.
 * Ice score and the CHILL+ star
 
 Two classifiers live in ~libyodaLib~. They answer different questions
-and they do not imply each other.
+and they do not imply each other. The argument is
+[[file:chill-plus-vs-cages.org][CHILL+ versus cages]].
 
-CHILL and CHILL+ look at the *four-neighbour star*. They compute
-bond-order correlations ~c_ij~ on the four nearest neighbours of each
-oxygen (or each mW site) and label the atom cubic, hexagonal,
-interfacial, clathrate, or water from the staggered and eclipsed
-pattern of that star. ~seams chill~ / ~seams chill-plus~ and
-~Frame.chill~ / ~Frame.chill_plus~ are this path.
-
-The *ice score* is cage membership. A molecule in a hexagonal cage
-(HC) is ice Ih. A molecule in a double-diamond cage (DDC) is ice Ic.
-A molecule in neither is water. The cages are assembled from
-six-membered primitive rings on a chosen bond graph, not from the
-four-neighbour star. ~seams cages~ and ~Frame.cages~ are this path.
-
-A configuration can agree exactly on the closed star of a vertex
-(same induced graph, same coordinates on those five atoms) and still
-disagree on that vertex's cage label, because the cage predicates
-read a larger neighbourhood of six-rings. The Catch2 suite encodes
-that fact: cage membership is not a function of the four-neighbour
-star.
-
-~seams cages --graph~ chooses the bond graph those rings are found
-on:
-
-| value | graph |
-|-------+-------|
-| ~cutoff~ | pairs inside the distance cutoff (2020 graph) |
-| ~knn~ | mutual k-nearest (default ~k=4~) |
-| ~knn-union~ | union k-nearest (completion graph of the seeded rule) |
-| ~seeded~ | mutual seeds, union completions (CLI default) |
-
-On a perfect cubic crystal the four graphs coincide. On a mixed
-nucleation dump they do not.
+~seams cages --graph~ chooses the bond graph the six-rings are found
+on: ~cutoff~, ~knn~, ~knn-union~, or ~seeded~ (CLI default). On a
+perfect cubic crystal the four graphs coincide. On a mixed nucleation
+dump they do not.

--- a/docs/orgmode/explanation/chill-plus-vs-cages.org
+++ b/docs/orgmode/explanation/chill-plus-vs-cages.org
@@ -1,0 +1,64 @@
+#+TITLE: CHILL+ versus cages
+#+OPTIONS: toc:nil num:nil
+
+Two classifiers live in ~libyodaLib~. They answer different questions
+and they do not imply each other.
+
+* Four-neighbour star
+
+CHILL and CHILL+ (~seams chill~ / ~seams chill-plus~,
+~chill::getCorrelPlus~ / ~getIceTypePlus~) look at the four-neighbour
+star. They compute bond-order correlations ~c_ij~ on the four nearest
+neighbours of each oxygen (or each mW site) and label the atom cubic,
+hexagonal, interfacial, clathrate, or water from the staggered and
+eclipsed pattern of that star.
+
+A molecule is cubic or hexagonal when its four bonds look like ice,
+even if those neighbours do not close a cage.
+
+CHILL+: Nguyen and Molinero, *J. Phys. Chem. B* 2015
+([[https://doi.org/10.1021/jp510289t][10.1021/jp510289t]]).
+CHILL: Moore et al., *Phys. Chem. Chem. Phys.* 2010.
+
+* Cage membership
+
+The ice score (~seams cages~, ~ring::seededCageAffiliation~ by
+default) is cage membership. A molecule in a hexagonal cage (HC) is
+ice Ih. A molecule in a double-diamond cage (DDC) is ice Ic. A
+molecule in neither is water. The cages are assembled from
+six-membered primitive rings on a chosen bond graph, not from the
+four-neighbour star.
+
+This is topological unit matching (TUM). The methods paper is the
+2020 JCIM article (see [[file:citation.org][Citation]]).
+
+* Why they disagree
+
+A configuration can agree exactly on the closed star of a vertex
+(same induced graph, same coordinates on those five atoms) and still
+disagree on that vertex's cage label, because the cage predicates
+read a larger neighbourhood of six-rings. The Catch2 suite encodes
+that fact: cage membership is not a function of the four-neighbour
+star.
+
+On the in-tree mixed TIP4P dump
+(~input/traj/exampleTraj.lammpstrj~), CHILL+ reports 42 cubic, 65
+hexagonal, 58 interfacial, and 85 water (107 bulk-ice stars). Seeded
+cages report zero HC and zero DDC. Local tetrahedral order is not
+cage membership. Walk through the commands in
+[[file:../tutorials/bulk-ice.org][the mixed TIP4P tutorial]].
+
+* Bond graph
+
+~seams cages --graph~ chooses the bond graph those rings are found
+on:
+
+| value | graph |
+|-------+-------|
+| ~cutoff~ | pairs inside the distance cutoff |
+| ~knn~ | mutual k-nearest (default ~k=4~) |
+| ~knn-union~ | union k-nearest (completion graph of the seeded rule) |
+| ~seeded~ | mutual seeds, union completions (CLI default) |
+
+On a perfect cubic crystal the four graphs coincide. On a mixed
+nucleation dump they do not have to.

--- a/docs/orgmode/explanation/chill-plus-vs-cages.org
+++ b/docs/orgmode/explanation/chill-plus-vs-cages.org
@@ -42,11 +42,10 @@ that fact: cage membership is not a function of the four-neighbour
 star.
 
 On the in-tree mixed TIP4P dump
-(~input/traj/exampleTraj.lammpstrj~), CHILL+ reports 42 cubic, 65
-hexagonal, 58 interfacial, and 85 water (107 bulk-ice stars). Seeded
-cages report zero HC and zero DDC. Local tetrahedral order is not
-cage membership. Walk through the commands in
-[[file:../tutorials/bulk-ice.org][the mixed TIP4P tutorial]].
+(~input/traj/exampleTraj.lammpstrj~), CHILL+ reports 12 interfacial
+clathrate and 238 water. Seeded cages report zero HC and zero DDC.
+A three-eclipsed star is not cage membership. Walk through the
+commands in [[file:../tutorials/bulk-ice.org][the mixed TIP4P tutorial]].
 
 * Bond graph
 

--- a/docs/orgmode/explanation/citation.org
+++ b/docs/orgmode/explanation/citation.org
@@ -1,0 +1,31 @@
+#+TITLE: Citation
+#+OPTIONS: toc:nil num:nil
+
+If you use this software, cite the methods paper.
+
+Goswami, R.; Goswami, A.; Singh, J. K. d-SEAMS: Deferred Structural
+Elucidation Analysis for Molecular Simulations. /J. Chem. Inf. Model./
+2020, 60, 2169--2177.
+[[https://doi.org/10.1021/acs.jcim.0c00031][10.1021/acs.jcim.0c00031]]
+(arXiv:1909.09830).
+
+#+begin_src bibtex
+@Article{Goswami2020,
+  author  = {Goswami, Rohit and Goswami, Amrita and Singh, Jayant Kumar},
+  title   = {{d-SEAMS}: Deferred Structural Elucidation Analysis for Molecular Simulations},
+  journal = {Journal of Chemical Information and Modeling},
+  year    = {2020},
+  volume  = {60},
+  number  = {4},
+  pages   = {2169--2177},
+  doi     = {10.1021/acs.jcim.0c00031},
+}
+#+end_src
+
+The v2 engine paper targets Computer Physics Communications. Cite
+JCIM 2020 until that article has a DOI; then cite both (JCIM for the
+methods, CPC for the v2 engine).
+
+Related method papers, only when the page uses that method: Nguyen
+and Molinero 2015 (CHILL+), Moore et al. 2010 (CHILL), ten Wolde
+et al. 1996 (local bond order).

--- a/docs/orgmode/explanation/index.org
+++ b/docs/orgmode/explanation/index.org
@@ -1,0 +1,19 @@
+#+TITLE: Explanation
+#+OPTIONS: toc:nil num:nil
+
+These pages are for understanding. They are not recipes.
+
+| page | question |
+|------+----------|
+| [[file:architecture.org][Three repositories]] | Why the engine, Python, and Lua are three packages |
+| [[file:chill-plus-vs-cages.org][CHILL+ versus cages]] | Why the two scores disagree |
+| [[file:citation.org][Citation]] | What to cite |
+
+#+begin_export rst
+.. toctree::
+   :maxdepth: 1
+
+   architecture
+   chill-plus-vs-cages
+   citation
+#+end_export

--- a/docs/orgmode/howto/ase-integration.org
+++ b/docs/orgmode/howto/ase-integration.org
@@ -1,58 +1,26 @@
 #+TITLE: ASE integration
 #+OPTIONS: toc:nil num:nil
 
-Turn an ASE ~Atoms~ into a ~pydseams.Frame~, classify ice, and write
-labels back onto the ~Atoms~.
-
-* Prerequisites
-
-The engine repository does not install Python. Build or install
-[[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]]:
+Turn an ASE ~Atoms~ into labels. The engine repository does not
+install Python. The full howto is
+[[https://d-seams.github.io/PydSEAMSlib/][pydseams ASE]].
 
 #+begin_src bash
 pip install 'pydseams[ase]'
 #+end_src
-
-~import pydseamslib~ still resolves to the same package.
-
-* Classify ice from ASE
 
 #+begin_src python
 import ase.io
 import pydseams as ds
 
 atoms = ase.io.read("input/traj/exampleTraj.lammpstrj", format="lammps-dump-text")
-# LAMMPS dumps often have numeric types; give them symbols first
-for atom in atoms:
-    atom.symbol = {1: "H", 2: "O"}.get(atom.number, atom.symbol)
-
-frame = ds.from_ase(atoms)          # oxygen; H-bonds if H is present
+frame = ds.from_ase(atoms)
 print(frame.chill_plus())
-print(frame.cages())
-
-labelled = frame.to_ase()           # arrays['ice_type'] after CHILL
-# arrays['hc'] / arrays['ddc'] after cages()
+labelled = frame.to_ase()
 #+end_src
 
 ~from_ase~ needs an orthorhombic cell. The analysed species is oxygen
-by default (~select="O"~). Hydrogen positions stay on the frame so
-~bonded="auto"~ can build a hydrogen-bond graph.
-
-* Single-site models (mW)
-
-#+begin_src python
-frame = ds.from_ase(atoms, select="O", bonded="cutoff")
-#+end_src
-
-~select~ is a chemical symbol, an atomic number, or ~None~ (every
-atom). ~bonded~ is ~auto~, ~hbond~, or ~cutoff~. Use ~cutoff~ when the
-~Atoms~ have no hydrogen.
-
-* Notes
-
-- ~Frame~ is the high-level object. ~pydseams.yoda~ is the compiled
-  engine module (~_core~ and ~cyoda~ are aliases of ~yoda~).
-- ~to_ase~ writes ~arrays['ice_type']~ after ~chill~ / ~chill_plus~.
-  After ~cages()~ it also writes per-atom ~hc~ and ~ddc~ flags.
-- Optional extra ~pydseams[solvis]~ builds a solvis ~System~ from the
-  same frame (~frame.to_solvis()~).
+by default (~select="O"~). ~bonded~ is ~auto~, ~hbond~, or ~cutoff~.
+~to_ase~ writes ~arrays['ice_type']~ after CHILL, and ~hc~ / ~ddc~
+after ~cages()~. Optional extra ~pydseams[solvis]~ builds a solvis
+~System~ (~frame.to_solvis()~).

--- a/docs/orgmode/howto/ase-integration.org
+++ b/docs/orgmode/howto/ase-integration.org
@@ -1,14 +1,19 @@
 #+TITLE: ASE integration
 #+OPTIONS: toc:nil num:nil
 
-Pass an ASE ~Atoms~ to ~pydseams.from_ase~. Oxygen is selected by
-default. Hydrogen bonds are used when the ~Atoms~ also contain H.
+Turn an ASE ~Atoms~ into a ~pydseams.Frame~, classify ice, and write
+labels back onto the ~Atoms~.
 
 * Prerequisites
+
+The engine repository does not install Python. Build or install
+[[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]]:
 
 #+begin_src bash
 pip install 'pydseams[ase]'
 #+end_src
+
+~import pydseamslib~ still resolves to the same package.
 
 * Classify ice from ASE
 
@@ -21,12 +26,17 @@ atoms = ase.io.read("input/traj/exampleTraj.lammpstrj", format="lammps-dump-text
 for atom in atoms:
     atom.symbol = {1: "H", 2: "O"}.get(atom.number, atom.symbol)
 
-frame = ds.from_ase(atoms)          # oxygen, H-bonds if H is present
+frame = ds.from_ase(atoms)          # oxygen; H-bonds if H is present
 print(frame.chill_plus())
 print(frame.cages())
 
 labelled = frame.to_ase()           # arrays['ice_type'] after CHILL
+# arrays['hc'] / arrays['ddc'] after cages()
 #+end_src
+
+~from_ase~ needs an orthorhombic cell. The analysed species is oxygen
+by default (~select="O"~). Hydrogen positions stay on the frame so
+~bonded="auto"~ can build a hydrogen-bond graph.
 
 * Single-site models (mW)
 
@@ -34,9 +44,15 @@ labelled = frame.to_ase()           # arrays['ice_type'] after CHILL
 frame = ds.from_ase(atoms, select="O", bonded="cutoff")
 #+end_src
 
-~select~ is a chemical symbol, an atomic number, or ~None~ (every atom).
+~select~ is a chemical symbol, an atomic number, or ~None~ (every
+atom). ~bonded~ is ~auto~, ~hbond~, or ~cutoff~. Use ~cutoff~ when the
+~Atoms~ have no hydrogen.
 
 * Notes
 
-The engine repository does not install Python. Build or install
-[[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]].
+- ~Frame~ is the high-level object. ~pydseams.yoda~ is the compiled
+  engine module (~_core~ and ~cyoda~ are aliases of ~yoda~).
+- ~to_ase~ writes ~arrays['ice_type']~ after ~chill~ / ~chill_plus~.
+  After ~cages()~ it also writes per-atom ~hc~ and ~ddc~ flags.
+- Optional extra ~pydseams[solvis]~ builds a solvis ~System~ from the
+  same frame (~frame.to_solvis()~).

--- a/docs/orgmode/howto/classify-cli.org
+++ b/docs/orgmode/howto/classify-cli.org
@@ -1,0 +1,55 @@
+#+TITLE: Classify a dump
+#+OPTIONS: toc:nil num:nil
+
+You have a LAMMPS water dump and want counts. Flags and the full
+surface live on [[file:../reference/cli.org][seams CLI]]. Measured
+numbers for the in-tree mixed frame live in
+[[file:../tutorials/bulk-ice.org][the mixed TIP4P tutorial]].
+
+* One frame
+
+#+begin_src bash
+seams read FILE
+seams chill-plus FILE --cutoff 3.5 --type 2
+seams cages FILE --type 2
+#+end_src
+
+~chill~ is the original CHILL rule. ~chill-plus~ is CHILL+.
+~chill_plus~ is a CLI alias of ~chill-plus~.
+
+* Type
+
+~--type 0~ (default) guesses type 2 then type 1. Mixed water dumps in
+this tree use type 2 oxygen. Single-site mW dumps use type 1.
+
+#+begin_src bash
+seams chill-plus FILE --type 2
+seams cages input/traj/mW_cubic.lammpstrj --type 1
+#+end_src
+
+* Frame range
+
+Frames are 1-based. ~--last~ is inclusive. ~--jobs~ walks the range
+via ~forEachLammpsFrame~ (~--jobs 1~ is serial).
+
+#+begin_src bash
+seams chill-plus FILE --frame 1 --last 10 --jobs 4
+#+end_src
+
+* Bond graph for cages
+
+#+begin_src bash
+seams cages FILE --graph seeded
+seams cages FILE --graph cutoff --cutoff 3.5
+seams cages FILE --graph knn -k 4
+seams cages FILE --graph knn-union -k 4
+#+end_src
+
+~seeded~ is the CLI default: mutual four-nearest seeds, union
+completions. On a perfect cubic crystal the four graphs coincide.
+
+* Features of this binary
+
+#+begin_src bash
+seams --features
+#+end_src

--- a/docs/orgmode/howto/confined-ice.org
+++ b/docs/orgmode/howto/confined-ice.org
@@ -1,0 +1,24 @@
+#+TITLE: Confined ice
+#+OPTIONS: toc:nil num:nil
+
+Classify ice in a nanotube or a monolayer.
+
+The engine functions are ~ring::prismAnalysis~ (one-dimensional
+prisms) and ~ring::polygonRingAnalysis~ (two-dimensional sheets).
+Those names live on [[file:../reference/api.org][API]]. The ~seams~
+CLI does not expose them.
+
+Use a scripting front end:
+
+- Lua examples under ~example_lua/iceNanotube/~ in
+  [[https://github.com/d-SEAMS/yodaStruct][yodaStruct]]
+- ~Frame.find_prisms~ and ~Frame.find_polygons~ in
+  [[https://d-seams.github.io/PydSEAMSlib/][pydseams]]
+
+External dumps (figshare project 73545):
+~Quasi-1D_Nanotube_LAMMPS_Trajectory~ and
+~Monolayer_LAMMPS_Trajectory~. This repository does not ship those
+files and does not pin prism counts.
+
+For the in-tree mixed TIP4P dump, start with
+[[file:../tutorials/bulk-ice.org][the mixed TIP4P tutorial]].

--- a/docs/orgmode/howto/faq.org
+++ b/docs/orgmode/howto/faq.org
@@ -1,0 +1,52 @@
+#+TITLE: FAQ
+#+OPTIONS: toc:nil num:nil
+
+* How do I install the engine?
+
+[[file:install.org][Install the engine]]. pixi or ~nix build~.
+
+* Where is Python?
+
+[[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]].
+~pip install pydseams~. ~import pydseamslib~ is an alias of
+~pydseams~. The compiled module is ~yoda~.
+
+* Where is Lua / Fennel?
+
+[[https://github.com/d-SEAMS/yodaStruct][yodaStruct]].
+~require("dseams")~. ~require("yoda")~ still resolves to that table.
+There is no ~yodaStruct~ executable.
+
+* Why do CHILL+ and cages disagree?
+
+They answer different questions.
+[[file:../explanation/chill-plus-vs-cages.org][CHILL+ versus cages]].
+
+* What does ~--graph seeded~ mean?
+
+Mutual four-nearest seeds, union completions. It is the CLI default
+for ~cages~ only.
+
+* Which ~--type~ do I pass?
+
+Mixed water dumps in this tree: type 2 oxygen. Single-site mW dumps:
+type 1. Default ~0~ guesses type 2 then type 1.
+
+* Why is chemfiles disabled on ~nix build~?
+
+chemfiles is not in the flake closure. The default pixi lock enables
+it.
+
+* How do I turn colors off?
+
+~NO_COLOR~. ~FORCE_COLOR~ forces them on.
+
+* Does ~seams~ walk a trajectory?
+
+Yes: ~--frame N --last M --jobs J~ via ~forEachLammpsFrame~.
+~--jobs 1~ is serial.
+
+* How do I cite this?
+
+[[file:../explanation/citation.org][Citation]]. The preferred citation
+is the 2020 JCIM paper.

--- a/docs/orgmode/howto/faq.org
+++ b/docs/orgmode/howto/faq.org
@@ -46,6 +46,13 @@ it.
 Yes: ~--frame N --last M --jobs J~ via ~forEachLammpsFrame~.
 ~--jobs 1~ is serial.
 
+* How do I view a classified dump?
+
+solvis, through ~pydseams[solvis]~ (~frame.to_solvis()~). That is
+the viewer for this release. See
+[[file:solvis.org][View a classified frame]]. OVITO still opens the
+LAMMPS text the engine writes; it is not the documented path.
+
 * How do I cite this?
 
 [[file:../explanation/citation.org][Citation]]. The preferred citation

--- a/docs/orgmode/howto/index.org
+++ b/docs/orgmode/howto/index.org
@@ -1,0 +1,25 @@
+#+TITLE: How-to
+#+OPTIONS: toc:nil num:nil
+
+A how-to solves a goal you already have. It is not a learning path.
+
+| guide | goal |
+|-------+------|
+| [[file:install.org][Install the engine]] | Get a ~seams~ binary |
+| [[file:classify-cli.org][Classify a dump]] | Run ~read~ / ~chill-plus~ / ~cages~ on a file you have |
+| [[file:ase-integration.org][ASE]] | Pointer to the pydseams ASE howto |
+| [[file:confined-ice.org][Confined ice]] | Nanotube and monolayer classification |
+| [[file:faq.org][FAQ]] | Short answers |
+| [[file:troubleshooting.org][Troubleshooting]] | Symptom, cause, fix |
+
+#+begin_export rst
+.. toctree::
+   :maxdepth: 1
+
+   install
+   classify-cli
+   ase-integration
+   confined-ice
+   faq
+   troubleshooting
+#+end_export

--- a/docs/orgmode/howto/index.org
+++ b/docs/orgmode/howto/index.org
@@ -8,6 +8,7 @@ A how-to solves a goal you already have. It is not a learning path.
 | [[file:install.org][Install the engine]] | Get a ~seams~ binary |
 | [[file:classify-cli.org][Classify a dump]] | Run ~read~ / ~chill-plus~ / ~cages~ on a file you have |
 | [[file:ase-integration.org][ASE]] | Pointer to the pydseams ASE howto |
+| [[file:solvis.org][View a classified frame]] | solvis via pydseams, not OVITO |
 | [[file:confined-ice.org][Confined ice]] | Nanotube and monolayer classification |
 | [[file:faq.org][FAQ]] | Short answers |
 | [[file:troubleshooting.org][Troubleshooting]] | Symptom, cause, fix |
@@ -19,6 +20,7 @@ A how-to solves a goal you already have. It is not a learning path.
    install
    classify-cli
    ase-integration
+   solvis
    confined-ice
    faq
    troubleshooting

--- a/docs/orgmode/howto/install.org
+++ b/docs/orgmode/howto/install.org
@@ -1,0 +1,45 @@
+#+TITLE: Install the engine
+#+OPTIONS: toc:nil num:nil
+
+Get a ~seams~ binary and ~libyodaLib~. This repository does not
+install Python or Lua.
+
+* pixi
+
+#+begin_src bash
+pixi run setup
+pixi run build
+./bbdir/seams --help
+./bbdir/seams --features
+#+end_src
+
+The default pixi lock includes Highway and chemfiles. Optional pixi
+environments: ~ira~, ~sphericart~, ~nauty~, ~mpi~, ~docs~.
+
+* Nix flake
+
+#+begin_src bash
+nix build
+./result/bin/seams --help
+nix develop
+nix run . -- read input/traj/exampleTraj.lammpstrj
+#+end_src
+
+The flake turns Eigen, BLAS/LAPACK, Catch2, and Highway on when
+nixpkgs provides them. Optional wrap-git backends (vesin, chemfiles,
+readcon-core, IRA, sphericart, nauty, MPI) stay off unless the package
+is already in the closure. Binary cache: ~cachix use dseams~.
+
+The flake on/off table lives on [[file:../reference/nix.org][Nix]].
+
+* Verify
+
+#+begin_src bash
+seams --help
+seams --version
+seams --features
+#+end_src
+
+~-Dwith_python=true~ and ~-Dwith_lua=enabled~ are Meson errors that
+name [[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]] and
+[[https://github.com/d-SEAMS/yodaStruct][yodaStruct]].

--- a/docs/orgmode/howto/solvis.org
+++ b/docs/orgmode/howto/solvis.org
@@ -1,0 +1,25 @@
+#+TITLE: View a classified frame
+#+OPTIONS: toc:nil num:nil
+
+View ice labels on a dump. The engine writes LAMMPS text. The
+viewer for this release is solvis (PyVista) through
+[[https://d-seams.github.io/PydSEAMSlib/][pydseams]], not OVITO.
+
+#+begin_src bash
+pip install 'pydseams[solvis]'
+#+end_src
+
+#+begin_src python
+import pydseams as ds
+
+frame = ds.read("input/traj/exampleTraj.lammpstrj")
+frame.chill_plus()
+frame.cages()
+system = frame.to_solvis()
+#+end_src
+
+~system~ is a ~solvis.System~ on the same ~Atoms~ ~to_ase~
+returns, including ~ice_type~ / ~hc~ / ~ddc~ arrays after those
+calls. Interactive plots follow the
+[[https://github.com/amritagos/solvis][solvis examples]]. The full
+howto is [[https://d-seams.github.io/PydSEAMSlib/][pydseams solvis]].

--- a/docs/orgmode/howto/troubleshooting.org
+++ b/docs/orgmode/howto/troubleshooting.org
@@ -1,0 +1,16 @@
+#+TITLE: Troubleshooting
+#+OPTIONS: toc:nil num:nil
+
+| symptom | cause | fix |
+|---------+-------+-----|
+| ~A command and a trajectory file are required~ / exit 2 | Missing positional | ~seams read FILE~ |
+| ~unknown command~ / exit 2 | Not ~read~ / ~chill~ / ~chill-plus~ / ~cages~ | ~chill_plus~ is an alias of ~chill-plus~ |
+| ~nop 0~ | Wrong type or empty file | ~--type 2~ on TIP4P, ~--type 1~ on mW |
+| ~chemfiles: disabled~ and ~.pdb~ fails | Flake / no chemfiles | Default pixi lock, or a Meson build that finds chemfiles |
+| ~.con~ fails | readcon-core off | Enable in a Meson build that can see it; the flake does not fetch the wrap |
+| ~--jobs~ does nothing useful | OpenMP off | ~seams --features~ |
+| ~ModuleNotFoundError: pydseams~ | Wrong repository | PydSEAMSlib, not ~pixi run~ in seams-core |
+| Looking for ~yodaStruct -c lua_inputs/config.yml~ | 2020 executable | ~seams~ here; Lua library in yodaStruct |
+
+When you file an issue, include ~seams --version~, ~seams --features~,
+the command line, and a minimal dump.

--- a/docs/orgmode/index.org
+++ b/docs/orgmode/index.org
@@ -14,10 +14,10 @@
 
 d-SEAMS (Deferred Structural Elucidation Analysis for Molecular
 Simulations) classifies ice in molecular-dynamics trajectories: CHILL
-and CHILL+, Franzblau / Yuan--Cormack primitive rings, and hexagonal /
+and CHILL+, Franzblau / Yuan-Cormack primitive rings, and hexagonal /
 double-diamond cage membership.
 
-This repository is the C++ engine (~libyodaLib~) and the ~seams~ CLI.
+This repository is the C++ engine (=libyodaLib=) and the =seams= CLI.
 
 #+begin_src bash
 seams read water.lammpstrj
@@ -27,11 +27,18 @@ seams cages water.lammpstrj
 
 Scripting front ends are separate packages:
 
-- Python: ~pydseams~ ([[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]]), compiled module ~yoda~
-- Lua/Fennel: ~dseams~ ([[https://github.com/d-SEAMS/yodaStruct][yodaStruct]]), ~require("dseams")~
+- Python: =pydseams= ([[https://d-seams.github.io/PydSEAMSlib/][docs]],
+  [[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]]), compiled
+  module =yoda=
+- Lua/Fennel: =dseams= ([[https://d-seams.github.io/yodaStruct/][docs]],
+  [[https://github.com/d-SEAMS/yodaStruct][yodaStruct]]),
+  =require("dseams")=
 
-Build with a Nix flake (~nix build~, ~nix develop~) or with
-~pixi run setup && pixi run build && pixi run test~.
+The header *Ecosystem* menu on every page jumps between the three
+Shibuya sites.
+
+Build with a Nix flake (=nix build=, =nix develop=) or with
+=pixi run setup && pixi run build && pixi run test=.
 
 * Getting Started
 #+begin_export rst
@@ -49,7 +56,6 @@ Build with a Nix flake (~nix build~, ~nix develop~) or with
      :caption: Tutorials
 
      tutorials/bulk-ice
-     tutorials/nanotube
 #+end_export
 
 * How-To Guides

--- a/docs/orgmode/index.org
+++ b/docs/orgmode/index.org
@@ -112,6 +112,7 @@ framework.
    howto/install
    howto/classify-cli
    howto/ase-integration
+   howto/solvis
    howto/confined-ice
    howto/faq
    howto/troubleshooting

--- a/docs/orgmode/index.org
+++ b/docs/orgmode/index.org
@@ -8,16 +8,39 @@
 =========
 
 :Author: `d-SEAMS core team <https://dseams.info>`_
+
+.. grid:: 1 2 3 3
+   :gutter: 2
+   :padding: 1 1 0 0
+   :class-container: sd-text-center
+
+   .. grid-item-card:: Read
+      :link: quickstart
+      :link-type: doc
+      :class-card: sd-shadow-sm
+
+      Load a LAMMPS frame and print nop, frame, and box.
+
+   .. grid-item-card:: Classify
+      :link: tutorials/bulk-ice
+      :link-type: doc
+      :class-card: sd-shadow-sm
+
+      CHILL+ four-neighbour star: cubic, hexagonal, interfacial, water.
+
+   .. grid-item-card:: Score
+      :link: explanation/chill-plus-vs-cages
+      :link-type: doc
+      :class-card: sd-shadow-sm
+
+      Cage membership: HC is ice Ih, DDC is ice Ic, else water.
 #+end_export
 
 * Overview
 
 d-SEAMS (Deferred Structural Elucidation Analysis for Molecular
-Simulations) classifies ice in molecular-dynamics trajectories: CHILL
-and CHILL+, Franzblau / Yuan-Cormack primitive rings, and hexagonal /
-double-diamond cage membership.
-
-This repository is the C++ engine (=libyodaLib=) and the =seams= CLI.
+Simulations) classifies ice in molecular-dynamics trajectories. This
+repository is the C++ engine (~libyodaLib~) and the ~seams~ CLI.
 
 #+begin_src bash
 seams read water.lammpstrj
@@ -27,73 +50,108 @@ seams cages water.lammpstrj
 
 Scripting front ends are separate packages:
 
-- Python: =pydseams= ([[https://d-seams.github.io/PydSEAMSlib/][docs]],
+- Python: ~pydseams~ ([[https://d-seams.github.io/PydSEAMSlib/][docs]],
   [[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]]), compiled
-  module =yoda=
-- Lua/Fennel: =dseams= ([[https://d-seams.github.io/yodaStruct/][docs]],
+  module ~yoda~
+- Lua/Fennel: ~dseams~ ([[https://d-seams.github.io/yodaStruct/][docs]],
   [[https://github.com/d-SEAMS/yodaStruct][yodaStruct]]),
-  =require("dseams")=
+  ~require("dseams")~
 
 The header *Ecosystem* menu on every page jumps between the three
 Shibuya sites.
 
-Build with a Nix flake (=nix build=, =nix develop=) or with
-=pixi run setup && pixi run build && pixi run test=.
+Build with a Nix flake (~nix build~, ~nix develop~) or with
+~pixi run setup && pixi run build && pixi run test~.
 
-* Getting Started
+* Suite stack
+
 #+begin_export rst
-  .. toctree::
-     :maxdepth: 1
-     :caption: Getting Started
+.. mermaid::
 
-     quickstart
+   flowchart TB
+     subgraph engine["seams-core"]
+       LIB[libyodaLib]
+       CLI[seams CLI]
+     end
+     subgraph fronts["Front ends"]
+       PY[pydseams Frame]
+       LUA["require(\"dseams\")"]
+     end
+     DUMP[LAMMPS / XYZ / chemfiles / con] --> LIB
+     LIB --> CLI
+     LIB --> PY
+     LIB --> LUA
+     CLI --> OUT[stdout counts]
+     PY --> ASE[ASE / solvis extras]
 #+end_export
 
-* Tutorials
-#+begin_export rst
-  .. toctree::
-     :maxdepth: 1
-     :caption: Tutorials
+* Documentation structure
 
-     tutorials/bulk-ice
+This documentation follows the [[https://diataxis.fr/][Diataxis]]
+framework.
+
+#+begin_export rst
+.. toctree::
+   :maxdepth: 1
+   :caption: Getting Started
+
+   quickstart
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Tutorials
+
+   tutorials/index
+   tutorials/bulk-ice
+
+.. toctree::
+   :maxdepth: 1
+   :caption: How-to
+
+   howto/index
+   howto/install
+   howto/classify-cli
+   howto/ase-integration
+   howto/confined-ice
+   howto/faq
+   howto/troubleshooting
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Explanation
+
+   explanation/index
+   explanation/architecture
+   explanation/chill-plus-vs-cages
+   explanation/citation
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Reference
+
+   reference/index
+   reference/cli
+   reference/data-formats
+   reference/nix
+   reference/api
+   reference/glossary
+   changelog
+
+.. toctree::
+   :maxdepth: 1
+   :caption: Development
+
+   contributing/index
 #+end_export
 
-* How-To Guides
-#+begin_export rst
-  .. toctree::
-     :maxdepth: 1
-     :caption: How-To Guides
+* Related projects
 
-     howto/ase-integration
-#+end_export
+- [[https://d-seams.github.io/PydSEAMSlib/][pydseams]] :: Python Frame API on ~yoda~
+- [[https://d-seams.github.io/yodaStruct/][dseams (Lua)]] :: ~require("dseams")~ and Fennel
+- [[https://dseams.info][dseams.info]] :: project site
 
-* Explanation
-#+begin_export rst
-  .. toctree::
-     :maxdepth: 1
-     :caption: Explanation
+* License
 
-     explanation/architecture
-#+end_export
-
-* Reference
-#+begin_export rst
-  .. toctree::
-     :maxdepth: 2
-     :caption: Reference
-
-     reference/cli
-     reference/nix
-     reference/api
-     reference/data-formats
-#+end_export
-
-* Development
-#+begin_export rst
-  .. toctree::
-     :maxdepth: 2
-     :caption: Development
-
-     contributing/index
-     changelog
-#+end_export
+MIT. Cite the 2020 JCIM paper (DOI
+[[https://doi.org/10.1021/acs.jcim.0c00031][10.1021/acs.jcim.0c00031]]).
+See [[file:explanation/citation.org][Citation]].

--- a/docs/orgmode/quickstart.org
+++ b/docs/orgmode/quickstart.org
@@ -1,8 +1,10 @@
 #+TITLE: Quickstart
 #+OPTIONS: toc:nil num:nil
 
-Classify ice on the in-tree mixed TIP4P example
-(~input/traj/exampleTraj.lammpstrj~, 250 waters).
+Build the engine, read a frame, and print what this binary linked.
+
+The in-tree mixed TIP4P dump is ~input/traj/exampleTraj.lammpstrj~
+(750 atoms, 250 waters; type 2 is oxygen).
 
 * Install the engine
 
@@ -19,8 +21,11 @@ pixi:
 #+begin_src bash
 pixi run setup
 pixi run build
-./bbdir/src/seams --help
+./bbdir/seams --help
 #+end_src
+
+Either path produces ~libyodaLib~ and the ~seams~ CLI. This repository
+does not install Python or Lua.
 
 * Read a frame
 
@@ -28,25 +33,33 @@ pixi run build
 seams read input/traj/exampleTraj.lammpstrj
 #+end_src
 
-Expected shape of the line: ~nop 250 frame 1 box ...~.
+The line is ~nop 250 frame 1 box ...~ after the oxygen guess (type 2,
+then type 1). Pass ~--type 2~ to skip the guess.
 
-* CHILL+
+* Features of this build
+
+#+begin_src bash
+seams --features
+#+end_src
+
+Each line is a compile-time backend: OpenMP, MPI, Highway SIMD, vesin,
+chemfiles, readcon-core, IRA/SOFI, sphericart, nauty. The Nix flake
+turns Eigen, BLAS/LAPACK, Catch2 and Highway on when nixpkgs provides
+them. Optional wrap-git backends stay off unless a package is already
+in the closure. ~pixi~ enables what conda-forge put in the environment
+(Highway and chemfiles are in the default pixi lock).
+
+* CHILL+ and cages
 
 #+begin_src bash
 seams chill-plus input/traj/exampleTraj.lammpstrj --cutoff 3.5 --type 2
-#+end_src
-
-On this fixture the four-neighbour labels are 42 cubic, 65 hexagonal,
-58 interfacial and 85 water.
-
-* Cages
-
-#+begin_src bash
 seams cages input/traj/exampleTraj.lammpstrj --type 2
 #+end_src
 
-The default bond graph is ~--graph seeded~ (mutual four-nearest seeds,
-union completions). This mixed frame has no complete HC or DDC.
+On this fixture the four-neighbour labels are 42 cubic, 65 hexagonal,
+58 interfacial and 85 water. The default bond graph is ~--graph seeded~
+(mutual four-nearest seeds, union completions). This mixed frame has
+no complete HC or DDC: cage membership is not the CHILL+ star.
 
 * Python and Lua
 
@@ -67,16 +80,7 @@ print(dseams.chill_plus(cloud, {cutoff = 3.5}))
 #+end_src
 
 Install those from
-[[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]] and
-[[https://github.com/d-SEAMS/yodaStruct][yodaStruct]].
-
-* Features of this build
-
-#+begin_src bash
-seams --features
-#+end_src
-
-Optional backends (vesin, chemfiles, readcon-core, IRA, sphericart,
-nauty, MPI) stay off unless the Meson probe finds them. The Nix flake
-enables Eigen, BLAS/LAPACK, Catch2 and Highway when nixpkgs provides
-them.
+[[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]] (~pydseams~,
+compiled module ~yoda~) and
+[[https://github.com/d-SEAMS/yodaStruct][yodaStruct]]
+(~require("dseams")~). ~import pydseamslib~ is an alias of ~pydseams~.

--- a/docs/orgmode/quickstart.org
+++ b/docs/orgmode/quickstart.org
@@ -56,8 +56,8 @@ seams chill-plus input/traj/exampleTraj.lammpstrj --cutoff 3.5 --type 2
 seams cages input/traj/exampleTraj.lammpstrj --type 2
 #+end_src
 
-On this fixture the four-neighbour labels are 42 cubic, 65 hexagonal,
-58 interfacial and 85 water. The default bond graph is ~--graph seeded~
+On this fixture the four-neighbour labels are 12 interfacial
+clathrate and 238 water. The default bond graph is ~--graph seeded~
 (mutual four-nearest seeds, union completions). This mixed frame has
 no complete HC or DDC: cage membership is not the CHILL+ star.
 

--- a/docs/orgmode/quickstart.org
+++ b/docs/orgmode/quickstart.org
@@ -63,24 +63,16 @@ no complete HC or DDC: cage membership is not the CHILL+ star.
 
 * Python and Lua
 
-The engine CLI is not a scripting host.
-
-#+begin_src python
-import pydseams as ds
-
-frame = ds.read("input/traj/exampleTraj.lammpstrj")
-print(frame.chill_plus())
-print(frame.cages())
-#+end_src
-
-#+begin_src lua
-local dseams = require("dseams")
-local cloud = dseams.read("input/traj/exampleTraj.lammpstrj")
-print(dseams.chill_plus(cloud, {cutoff = 3.5}))
-#+end_src
-
-Install those from
-[[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]] (~pydseams~,
-compiled module ~yoda~) and
+The engine CLI is not a scripting host. Install
+[[https://github.com/d-SEAMS/PydSEAMSlib][pydseams]] (~pip install
+pydseams~, compiled module ~yoda~) or
 [[https://github.com/d-SEAMS/yodaStruct][yodaStruct]]
 (~require("dseams")~). ~import pydseamslib~ is an alias of ~pydseams~.
+
+The Frame tutorial is
+[[https://d-seams.github.io/PydSEAMSlib/][pydseams docs]].
+Lua is [[https://d-seams.github.io/yodaStruct/][dseams docs]].
+
+The full install matrix is [[file:howto/install.org][Install]].
+The mixed-frame walkthrough is
+[[file:tutorials/bulk-ice.org][Classify ice on the mixed TIP4P example]].

--- a/docs/orgmode/reference/api.org
+++ b/docs/orgmode/reference/api.org
@@ -1,14 +1,16 @@
 #+TITLE: API Reference
 #+OPTIONS: toc:nil num:nil
 
-This page names the live entry points and the C++ functions they call.
-The generated pages under =api/= are the Doxygen comments from the
-public headers, converted by doxyrest. This is not a dump of
-~pydseamslib._core~.
+Lookup for the C++ identifiers in =src/include/internal=. Generated
+pages under =api/= are the Doxygen comments from those headers,
+converted by doxyrest. This is not a dump of ~pydseamslib._core~ and
+it is not a tutorial.
 
-* Where to start
+* Fronts
 
-Four fronts, one engine (~libyodaLib~).
+Four fronts, one engine (~libyodaLib~). Flags live on
+[[file:cli.org][seams CLI]]. Formats live on
+[[file:data-formats.org][data formats]].
 
 | Front | Package | First call |
 |-------+---------+------------|
@@ -17,71 +19,18 @@ Four fronts, one engine (~libyodaLib~).
 | Lua | [[https://github.com/d-SEAMS/yodaStruct][yodaStruct]] | ~require("dseams")~ |
 | Compiled Python | PydSEAMSlib | ~pydseams.yoda~ (~_core~ and ~cyoda~ are aliases) |
 
-** ~seams~ CLI
+~pydseams.yoda~ registers the C++ spellings below
+(~getCorrelPlus~, ~ringNetwork~, ~topoBulkCriteria~, ...).
 
-The engine command lives here. Flags and examples are on
-[[file:cli.org][seams CLI]].
+* Doxyrest wiring
 
-#+begin_src bash
-seams read input/traj/exampleTraj.lammpstrj
-seams chill-plus input/traj/exampleTraj.lammpstrj --cutoff 3.5 --type 2
-seams cages input/traj/exampleTraj.lammpstrj --graph seeded
-#+end_src
+~pixi run -e docs doxybuild~ runs from =docs/source=:
 
-** ~pydseams.Frame~
-
-High-level object in PydSEAMSlib. One frame, then the same analyses
-the CLI runs.
-
-#+begin_src python
-import pydseams as ds
-
-frame = ds.read("input/traj/exampleTraj.lammpstrj")
-print(frame.chill_plus())
-print(frame.cages())
-#+end_src
-
-** ~require("dseams")~
-
-Lua (and Fennel) table in yodaStruct. ~require("yoda")~ still resolves
-to that table.
-
-#+begin_src lua
-local dseams = require("dseams")
-local cloud = dseams.read("input/traj/exampleTraj.lammpstrj")
-print(dseams.chill_plus(cloud, {cutoff = 3.5}))
-#+end_src
-
-** ~pydseams.yoda~
-
-Compiled registrations of the C++ functions below. Use this when the
-Frame helpers are not enough and you need the same names as the
-headers (~getCorrelPlus~, ~ringNetwork~, ~topoBulkCriteria~, ...).
-
-* What doxyrest generates
-
-~pixi run -e docs doxybuild~ runs Doxygen on
-=src/include/internal= and doxyrest writes =docs/source/api/=. Tests
-and =src/include/external= are excluded.
-
-| Header | Namespace | Role |
-|--------+-----------+------|
-| =mol_sys.hpp= | ~molSys~ | ~Point~, ~PointCloud~, bond and ice enums |
-| =seams_input.hpp= | ~sinp~ | LAMMPS / XYZ / chemfiles / readcon readers |
-| =seams_output.hpp= | ~sout~ | dump, cage, ring, and cluster writers |
-| =neighbours.hpp= | ~nneigh~ | cutoff, k-nearest, and skin neighbour lists |
-| =bop.hpp= | ~chill~, ~sph~ | CHILL, CHILL+, ~q6~, Steinhardt ~ql~ |
-| =franzblau.hpp= | ~primitive~ | Franzblau primitive rings |
-| =ring.hpp= | ~ring~ | ring helpers and ~strucType~ |
-| =topo_bulk.hpp= | ~ring~, ~prism3~ | HC / DDC search, bulk polygons |
-| =topo_one_dim.hpp= | ~ring~ | ice-nanotube prisms |
-| =topo_two_dim.hpp= | ~ring~ | monolayer polygons |
-| =cage.hpp= | ~cage~ | ~Cage~, ~cageType~, ~iceType~ |
-| =cage_affiliation.hpp= | ~ring~ | claim-free HC / DDC flags |
-| =bulkTUM.hpp= | ~tum3~ | topological unit matching |
-| =bond.hpp= | ~bond~ | geometric hydrogen bonds |
-
-The generated tree (after a docs build):
+1. ~doxygen Doxyfile_seams.cfg~ -- ~INPUT~ is
+   =../../src/include/internal= (~EXTRACT_ALL=YES~, private members
+   off). =src/include/external= and =tests/= are excluded.
+2. ~doxyrest -c doxyrest-config.lua~ -- reads =xml/index.xml=, writes
+   =api/index.rst~ with title ~C++ headers (doxyrest)~.
 
 #+begin_export rst
 .. toctree::
@@ -90,6 +39,42 @@ The generated tree (after a docs build):
 
    ../api/index
 #+end_export
+
+* Headers
+
+Every file under =src/include/internal=.
+
+| Header | Namespace | Role |
+|--------+-----------+------|
+| =mol_sys.hpp= | ~molSys~ | ~Point~, ~PointCloud~, bond and ice enums |
+| =seams_input.hpp= | ~sinp~ | LAMMPS / XYZ / chemfiles / readcon readers |
+| =seams_output.hpp= | ~sout~ | dump, cage, ring, and cluster writers |
+| =neighbours.hpp= | ~nneigh~ | cutoff, k-nearest, skin neighbour lists |
+| =bop.hpp= | ~chill~, ~sph~ | CHILL, CHILL+, ~q6~, Steinhardt ~ql~ |
+| =franzblau.hpp= | ~primitive~ | Franzblau primitive rings |
+| =ring.hpp= | ~ring~ | ring helpers and ~strucType~ |
+| =topo_bulk.hpp= | ~ring~, ~prism3~ | HC / DDC search, bulk polygons |
+| =topo_one_dim.hpp= | ~ring~ | ice-nanotube prisms |
+| =topo_two_dim.hpp= | ~ring~ | monolayer polygons |
+| =cage.hpp= | ~cage~ | ~Cage~, ~cageType~, ~iceType~ |
+| =cage_affiliation.hpp= | ~ring~ | claim-free HC / DDC flags |
+| =cage_canon.hpp= | ~cage~ | nauty canonical certificates |
+| =bulkTUM.hpp= | ~tum3~ | topological unit matching |
+| =bond.hpp= | ~bond~ | geometric hydrogen bonds |
+| =absOrientation.hpp= | ~absor~ | Horn absolute orientation |
+| =pntCorrespondence.hpp= | ~pntToPnt~ | reference / target point sets |
+| =shapeMatch.hpp= | ~match~ | prism shape-matching |
+| =cluster.hpp= | ~clump~ | Stillinger ice clusters |
+| =order_parameter.hpp= | ~topoparam~ | height% and coverage area |
+| =rdf2d.hpp= | ~rdf2~ | in-plane radial distribution |
+| =selection.hpp= | ~gen~, ~ring~ | type and slice selections |
+| =generic.hpp= | ~gen~ | periodic distance, angles, medians |
+| =structure_desc.hpp= | ~chill~ | SOAP, template overlay, linear classifier |
+| =voronoi_qlm.hpp= | ~chill~ | Voronoi-weighted Steinhardt |
+| =ira_sofi.hpp= | ~ira~ | IRA match and SOFI point groups |
+| =sphericart_ylm.hpp= | ~seams::sphericart_ylm~ | batched Cartesian ~Y_lm~ |
+| =steinhardt_device.hpp= | ~seams::steinhardt~ | host / MPI / offload Steinhardt kernel |
+| =simd_distance.hpp= | ~seams~ | Highway periodic distance |
 
 * C++ functions a caller uses
 
@@ -106,11 +91,31 @@ same spellings.
 | ~sinp::readXYZ~ | =seams_input.hpp= | XYZ coordinates |
 | ~sinp::nLammpsFrames~ | =seams_input.hpp= | ~ITEM: TIMESTEP~ count |
 | ~sinp::forEachLammpsFrame~ | =seams_input.hpp= | walk ~[first, last]~, optional OpenMP |
+| ~sinp::dropLammpsDumpIndex~ | =seams_input.hpp= | drop a cached dump session |
 | ~sinp::readChemfiles~ | =seams_input.hpp= | PDB / GRO / DCD / ... when chemfiles is on |
 | ~sinp::readCon~ | =seams_input.hpp= | eOn =.con= when readcon-core is on |
+| ~sinp::readBonds~ | =seams_input.hpp= | ring / bond ID file |
+| ~sinp::atomInSlice~ | =seams_input.hpp= | closed-interval slice test (~lo == hi~ ignores that axis) |
 | ~sout::writeDump~ | =seams_output.hpp= | LAMMPS dump of a ~PointCloud~ |
 | ~sout::writeAllCages~ | =seams_output.hpp= | every HC and DDC into =cages/= |
 | ~sout::writeLAMMPSdataTopoBulk~ | =seams_output.hpp= | bulk HC / DDC data file |
+
+** Neighbours (~nneigh~)
+
+Rows are central atom then neighbours. ID-keyed lists carry a
+leading self entry. Index-keyed lists come from
+~neighbourListByIndex~.
+
+| Function | Header | Role |
+|----------+--------+------|
+| ~nneigh::neighListO~ | =neighbours.hpp= | cutoff list, one type |
+| ~nneigh::neighList~ | =neighbours.hpp= | cutoff list, two types |
+| ~nneigh::halfNeighList~ | =neighbours.hpp= | half cutoff list |
+| ~nneigh::neighbourListByIndex~ | =neighbours.hpp= | convert IDs to cloud indices |
+| ~nneigh::kNearestNeighbourList~ | =neighbours.hpp= | mutual or union k-nearest |
+| ~nneigh::bondGraphFromName~ | =neighbours.hpp= | ~cutoff~ / ~knn~ / ~knn-union~ |
+| ~nneigh::SkinNeighborList~ | =neighbours.hpp= | LAMMPS-skin persistent list |
+| ~nneigh::shellSeparation~ | =neighbours.hpp= | ~{max d_k, min d_{k+1}}~ certificate |
 
 ** CHILL (~chill~)
 
@@ -118,13 +123,20 @@ same spellings.
 |----------+--------+------|
 | ~chill::chillRule~ / ~chill::chillPlusRule~ | =bop.hpp= | published water thresholds |
 | ~chill::bondClassifier~ | =bop.hpp= | look up a named rule set |
+| ~chill::registerBondClassifier~ | =bop.hpp= | add or replace a named rule |
 | ~chill::classifyBonds~ | =bop.hpp= | fill ~Point::c_ij~ under a rule |
 | ~chill::getCorrel~ / ~chill::getIceType~ | =bop.hpp= | CHILL bonds and ice labels |
+| ~chill::getIceTypeNoPrint~ | =bop.hpp= | CHILL labels, no file |
 | ~chill::getCorrelPlus~ / ~chill::getIceTypePlus~ | =bop.hpp= | CHILL+ bonds and ice labels |
 | ~chill::getIceTypePlusNoPrint~ | =bop.hpp= | CHILL+ labels, no file |
 | ~chill::getq6~ | =bop.hpp= | per-atom ~q6~ |
 | ~chill::reclassifyWater~ | =bop.hpp= | ~q6~ reclassification of liquid |
 | ~chill::steinhardtQl~ | =bop.hpp= | local and Lechner-Dellago ~ql~ / ~qlBar~ |
+| ~chill::steinhardtQlVoronoi~ | =voronoi_qlm.hpp= | facet-area weighted ~ql~ |
+| ~chill::voronoiFacetWeights~ | =voronoi_qlm.hpp= | Voronoi neighbours and area weights |
+| ~chill::classifyTemplates~ | =structure_desc.hpp= | FCC / HCP / BCC / SC overlay |
+| ~chill::soapSpectrum~ / ~chill::soapSpectrumAll~ | =structure_desc.hpp= | Bartok SOAP |
+| ~chill::voronoiFeature~ / ~chill::voronoiFeatures~ | =structure_desc.hpp= | ~[q4, q6, q8]~ |
 
 Ice labels are ~molSys::atom_state_type~: ~cubic~, ~hexagonal~,
 ~water~, ~interfacial~, ~clathrate~, ~interClathrate~,
@@ -134,8 +146,7 @@ Ice labels are ~molSys::atom_state_type~: ~cubic~, ~hexagonal~,
 ** Rings (~primitive~, ~ring~)
 
 Neighbour lists first (~nneigh::neighListO~, then
-~nneigh::neighbourListByIndex~). Rows are central atom then
-neighbours.
+~nneigh::neighbourListByIndex~).
 
 | Function | Header | Role |
 |----------+--------+------|
@@ -145,6 +156,7 @@ neighbours.
 | ~ring::polygonRingAnalysis~ | =topo_two_dim.hpp= | monolayer polygon types |
 | ~ring::bulkPolygonRingAnalysis~ | =topo_bulk.hpp= | bulk polygon types |
 | ~ring::prismAnalysis~ | =topo_one_dim.hpp= | ice-nanotube prism blocks |
+| ~ring::findPrisms~ | =topo_one_dim.hpp= | prism ring IDs |
 
 ** Cages (~cage~, ~ring~, ~tum3~)
 
@@ -157,8 +169,27 @@ neighbours.
 | ~ring::seededCageAffiliation~ | =cage_affiliation.hpp= | mutual-k seeds, union completions |
 | ~tum3::topoBulkCriteria~ | =bulkTUM.hpp= | cages plus ~ring::strucType~ |
 | ~tum3::topoUnitMatchingBulk~ | =bulkTUM.hpp= | TUM with optional cluster XYZ |
+| ~cage::canonicalCertificate~ | =cage_canon.hpp= | nauty adjacency certificate |
+| ~cage::isHexagonalPrism~ | =cage_canon.hpp= | ring graph isomorphic to HC |
 
 A ~cage::Cage~ holds a ~cage::cageType~ (~HexC~ or ~DoubleDiaC~) and
 the ring indices that make it. Per-atom cage labels are
 ~cage::iceType~ (~dummy~, ~hc~, ~ddc~, ~mixed~, ~pnc~, ~mixed2~).
 The CLI default ~--graph seeded~ is ~seededCageAffiliation~.
+
+~ring::strucType~: ~unclassified~, ~DDC~, ~HCbasal~, ~HCprismatic~,
+~bothBasal~, ~bothPrismatic~, ~Prism~, ~deformedPrism~,
+~mixedPrismRing~.
+
+** Bonds, orientation, optional backends
+
+| Function | Header | Role |
+|----------+--------+------|
+| ~bond::populateHbonds~ | =bond.hpp= | geometric H-bonds (2.42 A, 30 deg) |
+| ~bond::populateHbondsWithInputClouds~ | =bond.hpp= | same, with a hydrogen ~PointCloud~ |
+| ~absor::hornAbsOrientation~ | =absOrientation.hpp= | Horn quaternion overlay |
+| ~ira::available~ / ~ira::match~ / ~ira::pointGroup~ | =ira_sofi.hpp= | IRA overlay, SOFI point group |
+| ~ira::orient~ | =ira_sofi.hpp= | Horn-shaped quat + RMSD from IRA |
+| ~seams::sphericart_ylm::ylmCartesian~ | =sphericart_ylm.hpp= | batched Cartesian ~Y_lm~ |
+| ~clump::clusterAnalysis~ | =cluster.hpp= | largest ice cluster |
+| ~rdf2::rdf2Danalysis_AA~ | =rdf2d.hpp= | in-plane RDF |

--- a/docs/orgmode/reference/api.org
+++ b/docs/orgmode/reference/api.org
@@ -1,276 +1,164 @@
 #+TITLE: API Reference
 #+OPTIONS: toc:nil num:nil
 
-This page documents all types and functions exposed by ~pydseams.yoda~.
+This page names the live entry points and the C++ functions they call.
+The generated pages under =api/= are the Doxygen comments from the
+public headers, converted by doxyrest. This is not a dump of
+~pydseamslib._core~.
 
-* Data types
+* Where to start
 
-** PointDouble
+Four fronts, one engine (~libyodaLib~).
 
-Represents a single atom in the system.
+| Front | Package | First call |
+|-------+---------+------------|
+| CLI | this repo (~seams~) | ~seams read FILE~, ~seams chill-plus FILE~, ~seams cages FILE~ |
+| Python Frame | [[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]] | ~pydseams.Frame~ from ~pydseams.read(...)~ |
+| Lua | [[https://github.com/d-SEAMS/yodaStruct][yodaStruct]] | ~require("dseams")~ |
+| Compiled Python | PydSEAMSlib | ~pydseams.yoda~ (~_core~ and ~cyoda~ are aliases) |
 
-| Field     | Type            | Description                                   |
-|-----------+-----------------+-----------------------------------------------|
-| ~x~       | float           | X coordinate (Angstroms)                      |
-| ~y~       | float           | Y coordinate (Angstroms)                      |
-| ~z~       | float           | Z coordinate (Angstroms)                      |
-| ~c_type~  | int             | LAMMPS atom type                              |
-| ~molID~   | int             | Molecule ID                                   |
-| ~atomID~  | int             | Atom ID                                       |
-| ~iceType~ | AtomStateType   | Ice classification (set by CHILL+)            |
-| ~c_ij~    | list[Result]    | Bond-order correlations (set by getCorrelPlus) |
-| ~inSlice~ | bool            | Whether atom is in the selected slice          |
+** ~seams~ CLI
 
-** PointCloudDouble
+The engine command lives here. Flags and examples are on
+[[file:cli.org][seams CLI]].
 
-Container for a set of atoms and simulation box metadata.
-
-| Field          | Type                   | Description                    |
-|----------------+------------------------+--------------------------------|
-| ~pts~          | list[PointDouble]      | All atoms in the frame         |
-| ~nop~          | int                    | Number of particles            |
-| ~currentFrame~ | int                    | Frame index                    |
-| ~box~          | list[float]            | Box dimensions [Lx, Ly, Lz]   |
-| ~boxLow~       | list[float]            | Box lower bounds [xlo, ylo, zlo] |
-| ~idIndexMap~   | dict[int, int]         | Atom ID to index mapping       |
-
-** Result
-
-A single bond-order correlation measurement.
-
-| Field        | Type      | Description                          |
-|--------------+-----------+--------------------------------------|
-| ~classifier~ | BondType  | Bond classification (staggered, eclipsed, out_of_range) |
-| ~c_value~    | float     | Correlation value in [-1, 1]         |
-
-** Enumerations
-
-*** BondType
-
-- ~staggered~ -- eclipsed bond orientation
-- ~eclipsed~ -- staggered bond orientation
-- ~out_of_range~ -- correlation outside classification thresholds
-
-*** AtomStateType
-
-- ~cubic~ -- cubic ice (Ic)
-- ~hexagonal~ -- hexagonal ice (Ih)
-- ~water~ -- liquid water
-- ~interfacial~ -- interfacial ice
-- ~clathrate~ -- clathrate hydrate
-- ~interClathrate~ -- inter-clathrate
-- ~unclassified~ -- not yet classified
-- ~reCubic~ -- reclassified cubic
-- ~reHex~ -- reclassified hexagonal
-
-* I/O functions
-
-** readLammpsTrjreduced
-
-#+begin_src python
-cloud = yoda.readLammpsTrjreduced(
-    filename, targetFrame, typeI, isSlice, coordLow, coordHigh
-)
+#+begin_src bash
+seams read input/traj/exampleTraj.lammpstrj
+seams chill-plus input/traj/exampleTraj.lammpstrj --cutoff 3.5 --type 2
+seams cages input/traj/exampleTraj.lammpstrj --graph seeded
 #+end_src
 
-Read a LAMMPS trajectory, selecting atoms of a single type. Returns a
-~PointCloudDouble~.
+** ~pydseams.Frame~
 
-| Argument      | Type        | Description                           |
-|---------------+-------------+---------------------------------------|
-| ~filename~    | str         | Path to LAMMPS dump file              |
-| ~targetFrame~ | int         | Frame number to read (1-indexed)      |
-| ~typeI~       | int         | LAMMPS atom type to select            |
-| ~isSlice~     | bool        | Enable coordinate slice selection     |
-| ~coordLow~    | list[float] | Lower slice bounds [x, y, z]          |
-| ~coordHigh~   | list[float] | Upper slice bounds [x, y, z]          |
-
-** readLammpsTrjO
-
-Same as ~readLammpsTrjreduced~ but with argument named ~typeO~ instead of ~typeI~.
-
-** readLammpsTrj
-
-Read all atoms from a LAMMPS trajectory (no type filtering).
-
-** readXYZ
+High-level object in PydSEAMSlib. One frame, then the same analyses
+the CLI runs.
 
 #+begin_src python
-cloud = yoda.readXYZ(filename)
+import pydseams as ds
+
+frame = ds.read("input/traj/exampleTraj.lammpstrj")
+print(frame.chill_plus())
+print(frame.cages())
 #+end_src
 
-Read an XYZ format file. Returns a ~PointCloudDouble~.
+** ~require("dseams")~
 
-** readChemfiles (optional, requires chemfiles)
+Lua (and Fennel) table in yodaStruct. ~require("yoda")~ still resolves
+to that table.
 
-#+begin_src python
-cloud = yoda.readChemfiles(filename, targetFrame, typeFilter=-1)
+#+begin_src lua
+local dseams = require("dseams")
+local cloud = dseams.read("input/traj/exampleTraj.lammpstrj")
+print(dseams.chill_plus(cloud, {cutoff = 3.5}))
 #+end_src
 
-Read any trajectory format supported by chemfiles (PDB, GRO, DCD, TRR, and
-40+ others). Available when d-SEAMS is built with chemfiles.
+** ~pydseams.yoda~
 
-| Argument      | Type | Description                                    |
-|---------------+------+------------------------------------------------|
-| ~filename~    | str  | Path to trajectory file (any chemfiles format) |
-| ~targetFrame~ | int  | Frame number to read (1-indexed)               |
-| ~typeFilter~  | int  | Atomic number to filter (-1 = all atoms)       |
+Compiled registrations of the C++ functions below. Use this when the
+Frame helpers are not enough and you need the same names as the
+headers (~getCorrelPlus~, ~ringNetwork~, ~topoBulkCriteria~, ...).
 
-** readCon (optional, requires readcon-core)
+* What doxyrest generates
 
-#+begin_src python
-cloud = yoda.readCon(filename, targetFrame)
-#+end_src
+~pixi run -e docs doxybuild~ runs Doxygen on
+=src/include/internal= and doxyrest writes =docs/source/api/=. Tests
+and =src/include/external= are excluded.
 
-Read a =.con= format file used by eOn for saddle point searches. Available when
-d-SEAMS is built with readcon-core.
+| Header | Namespace | Role |
+|--------+-----------+------|
+| =mol_sys.hpp= | ~molSys~ | ~Point~, ~PointCloud~, bond and ice enums |
+| =seams_input.hpp= | ~sinp~ | LAMMPS / XYZ / chemfiles / readcon readers |
+| =seams_output.hpp= | ~sout~ | dump, cage, ring, and cluster writers |
+| =neighbours.hpp= | ~nneigh~ | cutoff, k-nearest, and skin neighbour lists |
+| =bop.hpp= | ~chill~, ~sph~ | CHILL, CHILL+, ~q6~, Steinhardt ~ql~ |
+| =franzblau.hpp= | ~primitive~ | Franzblau primitive rings |
+| =ring.hpp= | ~ring~ | ring helpers and ~strucType~ |
+| =topo_bulk.hpp= | ~ring~, ~prism3~ | HC / DDC search, bulk polygons |
+| =topo_one_dim.hpp= | ~ring~ | ice-nanotube prisms |
+| =topo_two_dim.hpp= | ~ring~ | monolayer polygons |
+| =cage.hpp= | ~cage~ | ~Cage~, ~cageType~, ~iceType~ |
+| =cage_affiliation.hpp= | ~ring~ | claim-free HC / DDC flags |
+| =bulkTUM.hpp= | ~tum3~ | topological unit matching |
+| =bond.hpp= | ~bond~ | geometric hydrogen bonds |
 
-* Neighbour list functions
+The generated tree (after a docs build):
 
-** neighListO
+#+begin_export rst
+.. toctree::
+   :maxdepth: 1
+   :caption: C++ (doxyrest)
 
-#+begin_src python
-nList = yoda.neighListO(rcutoff, yCloud, typeI)
-#+end_src
+   ../api/index
+#+end_export
 
-Build a neighbour list for atoms of a given type within a cutoff distance.
-Uses O(n) cell-list algorithm (vesin) when available, with automatic fallback
-to O(n^2) brute-force.
+* C++ functions a caller uses
 
-| Argument   | Type             | Description                     |
-|------------+------------------+---------------------------------|
-| ~rcutoff~  | float            | Cutoff distance (Angstroms)     |
-| ~yCloud~   | PointCloudDouble | Input point cloud               |
-| ~typeI~    | int              | Atom type to consider           |
+Names below are the C++ identifiers. ~pydseams.yoda~ registers the
+same spellings.
 
-Returns a list of lists. Each inner list starts with the atom's own ID followed
-by the IDs of its neighbours.
+** I/O (~sinp~, ~sout~)
 
-** neighbourListByIndex
+| Function | Header | Role |
+|----------+--------+------|
+| ~sinp::readLammpsTrj~ | =seams_input.hpp= | every atom in one LAMMPS frame (1-based) |
+| ~sinp::readLammpsTrjO~ | =seams_input.hpp= | one LAMMPS type (oxygen) |
+| ~sinp::readLammpsTrjreduced~ | =seams_input.hpp= | one type, optional coordinate slice |
+| ~sinp::readXYZ~ | =seams_input.hpp= | XYZ coordinates |
+| ~sinp::nLammpsFrames~ | =seams_input.hpp= | ~ITEM: TIMESTEP~ count |
+| ~sinp::forEachLammpsFrame~ | =seams_input.hpp= | walk ~[first, last]~, optional OpenMP |
+| ~sinp::readChemfiles~ | =seams_input.hpp= | PDB / GRO / DCD / ... when chemfiles is on |
+| ~sinp::readCon~ | =seams_input.hpp= | eOn =.con= when readcon-core is on |
+| ~sout::writeDump~ | =seams_output.hpp= | LAMMPS dump of a ~PointCloud~ |
+| ~sout::writeAllCages~ | =seams_output.hpp= | every HC and DDC into =cages/= |
+| ~sout::writeLAMMPSdataTopoBulk~ | =seams_output.hpp= | bulk HC / DDC data file |
 
-#+begin_src python
-nListIdx = yoda.neighbourListByIndex(yCloud, nList)
-#+end_src
+** CHILL (~chill~)
 
-Convert an ID-based neighbour list to an index-based neighbour list.
+| Function | Header | Role |
+|----------+--------+------|
+| ~chill::chillRule~ / ~chill::chillPlusRule~ | =bop.hpp= | published water thresholds |
+| ~chill::bondClassifier~ | =bop.hpp= | look up a named rule set |
+| ~chill::classifyBonds~ | =bop.hpp= | fill ~Point::c_ij~ under a rule |
+| ~chill::getCorrel~ / ~chill::getIceType~ | =bop.hpp= | CHILL bonds and ice labels |
+| ~chill::getCorrelPlus~ / ~chill::getIceTypePlus~ | =bop.hpp= | CHILL+ bonds and ice labels |
+| ~chill::getIceTypePlusNoPrint~ | =bop.hpp= | CHILL+ labels, no file |
+| ~chill::getq6~ | =bop.hpp= | per-atom ~q6~ |
+| ~chill::reclassifyWater~ | =bop.hpp= | ~q6~ reclassification of liquid |
+| ~chill::steinhardtQl~ | =bop.hpp= | local and Lechner-Dellago ~ql~ / ~qlBar~ |
 
-** getNewNeighbourListByIndex
+Ice labels are ~molSys::atom_state_type~: ~cubic~, ~hexagonal~,
+~water~, ~interfacial~, ~clathrate~, ~interClathrate~,
+~unclassified~, ~reCubic~, ~reHex~. Bond labels are
+~molSys::bond_type~: ~staggered~, ~eclipsed~, ~out_of_range~.
 
-#+begin_src python
-nListIdx = yoda.getNewNeighbourListByIndex(yCloud, cutoff)
-#+end_src
+** Rings (~primitive~, ~ring~)
 
-Build a neighbour list directly by index (combining neighbour search and index
-conversion in one step).
+Neighbour lists first (~nneigh::neighListO~, then
+~nneigh::neighbourListByIndex~). Rows are central atom then
+neighbours.
 
-* Bond functions
+| Function | Header | Role |
+|----------+--------+------|
+| ~primitive::ringNetwork~ | =franzblau.hpp= | Franzblau primitive rings, by index |
+| ~primitive::RingUpdater~ | =franzblau.hpp= | same rings, incremental across frames |
+| ~ring::getSingleRingSize~ | =ring.hpp= | keep rings of one size |
+| ~ring::polygonRingAnalysis~ | =topo_two_dim.hpp= | monolayer polygon types |
+| ~ring::bulkPolygonRingAnalysis~ | =topo_bulk.hpp= | bulk polygon types |
+| ~ring::prismAnalysis~ | =topo_one_dim.hpp= | ice-nanotube prism blocks |
 
-** populateHbonds
+** Cages (~cage~, ~ring~, ~tum3~)
 
-#+begin_src python
-hbonds = yoda.populateHbonds(filename, yCloud, nList, targetFrame, Htype)
-#+end_src
+| Function | Header | Role |
+|----------+--------+------|
+| ~ring::findHC~ / ~ring::findDDC~ | =topo_bulk.hpp= | hexagonal and double-diamond cages |
+| ~ring::topoBulkAnalysis~ | =topo_bulk.hpp= | HC / DDC classification of the frame |
+| ~ring::cageAffiliation~ | =cage_affiliation.hpp= | claim-free per-ring HC / DDC flags |
+| ~ring::AffiliationUpdater~ | =cage_affiliation.hpp= | same flags, incremental |
+| ~ring::seededCageAffiliation~ | =cage_affiliation.hpp= | mutual-k seeds, union completions |
+| ~tum3::topoBulkCriteria~ | =bulkTUM.hpp= | cages plus ~ring::strucType~ |
+| ~tum3::topoUnitMatchingBulk~ | =bulkTUM.hpp= | TUM with optional cluster XYZ |
 
-Build a hydrogen bond network by reading hydrogen positions from the trajectory
-and applying geometric criteria.
-
-| Argument      | Type             | Description                     |
-|---------------+------------------+---------------------------------|
-| ~filename~    | str              | Path to LAMMPS dump file        |
-| ~yCloud~      | PointCloudDouble | Oxygen point cloud              |
-| ~nList~       | list[list[int]]  | Oxygen neighbour list           |
-| ~targetFrame~ | int              | Frame number (1-indexed)        |
-| ~Htype~       | int              | Hydrogen atom type              |
-
-Returns a list of lists with the same structure as the neighbour list, but
-containing only hydrogen-bonded pairs.
-
-* CHILL+ functions
-
-** getCorrelPlus
-
-#+begin_src python
-cloud = yoda.getCorrelPlus(yCloud, nList, isSlice)
-#+end_src
-
-Compute CHILL+ bond-order correlations. Populates the ~c_ij~ field on each atom
-in the returned cloud.
-
-** getIceTypePlus
-
-#+begin_src python
-cloud = yoda.getIceTypePlus(yCloud, nList, path, firstFrame, isSlice, outputFileName)
-#+end_src
-
-Run full CHILL+ classification and write results to a file. Sets the ~iceType~
-field on each atom.
-
-** getq6
-
-#+begin_src python
-q6 = yoda.getq6(yCloud, nList, isSlice)
-#+end_src
-
-Compute the q6 bond order parameter for each atom.
-
-** reclassifyWater
-
-#+begin_src python
-cloud = yoda.reclassifyWater(yCloud, q6)
-#+end_src
-
-Reclassify water molecules using q6 values.
-
-* Ring analysis functions
-
-** ringNetwork
-
-#+begin_src python
-rings = yoda.ringNetwork(nList, maxDepth)
-#+end_src
-
-Find primitive rings in the network using the Franzblau algorithm.
-
-| Argument   | Type            | Description                      |
-|------------+-----------------+----------------------------------|
-| ~nList~    | list[list[int]] | Index-based neighbour list       |
-| ~maxDepth~ | int             | Maximum ring size to search for  |
-
-Returns a list of rings, where each ring is a list of atom indices.
-
-** polygonRingAnalysis
-
-Classify rings by polygon type for 2D systems (sheets).
-
-** bulkPolygonRingAnalysis
-
-Classify rings by polygon type for bulk (3D) systems.
-
-** prismAnalysis
-
-Find and classify prismatic cages in the ring network.
-
-* Topological unit matching (TUM)
-
-** topoBulkCriteria
-
-#+begin_src python
-yoda.topoBulkCriteria(path, rings, nList, yCloud, firstFrame, numHC, numDDC, ringType)
-#+end_src
-
-Apply topological criteria to identify hexagonal cages (HC) and double-diamond
-cages (DDC) in bulk ice.
-
-** topoUnitMatchingBulk
-
-Run full TUM analysis for bulk systems, including optional cluster analysis.
-
-* Output functions
-
-** writeDump
-
-#+begin_src python
-yoda.writeDump(yCloud, path, outFile)
-#+end_src
-
-Write the point cloud to a LAMMPS dump file.
+A ~cage::Cage~ holds a ~cage::cageType~ (~HexC~ or ~DoubleDiaC~) and
+the ring indices that make it. Per-atom cage labels are
+~cage::iceType~ (~dummy~, ~hc~, ~ddc~, ~mixed~, ~pnc~, ~mixed2~).
+The CLI default ~--graph seeded~ is ~seededCageAffiliation~.

--- a/docs/orgmode/reference/cli.org
+++ b/docs/orgmode/reference/cli.org
@@ -2,8 +2,8 @@
 #+OPTIONS: toc:nil num:nil
 
 The engine command is ~seams~. It uses Argum (the same parser as
-eonclient). Help, errors and ice-type counts are colorized.
-~NO_COLOR~ / ~FORCE_COLOR~ apply.
+eonclient). Help, errors, ice-type counts and ~--features~ are
+colorized. ~NO_COLOR~ turns colors off; ~FORCE_COLOR~ turns them on.
 
 #+begin_src text
 seams --help
@@ -15,17 +15,77 @@ seams chill-plus FILE
 seams cages FILE
 #+end_src
 
+* Commands
+
+| command | action |
+|---------+--------|
+| ~read~ | print ~nop~, 1-based ~frame~, and box lengths |
+| ~chill~ | CHILL four-neighbour labels |
+| ~chill-plus~ | CHILL+ four-neighbour labels (~chill_plus~ is an alias) |
+| ~cages~ | ice score: HC = Ih, DDC = Ic, neither = water |
+
+A command and a trajectory file are required. Unknown commands exit 2.
+
 * Options
 
-| flag | meaning |
-|------+---------|
-| ~-f~, ~--frame N~ | first frame, 1-based |
-| ~--last N~ | last frame inclusive; omit for one frame |
-| ~-j~, ~--jobs N~ | OpenMP workers over a frame range |
-| ~-t~, ~--type I~ | atom type; ~0~ guesses oxygen then type 1 |
-| ~-c~, ~--cutoff A~ | neighbour cutoff (Å) |
-| ~-k N~ | ~k~ for knn / seeded cages |
-| ~--graph KIND~ | ~cutoff~ / ~knn~ / ~knn-union~ / ~seeded~ |
+| flag | default | meaning |
+|------+---------+---------|
+| ~-h~, ~--help~ | | print help and exit |
+| ~-v~, ~--version~ | | print ~seams~ and the Meson project version |
+| ~--features~ | | print compile-time backends and exit |
+| ~-f~, ~--frame N~ | ~1~ | first frame, 1-based |
+| ~--last N~ | omitted | last frame inclusive; omit for one frame |
+| ~-j~, ~--jobs N~ | ~1~ | OpenMP workers over a frame range; ~1~ is serial |
+| ~-t~, ~--type I~ | ~0~ | atom type; ~0~ guesses oxygen (type 2) then type 1 |
+| ~-c~, ~--cutoff A~ | ~3.5~ | neighbour cutoff (Angstrom) |
+| ~-k N~ | ~4~ | ~k~ for ~knn~ / ~knn-union~ / ~seeded~ cages |
+| ~--graph KIND~ | ~seeded~ | bond graph for ~cages~ |
+
+* ~--graph~
+
+Used only by ~cages~.
+
+| value | graph |
+|-------+-------|
+| ~cutoff~ | pairs inside ~--cutoff~ |
+| ~knn~ | mutual k-nearest |
+| ~knn-union~ | union k-nearest |
+| ~seeded~ | mutual four-nearest seeds, union completions |
+
+Unknown names fail at run time.
+
+* File suffix
+
+~seams~ picks a reader from the path suffix:
+
+| suffix | reader | compile-time gate |
+|--------+--------+-------------------|
+| ~.xyz~ | ~readXYZ~ | always |
+| ~.con~ | ~readCon~ | ~readcon-core~ |
+| ~.pdb~, ~.gro~, ~.dcd~ | ~readChemfiles~ | ~chemfiles~ |
+| anything else | LAMMPS dump | always |
+
+~--frame~ / ~--last~ / ~--jobs~ walk a LAMMPS dump through
+~forEachLammpsFrame~ (each worker opens its own handle). Single-frame
+~read~ / ~chill~ / ~chill-plus~ / ~cages~ work on every linked
+suffix.
+
+* ~--features~
+
+One line per backend: OpenMP, MPI, Highway SIMD, vesin neighbours,
+chemfiles, readcon-core, IRA/SOFI, sphericart, nauty. Each line is
+~enabled~ or ~disabled~.
+
+* Colors
+
+Argum's ~environmentColorStatus~:
+
+- ~NO_COLOR~ set and non-empty: colors off
+- ~FORCE_COLOR~ set and non-empty: colors on
+- otherwise TTY / ~CLICOLOR~ / ~COLORTERM~ heuristics
+
+Ice-type names in ~chill~ / ~chill-plus~ / ~cages~ counts are
+colorized the same way.
 
 * Examples
 
@@ -33,9 +93,14 @@ seams cages FILE
 seams read input/traj/exampleTraj.lammpstrj
 seams chill-plus input/traj/exampleTraj.lammpstrj --cutoff 3.5 --type 2
 seams cages input/traj/mW_cubic.lammpstrj --type 1 --graph seeded
+seams cages dump.lammpstrj --graph cutoff
+seams cages dump.lammpstrj --graph knn
+seams cages dump.lammpstrj --graph knn-union
 seams chill-plus dump.lammpstrj --frame 1 --last 50 --jobs 8
 #+end_src
 
 Lua and Python are not this binary. See
-[[https://github.com/d-SEAMS/yodaStruct][yodaStruct]] and
-[[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]].
+[[https://github.com/d-SEAMS/yodaStruct][yodaStruct]]
+(~require("dseams")~) and
+[[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]]
+(~pydseams~).

--- a/docs/orgmode/reference/cli.org
+++ b/docs/orgmode/reference/cli.org
@@ -1,9 +1,9 @@
 #+TITLE: seams CLI
 #+OPTIONS: toc:nil num:nil
 
-The engine command is ~seams~. It uses Argum (the same parser as
-eonclient). Help, errors, ice-type counts and ~--features~ are
-colorized. ~NO_COLOR~ turns colors off; ~FORCE_COLOR~ turns them on.
+The engine command is ~seams~. The parser is Argum (the same parser as
+eonclient). Help, errors, ice-type counts, and ~--features~ are
+colorized through Argum's ~environmentColorStatus~.
 
 #+begin_src text
 seams --help
@@ -15,31 +15,72 @@ seams chill-plus FILE
 seams cages FILE
 #+end_src
 
+A positional ~command~ and a positional ~file~ are required. Missing
+either, an unknown command, or a parse error exits 2.
+
 * Commands
 
-| command | action |
-|---------+--------|
-| ~read~ | print ~nop~, 1-based ~frame~, and box lengths |
-| ~chill~ | CHILL four-neighbour labels |
-| ~chill-plus~ | CHILL+ four-neighbour labels (~chill_plus~ is an alias) |
-| ~cages~ | ice score: HC = Ih, DDC = Ic, neither = water |
+The ~command~ positional help string is ~read | chill | chill-plus |
+cages~. ~chill_plus~ is an accepted alias of ~chill-plus~ (not listed
+in that help string).
 
-A command and a trajectory file are required. Unknown commands exit 2.
+| command | action | stdout |
+|---------+--------+--------|
+| ~read~ | print the loaded cloud | ~nop N frame F box Lx Ly Lz~ |
+| ~chill~ | CHILL four-neighbour labels | ~nop N~ then ~name count~ for each ice type present |
+| ~chill-plus~ | CHILL+ four-neighbour labels | same as ~chill~ |
+| ~cages~ | ice score on six-membered rings | ~nop N graph KIND hexagonal IH cubic IC water W~ |
+
+~chill~ / ~chill-plus~ call ~nneigh::neighListO~, then
+~chill::getCorrel~ / ~chill::getIceTypeNoPrint~ or
+~chill::getCorrelPlus~ / ~chill::getIceTypePlusNoPrint~. Ice names
+are the ~molSys::atom_state_type~ enumerators: ~cubic~, ~hexagonal~,
+~water~, ~interfacial~, ~clathrate~, ~interClathrate~, ~reCubic~,
+~reHex~, ~unclassified~.
+
+~cages~ reports cage membership, not CHILL labels: hexagonal = HC
+(Ih), cubic = DDC (Ic), water = neither. The bond graph is
+~--graph~.
+
+An empty cloud (~nop 0~) still prints. ~chill~ / ~chill-plus~ print
+~nop 0~. ~cages~ prints ~nop 0 graph KIND hexagonal 0 cubic 0
+water 0~.
 
 * Options
 
-| flag | default | meaning |
-|------+---------+---------|
-| ~-h~, ~--help~ | | print help and exit |
-| ~-v~, ~--version~ | | print ~seams~ and the Meson project version |
-| ~--features~ | | print compile-time backends and exit |
-| ~-f~, ~--frame N~ | ~1~ | first frame, 1-based |
-| ~--last N~ | omitted | last frame inclusive; omit for one frame |
-| ~-j~, ~--jobs N~ | ~1~ | OpenMP workers over a frame range; ~1~ is serial |
-| ~-t~, ~--type I~ | ~0~ | atom type; ~0~ guesses oxygen (type 2) then type 1 |
-| ~-c~, ~--cutoff A~ | ~3.5~ | neighbour cutoff (Angstrom) |
-| ~-k N~ | ~4~ | ~k~ for ~knn~ / ~knn-union~ / ~seeded~ cages |
-| ~--graph KIND~ | ~seeded~ | bond graph for ~cages~ |
+Names and help text are the Argum ~Option~ / ~Positional~
+definitions in =src/seams_cli.cpp=. Defaults are the C++
+initializers (Argum does not write defaults into the help).
+
+| flag | default | Argum help |
+|------+---------+------------|
+| ~-h~, ~--help~ | | ~show this help message and exit~ |
+| ~-v~, ~--version~ | | ~Print version information~ |
+| ~--features~ | | ~Print compile-time backends~ |
+| ~-f~, ~--frame N~ | ~1~ | ~First frame (1-based)~ |
+| ~--last N~ | omitted (~0~) | ~Last frame (inclusive). Omit for a single --frame~ |
+| ~-j~, ~--jobs N~ | ~1~ | ~Parallel frame workers (OpenMP). 1 is serial~ |
+| ~-t~, ~--type I~ | ~0~ | ~Atom type (0 guesses oxygen then type 1)~ |
+| ~-c~, ~--cutoff ANGSTROM~ | ~3.5~ | ~Neighbour cutoff~ |
+| ~-k N~ | ~4~ | ~k for knn / seeded cages~ |
+| ~--graph KIND~ | ~seeded~ | ~Bond graph for cages: cutoff \| knn \| knn-union \| seeded~ |
+
+~--help~, ~--version~, and ~--features~ print and exit 0 before any
+file is opened.
+
+~--cutoff~ is in Angstrom. ~-k~ also applies to ~knn-union~ (the
+same ~k~ feeds ~nneigh::kNearestNeighbourList~). ~--graph~ is used
+only by ~cages~.
+
+* ~--type~
+
+| value | single frame (~load~) | ~--last~ range (~forEachLammpsFrame~) |
+|-------+------------------------+---------------------------------------|
+| ~0~ | LAMMPS: type 2, then type 1 if that cloud is empty. chemfiles: keep every atom. XYZ: every atom is type 1 | LAMMPS: every atom (~sinp::readLammpsTrj~). Classification uses ~cloud.pts[0].type~ |
+| ~I > 0~ | LAMMPS ~readLammpsTrjO~ / chemfiles filter ~I~ | LAMMPS ~readLammpsTrjO~ with that type |
+
+XYZ always stores type 1. Classification still uses ~--type~ after
+the read (type 0 then becomes 1).
 
 * ~--graph~
 
@@ -47,45 +88,97 @@ Used only by ~cages~.
 
 | value | graph |
 |-------+-------|
-| ~cutoff~ | pairs inside ~--cutoff~ |
-| ~knn~ | mutual k-nearest |
-| ~knn-union~ | union k-nearest |
-| ~seeded~ | mutual four-nearest seeds, union completions |
+| ~seeded~ | mutual ~k~-nearest seeds, union completions (~ring::seededCageAffiliation~) |
+| ~cutoff~ | pairs inside ~--cutoff~ (~nneigh::neighListO~) |
+| ~knn~ | mutual k-nearest (~nneigh::BondGraph::KnnMutual~) |
+| ~knn-union~ | union k-nearest (~nneigh::BondGraph::KnnUnion~) |
 
-Unknown names fail at run time.
+~nneigh::bondGraphFromName~ also accepts ~knn-mutual~ and ~mutual~
+as ~knn~, and ~union~ as ~knn-union~. ~seeded~ is handled in the CLI
+and is not a ~BondGraph~ enumerator. Any other name throws
+~std::invalid_argument~ (~unknown bond graph 'NAME' (use cutoff,
+knn, knn-union)~) and ~cages~ exits 2.
+
+Candidate cutoff for the knn graphs is ~--cutoff + 1.5~.
 
 * File suffix
 
-~seams~ picks a reader from the path suffix:
+~seams~ picks a reader from the path suffix
+(~path.find_last_of('.')~):
 
 | suffix | reader | compile-time gate |
 |--------+--------+-------------------|
-| ~.xyz~ | ~readXYZ~ | always |
-| ~.con~ | ~readCon~ | ~readcon-core~ |
-| ~.pdb~, ~.gro~, ~.dcd~ | ~readChemfiles~ | ~chemfiles~ |
-| anything else | LAMMPS dump | always |
+| ~xyz~ | ~sinp::readXYZ~ | always |
+| ~con~ | ~sinp::readCon~ | ~SEAMS_HAS_READCON~ |
+| ~pdb~, ~gro~, ~dcd~ | ~sinp::readChemfiles~ | ~SEAMS_HAS_CHEMFILES~ |
+| anything else | LAMMPS dump (~readLammpsTrjO~ / ~readLammpsTrj~) | always |
 
-~--frame~ / ~--last~ / ~--jobs~ walk a LAMMPS dump through
-~forEachLammpsFrame~ (each worker opens its own handle). Single-frame
-~read~ / ~chill~ / ~chill-plus~ / ~cages~ work on every linked
-suffix.
+A build without chemfiles or readcon-core treats ~.pdb~ / ~.gro~ /
+~.dcd~ / ~.con~ as LAMMPS dumps. ~seams --features~ reports those
+gates.
+
+* Frame ranges
+
+Omit ~--last~, or set it equal to ~--frame~, for one frame. That
+path calls ~load~ and works for every linked suffix.
+
+A range (~--last~ > ~--frame~) always walks a LAMMPS dump through
+~sinp::forEachLammpsFrame~. Each OpenMP worker opens its own handle
+and seeks the shared ~ITEM: TIMESTEP~ offset table. ~--jobs 1~ is
+serial. Non-LAMMPS suffixes are not walked this way.
 
 * ~--features~
 
-One line per backend: OpenMP, MPI, Highway SIMD, vesin neighbours,
-chemfiles, readcon-core, IRA/SOFI, sphericart, nauty. Each line is
-~enabled~ or ~disabled~.
+Heading ~Compile-time features:~ then one line per backend. Each
+line is ~NAME: enabled~ or ~NAME: disabled~.
+
+| printed name | macro |
+|--------------+-------|
+| ~OpenMP~ | ~SEAMS_HAS_OPENMP~ |
+| ~MPI~ | ~SEAMS_HAS_MPI~ |
+| ~Highway SIMD~ | ~SEAMS_HAS_HWY~ |
+| ~vesin neighbours~ | ~SEAMS_HAS_VESIN~ |
+| ~chemfiles~ | ~SEAMS_HAS_CHEMFILES~ |
+| ~readcon-core~ | ~SEAMS_HAS_READCON~ |
+| ~IRA/SOFI~ | ~SEAMS_HAS_IRA~ |
+| ~sphericart~ | ~SEAMS_HAS_SPHERICART~ |
+| ~nauty~ | ~SEAMS_HAS_NAUTY~ |
 
 * Colors
 
-Argum's ~environmentColorStatus~:
+~colorizerForFile(environmentColorStatus(), stdout)~. Argum's
+~environmentColorStatus~ (first match wins):
 
-- ~NO_COLOR~ set and non-empty: colors off
-- ~FORCE_COLOR~ set and non-empty: colors on
-- otherwise TTY / ~CLICOLOR~ / ~COLORTERM~ heuristics
+| condition | result |
+|-----------+--------|
+| ~NO_COLOR~ set and non-empty | off |
+| ~FORCE_COLOR~ set and non-empty | on |
+| ~CLICOLOR_FORCE~ set, non-empty, not ~0~ / ~false~ | on |
+| ~CLICOLOR_FORCE~ is ~0~ or ~false~ | off |
+| ~CLICOLOR~ is ~0~ or ~false~ | off |
+| ~CLICOLOR~ set and non-empty | allowed (TTY decides) |
+| ~COLORTERM~ set and non-empty | allowed |
+| ~TERM=dumb~ | off |
+| otherwise | TTY / ~TERM~ heuristics |
 
-Ice-type names in ~chill~ / ~chill-plus~ / ~cages~ counts are
-colorized the same way.
+Color roles on this binary:
+
+| role | used for |
+|------+----------|
+| ~heading~ | ~d-SEAMS~ banner, ~nop~, ~Compile-time features:~ |
+| ~progName~ | ~seams~ in ~--version~; ~clathrate~, ~interClathrate~ |
+| ~longOption~ | ~frame~, ~graph~; ~cubic~, ~reCubic~ |
+| ~shortOption~ | ~box~; ~hexagonal~, ~reHex~ |
+| ~warning~ | usage line; ~interfacial~; ~enabled~ |
+| ~error~ | parse / missing-args / unknown-command; ~unclassified~; ~disabled~ |
+| uncolored | ~water~ |
+
+* Exit status
+
+| code | when |
+|------+------|
+| ~0~ | success, including ~--help~ / ~--version~ / ~--features~ |
+| ~2~ | parse error, missing command or file, unknown command, unknown ~--graph~ |
 
 * Examples
 

--- a/docs/orgmode/reference/data-formats.org
+++ b/docs/orgmode/reference/data-formats.org
@@ -1,10 +1,25 @@
 #+TITLE: Data Formats
 #+OPTIONS: toc:nil num:nil
 
-* LAMMPS trajectory format
+~seams~ and the C++ readers share one suffix table. Coordinates are
+Cartesian Angstroms. Frames are 1-based (the file's timestep value is
+not the frame index).
 
-d-SEAMS reads LAMMPS dump files in the standard text format. Each frame in the
-trajectory has the following structure:
+| suffix | reader | always compiled? |
+|--------+--------+------------------|
+| ~.lammpstrj~, ~.dump~, ~.lammps~, anything else | LAMMPS dump text | yes |
+| ~.xyz~ | ~readXYZ~ | yes |
+| ~.pdb~, ~.gro~, ~.dcd~ | ~readChemfiles~ | only with chemfiles |
+| ~.con~ | ~readCon~ | only with readcon-core |
+
+~seams --features~ reports whether chemfiles and readcon-core linked.
+Python ~pydseams.read~ and Lua ~dseams.read~ use the same suffixes.
+~pydseams.available_readers()~ lists what that wheel linked.
+
+* LAMMPS dump
+
+Default reader. Text dump, frames concatenated, each starting with
+~ITEM: TIMESTEP~.
 
 #+begin_src text
 ITEM: TIMESTEP
@@ -18,49 +33,83 @@ ITEM: BOX BOUNDS pp pp pp
 ITEM: ATOMS id mol type x y z c_peratom
 1 1 2 1.62441 -0.745636 131.621 -28.449
 2 1 1 2.11159 -0.763153 132.444 9.60885
-3 1 1 0.727051 -0.969064 131.868 9.36579
 #+end_src
 
-** Header fields
+That block is the first snapshot of
+~input/traj/exampleTraj.lammpstrj~ (750 atoms, 250 waters).
 
-- ~ITEM: TIMESTEP~ :: The simulation timestep for this frame.
-- ~ITEM: NUMBER OF ATOMS~ :: Total number of atoms in the frame.
-- ~ITEM: BOX BOUNDS~ :: Three lines giving lo/hi bounds for x, y, z. The boundary
-  flags (~pp~ = periodic-periodic) follow on the header line.
-- ~ITEM: ATOMS~ :: Column names for atom data. The required columns are ~id~,
-  ~mol~, ~type~, ~x~, ~y~, ~z~. Additional columns (like ~c_peratom~) are
-  accepted but not used by d-SEAMS.
+Required ~ITEM: ATOMS~ columns: ~type~, and one coordinate triple.
+The coordinate names follow LAMMPS ~ReaderNative~: ~x~ / ~y~ / ~z~
+if present, otherwise the first of ~xu~ / ~xs~ / ~xsu~ (and the ~y~
+and ~z~ analogues). Extra columns are ignored.
 
-** Atom type conventions
+Optional columns: ~id~, ~mol~. Missing ~mol~ falls back to ~id~.
 
-For water simulations analyzed with CHILL+ or hydrogen bond detection:
+~PointCloud.box~ is ~hi - lo~ per axis. ~PointCloud.boxLow~ is the
+lower bound. A third number on a box line is a triclinic tilt and is
+appended to ~box~.
 
-| Type ID | Atom | Notes                            |
-|---------+------+----------------------------------|
-|       1 | H    | Hydrogen, used by ~populateHbonds~ |
-|       2 | O    | Oxygen, used by ~readLammpsTrjreduced~ and ~neighListO~ |
+~seams --type 0~ (the default) reads type 2, then type 1 if that
+cloud is empty. Mixed water dumps in this tree use type 2 for oxygen
+and type 1 for hydrogen. Single-site mW dumps in this tree use type 1.
 
-These type IDs are passed as the ~typeI~ and ~Htype~ arguments to the reader and
-bond functions. Adjust them to match your LAMMPS data file.
+A live dump session caches ~ITEM: TIMESTEP~ offsets. Sequential
+~load_frame~ walks do not rescan prior snapshots. ~seams --frame N
+--last M --jobs J~ walks that table with one handle per OpenMP
+worker.
 
-** Multiple frames
+The C++ readers also accept a coordinate slice (~isSlice~,
+~coordLow~, ~coordHigh~). An atom is kept when each component lies in
+the closed interval, or when that axis has ~lo == hi~ (ignored). The
+CLI does not expose the slice.
 
-A trajectory file can contain multiple frames concatenated back to back. Each
-frame starts with ~ITEM: TIMESTEP~. The ~targetFrame~ argument to the reader
-functions selects which frame to read (1-indexed).
+* XYZ
 
-** Coordinate conventions
+Always compiled. Standard XYZ:
 
-d-SEAMS uses Cartesian coordinates in Angstroms. The box dimensions stored in
-~PointCloud.box~ are computed as ~hi - lo~ for each dimension. The lower bounds
-are stored in ~PointCloud.boxLow~.
+#+begin_src text
+12
+comment
+O 8.995 10.3859997 15.0939999
+O 6.7459998 14.2810001 15.0939999
+#+end_src
 
-* Slice selection
+~templates/hc.xyz~ is this shape (hexagonal-cage template). The first
+line is the atom count, the second line is skipped, each data line is
+~symbol x y z~. Every atom is stored as type 1. The box is the axis-
+aligned bounding box of the coordinates (~boxLow~ is the minimum);
+the comment line is not parsed for a lattice. ~seams~ routes ~.xyz~
+here and ignores ~--type~ on the read (classification still uses
+~--type~, which then sees type 1).
 
-When ~isSlice=True~ is passed to a reader function, only atoms within the
-coordinate range ~[coordLow, coordHigh]~ are included. The comparison is
-per-component: an atom is included when ~coordLow[i] <= pos[i] <= coordHigh[i]~
-for all three dimensions.
+XYZ files in this tree do not carry a periodic cell. Analyses that
+need the true box should use a LAMMPS dump.
 
-When ~isSlice=False~, the ~coordLow~ and ~coordHigh~ arguments are ignored.
-Convention is to pass ~[0, 0, 0]~ for both.
+* chemfiles (PDB, GRO, DCD)
+
+Compiled when Meson finds chemfiles (~SEAMS_HAS_CHEMFILES~). The CLI
+opens ~.pdb~, ~.gro~, and ~.dcd~ only. The C++ entry
+~readChemfiles~ accepts any path chemfiles can open.
+
+Frame ~N~ is ~read_step(N-1)~. ~--type I~ with ~I > 0~ keeps that
+numeric type; otherwise every atom is kept. Type is the chemfiles
+type or name string when it is all digits, otherwise the atomic
+number. ~box~ is the cell lengths; ~boxLow~ is the origin.
+~atomID~ is the 1-based file order. ~molID~ is the residue id when
+the format has residues.
+
+A flake build leaves chemfiles off. The default pixi environment
+ships chemfiles, so ~pixi run build~ reports ~chemfiles: enabled~.
+
+* eOn ~.con~
+
+Compiled when Meson finds readcon-core (~SEAMS_HAS_READCON~).
+~input/con/tiny_multi_cuh2.con~ is a two-frame fixture.
+
+~type~ is the atomic number from the file. ~atomID~ is the file atom
+id. ~box~ is the cell lengths; ~boxLow~ is the origin. Frame ~N~ is
+the Nth record from the iterator.
+
+A flake build leaves readcon-core off (the wrap is not downloaded).
+Enable it in a Meson build that can see the wrap or a system package,
+then ~seams --features~ reports ~readcon-core: enabled~.

--- a/docs/orgmode/reference/data-formats.org
+++ b/docs/orgmode/reference/data-formats.org
@@ -8,13 +8,52 @@ not the frame index).
 | suffix | reader | always compiled? |
 |--------+--------+------------------|
 | ~.lammpstrj~, ~.dump~, ~.lammps~, anything else | LAMMPS dump text | yes |
-| ~.xyz~ | ~readXYZ~ | yes |
-| ~.pdb~, ~.gro~, ~.dcd~ | ~readChemfiles~ | only with chemfiles |
-| ~.con~ | ~readCon~ | only with readcon-core |
+| ~.xyz~ | ~sinp::readXYZ~ | yes |
+| ~.pdb~, ~.gro~, ~.dcd~ | ~sinp::readChemfiles~ | only with ~SEAMS_HAS_CHEMFILES~ |
+| ~.con~ | ~sinp::readCon~ | only with ~SEAMS_HAS_READCON~ |
 
-~seams --features~ reports whether chemfiles and readcon-core linked.
-Python ~pydseams.read~ and Lua ~dseams.read~ use the same suffixes.
-~pydseams.available_readers()~ lists what that wheel linked.
+The CLI matches the substring after the last ~.~ (~xyz~, ~con~,
+~pdb~, ~gro~, ~dcd~). Everything else, including a path with no
+dot, is a LAMMPS dump. ~seams --features~ reports chemfiles and
+readcon-core. Python ~pydseams.read~ and Lua ~dseams.read~ use the
+same suffixes.
+
+* Type columns
+
+| reader | ~Point::type~ | ~--type 0~ | ~--type I~ (~I > 0~) |
+|--------+---------------+------------+----------------------|
+| LAMMPS | ~ITEM: ATOMS~ ~type~ column | single-frame: keep type 2, then type 1 if empty | keep type ~I~ |
+| XYZ | hard-coded ~1~ | ignored on the read | ignored on the read |
+| chemfiles | numeric ~type~ string, else numeric ~name~, else atomic number (or ~1~) | keep every atom (~typeFilter = -1~) | keep type ~I~ |
+| readcon | atomic number from the file | keep every atom | keep every atom (~--type~ is not applied) |
+
+~Point::atomID~ is the file id when the format has one, else
+1-based file order. ~Point::molID~ is ~mol~ when present, else
+~atomID~ (chemfiles: residue id when the format has residues).
+
+* Empty frames
+
+A reader that cannot fill atoms returns a cloud with ~nop == 0~
+(~pts~ empty). ~currentFrame~ is still the requested 1-based index
+when the reader knows it.
+
+| situation | result |
+|-----------+--------|
+| LAMMPS path missing or unreadable | empty cloud, ~currentFrame = targetFrame~ |
+| LAMMPS frame does not exist | empty cloud, ~currentFrame = targetFrame~ |
+| LAMMPS type filter matches nothing | ~nop == 0~ |
+| XYZ path missing | ~std::runtime_error("Wrong filepath")~ |
+| chemfiles frame out of range | cloud left as passed in (usually empty) |
+| chemfiles throws | empty cloud |
+| readcon path unreadable or frame missing | empty cloud |
+
+~seams chill~ / ~seams chill-plus~ on an empty cloud print ~nop 0~
+and return 0. ~seams cages~ prints ~nop 0 graph KIND hexagonal 0
+cubic 0 water 0~.
+
+~sinp::nLammpsFrames~ is ~0~ when the file cannot be read.
+~sinp::forEachLammpsFrame~ is a no-op when that count is ~0~, or
+when ~first > last~.
 
 * LAMMPS dump
 
@@ -41,22 +80,24 @@ That block is the first snapshot of
 Required ~ITEM: ATOMS~ columns: ~type~, and one coordinate triple.
 The coordinate names follow LAMMPS ~ReaderNative~: ~x~ / ~y~ / ~z~
 if present, otherwise the first of ~xu~ / ~xs~ / ~xsu~ (and the ~y~
-and ~z~ analogues). Extra columns are ignored.
+and ~z~ analogues ~yu~ / ~ys~ / ~ysu~, ~zu~ / ~zs~ / ~zsu~). Extra
+columns are ignored.
 
 Optional columns: ~id~, ~mol~. Missing ~mol~ falls back to ~id~.
+If both are missing, the reader uses column 0 for both.
 
 ~PointCloud.box~ is ~hi - lo~ per axis. ~PointCloud.boxLow~ is the
 lower bound. A third number on a box line is a triclinic tilt and is
 appended to ~box~.
 
-~seams --type 0~ (the default) reads type 2, then type 1 if that
-cloud is empty. Mixed water dumps in this tree use type 2 for oxygen
-and type 1 for hydrogen. Single-site mW dumps in this tree use type 1.
+Mixed water dumps in this tree use type 2 for oxygen and type 1 for
+hydrogen. Single-site mW dumps in this tree use type 1.
 
 A live dump session caches ~ITEM: TIMESTEP~ offsets. Sequential
-~load_frame~ walks do not rescan prior snapshots. ~seams --frame N
---last M --jobs J~ walks that table with one handle per OpenMP
-worker.
+walks do not rescan prior snapshots. ~seams --frame N --last M
+--jobs J~ walks that table with one handle per OpenMP worker.
+~sinp::dropLammpsDumpIndex~ drops a cached session (tests that
+rewrite a path in place).
 
 The C++ readers also accept a coordinate slice (~isSlice~,
 ~coordLow~, ~coordHigh~). An atom is kept when each component lies in
@@ -89,14 +130,14 @@ need the true box should use a LAMMPS dump.
 
 Compiled when Meson finds chemfiles (~SEAMS_HAS_CHEMFILES~). The CLI
 opens ~.pdb~, ~.gro~, and ~.dcd~ only. The C++ entry
-~readChemfiles~ accepts any path chemfiles can open.
+~sinp::readChemfiles~ accepts any path chemfiles can open.
 
 Frame ~N~ is ~read_step(N-1)~. ~--type I~ with ~I > 0~ keeps that
 numeric type; otherwise every atom is kept. Type is the chemfiles
 type or name string when it is all digits, otherwise the atomic
-number. ~box~ is the cell lengths; ~boxLow~ is the origin.
-~atomID~ is the 1-based file order. ~molID~ is the residue id when
-the format has residues.
+number (~value_or(1)~). ~box~ is the cell lengths; ~boxLow~ is the
+origin. ~atomID~ is the 1-based file order. ~molID~ is the residue
+id when the format has residues, else ~atomID~.
 
 A flake build leaves chemfiles off. The default pixi environment
 ships chemfiles, so ~pixi run build~ reports ~chemfiles: enabled~.
@@ -104,11 +145,13 @@ ships chemfiles, so ~pixi run build~ reports ~chemfiles: enabled~.
 * eOn ~.con~
 
 Compiled when Meson finds readcon-core (~SEAMS_HAS_READCON~).
-~input/con/tiny_multi_cuh2.con~ is a two-frame fixture.
+~input/con/tiny_multi_cuh2.con~ is a two-frame fixture (Cu + H,
+~con_spec_version~ 2).
 
 ~type~ is the atomic number from the file. ~atomID~ is the file atom
-id. ~box~ is the cell lengths; ~boxLow~ is the origin. Frame ~N~ is
-the Nth record from the iterator.
+id. ~molID~ is set to ~atomID~. ~box~ is ~frame->cell[0..2]~;
+~boxLow~ is the origin. Frame ~N~ is the Nth record from the
+iterator. The CLI does not type-filter ~.con~.
 
 A flake build leaves readcon-core off (the wrap is not downloaded).
 Enable it in a Meson build that can see the wrap or a system package,

--- a/docs/orgmode/reference/glossary.org
+++ b/docs/orgmode/reference/glossary.org
@@ -1,0 +1,18 @@
+#+TITLE: Glossary
+#+OPTIONS: toc:nil num:nil
+
+| term | meaning |
+|------+---------|
+| ~libyodaLib~ | C++ engine library in this repository |
+| ~seams~ | Argum CLI in this repository |
+| ~yoda~ | Compiled Python module in PydSEAMSlib (~_core~ / ~cyoda~ aliases) |
+| ~dseams~ | Lua table from ~require("dseams")~ in yodaStruct |
+| CHILL+ | Four-neighbour staggered/eclipsed star classifier |
+| CHILL | Original four-neighbour rule (~seams chill~) |
+| HC | Hexagonal cage (ice Ih, 12 waters) |
+| DDC | Double-diamond cage (ice Ic, 14 waters) |
+| ice score | Per-atom HC / DDC membership (~seams cages~) |
+| ~seeded~ | Mutual four-nearest seeds, union completions |
+| ~nop~ | Number of particles in the analysed cloud |
+| TUM | Topological unit matching |
+| ~PointCloud~ | Positions, types, box, and per-atom labels |

--- a/docs/orgmode/reference/index.org
+++ b/docs/orgmode/reference/index.org
@@ -1,0 +1,23 @@
+#+TITLE: Reference
+#+OPTIONS: toc:nil num:nil
+
+Lookup pages for the engine. Tutorials and how-tos live elsewhere.
+
+| page | what it names |
+|------+---------------|
+| [[file:cli.org][seams CLI]] | ~seams~ subcommands, flags, colors |
+| [[file:data-formats.org][data formats]] | LAMMPS dump, XYZ, chemfiles, ~.con~ |
+| [[file:api.org][API]] | C++ identifiers and the doxyrest tree |
+| [[file:nix.org][Nix flake]] | ~nix build~, ~nix develop~, flake outputs |
+| [[file:glossary.org][glossary]] | Engine terms |
+
+#+begin_export rst
+.. toctree::
+   :maxdepth: 1
+
+   cli
+   data-formats
+   api
+   nix
+   glossary
+#+end_export

--- a/docs/orgmode/reference/nix.org
+++ b/docs/orgmode/reference/nix.org
@@ -2,42 +2,60 @@
 #+OPTIONS: toc:nil num:nil
 
 The flake builds ~libyodaLib~ and the ~seams~ CLI with Meson. It does
-not build Python or Lua.
+not build Python or Lua. There are no overlays.
 
 #+begin_src bash
 nix build                  # ./result/bin/seams
 nix run . -- read input/traj/exampleTraj.lammpstrj
-nix develop                # compiler, Eigen, BLAS, Catch2, gdb, ccache
-nix flake update nixpkgs
+nix develop                # inputsFrom seams, plus gdb, ccache, clang-tools
+nix flake update           # refresh the nixpkgs pin
 nix fmt
 #+end_src
 
-~nix build~ runs the Catch2 suite (Meson ~doCheck~) plus the ~seams
-read~ / ~--help~ / ~--version~ / ~--features~ smoke tests.
+~nix build~ runs Meson ~doCheck~: the Catch2 suite plus the CLI
+smoke tests ~seams_read~, ~seams_help~, ~seams_version~,
+~seams_features~.
 
-Supported systems: ~x86_64-linux~, ~aarch64-linux~, ~x86_64-darwin~,
-~aarch64-darwin~. ~packages.default~ and ~apps.default~ are ~seams~.
-The formatter is ~nixfmt~.
+* Flake outputs
 
-* What the flake enables
+From =flake.nix=. Supported systems: ~x86_64-linux~,
+~aarch64-linux~, ~x86_64-darwin~, ~aarch64-darwin~.
 
-From ~nix/package.nix~:
+| output | value |
+|--------+-------|
+| ~packages.<system>.seams~ | =nix/package.nix= derivation |
+| ~packages.<system>.default~ | same as ~seams~ |
+| ~apps.<system>.default~ | ~${packages.default}/bin/seams~ |
+| ~checks.<system>.seams~ | the ~seams~ package |
+| ~checks.<system>.default~ | same as ~seams~ |
+| ~devShells.<system>.default~ | ~inputsFrom~ the package; extra packages ~gdb~, ~ccache~, ~clang-tools~ |
+| ~formatter.<system>~ | ~nixfmt~ |
+
+The only flake input is ~nixpkgs~ (~github:NixOS/nixpkgs/nixos-unstable~).
+
+* What the package enables
+
+From =nix/package.nix= (~pname = "seams"~, ~version = "2.2.0"~):
 
 | on | Eigen, BLAS, LAPACK, Catch2 3, Highway (~libhwy~) |
-| OpenMP | when the toolchain links a parallel region (Clang gets ~llvmPackages.openmp~) |
-| Meson flags | ~with_tests=true~, ~with_cli=true~ |
+| OpenMP | ~dependency('openmp')~ probe; Clang also gets ~llvmPackages.openmp~ |
+| Meson flags | ~with_tests=true~, ~with_cli=true~, ~with_python=false~, ~with_lua=false~, ~with_mpi=false~, ~with_openmp_offload=false~ |
 | ~mesonAutoFeatures~ | ~disabled~ |
 | wrap mode | ~nodownload~ (Meson setup hook) |
 
+The fileset is =meson.build=, =meson_options.txt=, =src=, =tests=,
+=input=, =templates=, and the wraps =readcon-core.wrap=,
+=vesin.wrap=, =robin-map.wrap=, =subprojects/packagefiles=.
+
 * What stays off
 
-| ~with_python~ | error if forced; Python is PydSEAMSlib |
-| ~with_lua~ | error if forced; Lua is yodaStruct |
-| ~with_mpi~ | disabled |
-| ~with_openmp_offload~ | disabled |
-| vesin, readcon-core | wrap-git fallbacks are not fetched |
+| ~with_python~ | Meson error if forced; Python is PydSEAMSlib |
+| ~with_lua~ | Meson error if forced; Lua is yodaStruct |
+| ~with_mpi~ | ~false~ |
+| ~with_openmp_offload~ | ~false~ |
+| vesin, readcon-core | wrap-git fallbacks are not fetched (~nodownload~) |
 | chemfiles | not in the flake closure |
-| IRA, sphericart, nauty | ~auto_features=disabled~, so the auto probes stay off |
+| IRA, sphericart, nauty | ~auto_features=disabled~, so the ~auto~ probes stay off |
 
 ~seams --features~ on a flake build therefore reports Highway (and
 OpenMP when it linked) as enabled, and vesin, chemfiles, readcon-core,
@@ -53,7 +71,8 @@ the Meson subproject.
 
 * Cachix
 
-The [[https://dseams.cachix.org/][dseams]] cache is optional:
+The [[https://dseams.cachix.org/][dseams]] cache is optional (not a
+flake input):
 
 #+begin_src bash
 nix-env -iA cachix -f https://cachix.org/api/v1/install

--- a/docs/orgmode/reference/nix.org
+++ b/docs/orgmode/reference/nix.org
@@ -1,22 +1,48 @@
 #+TITLE: Nix flake
 #+OPTIONS: toc:nil num:nil
 
+The flake builds ~libyodaLib~ and the ~seams~ CLI with Meson. It does
+not build Python or Lua.
+
 #+begin_src bash
 nix build                  # ./result/bin/seams
 nix run . -- read input/traj/exampleTraj.lammpstrj
-nix develop
+nix develop                # compiler, Eigen, BLAS, Catch2, gdb, ccache
 nix flake update nixpkgs
 nix fmt
 #+end_src
 
-~nix build~ runs the Catch2 suite (Meson install check).
+~nix build~ runs the Catch2 suite (Meson ~doCheck~) plus the ~seams
+read~ / ~--help~ / ~--version~ / ~--features~ smoke tests.
+
+Supported systems: ~x86_64-linux~, ~aarch64-linux~, ~x86_64-darwin~,
+~aarch64-darwin~. ~packages.default~ and ~apps.default~ are ~seams~.
+The formatter is ~nixfmt~.
 
 * What the flake enables
 
-Eigen, BLAS/LAPACK, Catch2, Highway when nixpkgs has them. OpenMP when
-the toolchain links it. Optional wrap-git backends (vesin,
-readcon-core) and chemfiles stay off unless a nixpkgs package is
-already in the closure.
+From ~nix/package.nix~:
+
+| on | Eigen, BLAS, LAPACK, Catch2 3, Highway (~libhwy~) |
+| OpenMP | when the toolchain links a parallel region (Clang gets ~llvmPackages.openmp~) |
+| Meson flags | ~with_tests=true~, ~with_cli=true~ |
+| ~mesonAutoFeatures~ | ~disabled~ |
+| wrap mode | ~nodownload~ (Meson setup hook) |
+
+* What stays off
+
+| ~with_python~ | error if forced; Python is PydSEAMSlib |
+| ~with_lua~ | error if forced; Lua is yodaStruct |
+| ~with_mpi~ | disabled |
+| ~with_openmp_offload~ | disabled |
+| vesin, readcon-core | wrap-git fallbacks are not fetched |
+| chemfiles | not in the flake closure |
+| IRA, sphericart, nauty | ~auto_features=disabled~, so the auto probes stay off |
+
+~seams --features~ on a flake build therefore reports Highway (and
+OpenMP when it linked) as enabled, and vesin, chemfiles, readcon-core,
+IRA/SOFI, sphericart, nauty, and MPI as disabled. Optional backends
+turn on only if a nixpkgs package is already in the closure.
 
 * Front-end flakes
 

--- a/docs/orgmode/tutorials/bulk-ice.org
+++ b/docs/orgmode/tutorials/bulk-ice.org
@@ -1,26 +1,68 @@
-#+TITLE: Bulk ice on the mixed TIP4P example
+#+TITLE: Classify ice on the mixed TIP4P example
 #+OPTIONS: toc:nil num:nil
 
-This walk uses ~input/traj/exampleTraj.lammpstrj~ from a seams-core
-checkout (250 waters, type 2 is oxygen).
+You classify one in-tree frame two ways: CHILL+ (a four-neighbour
+staggered/eclipsed star per oxygen) and topological cages (HC/DDC
+membership). The result is a labelled oxygen set and a reason the two
+scores disagree.
+
+Work from a seams-core checkout with =seams= on =PATH=. The dump is
+=input/traj/exampleTraj.lammpstrj=: one frame, 250 TIP4P waters, 750
+atoms, type 2 oxygen and type 1 hydrogen. Both classifiers use the
+oxygens.
+
+Python is a separate package
+([[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]]). The engine
+CLI is not a scripting host.
+
+* Read the frame
+
+#+begin_src bash
+seams read input/traj/exampleTraj.lammpstrj
+#+end_src
+
+The line starts =nop 250 frame 1 box ...=. The CLI guesses oxygen
+(type 2) and falls back to type 1. Pass =--type 2= on the classifiers
+so the type is explicit.
 
 * CHILL+ from the CLI
+
+CHILL+ looks at each oxygen's four nearest neighbours inside the
+cutoff. Each of those four bonds is staggered or eclipsed from the
+pair correlation =c_ij=. The star of four labels is the ice type:
+
+| label       | four-neighbour star              |
+|-------------+----------------------------------|
+| cubic       | four staggered                   |
+| hexagonal   | three staggered and one eclipsed |
+| interfacial | ice-like, not cubic or hexagonal |
+| water       | none of the above                |
 
 #+begin_src bash
 seams chill-plus input/traj/exampleTraj.lammpstrj --cutoff 3.5 --type 2
 #+end_src
 
-Four-neighbour staggered/eclipsed counts on this frame:
+The line is:
 
-| label        | atoms |
-|--------------+-------|
-| cubic        |    42 |
-| hexagonal    |    65 |
-| interfacial  |    58 |
-| water        |    85 |
-| bulk ice     |   107 |
+#+begin_example
+nop 250 cubic 42 hexagonal 65 interfacial 58 water 85
+#+end_example
+
+| label       | atoms |
+|-------------+-------|
+| cubic       |    42 |
+| hexagonal   |    65 |
+| interfacial |    58 |
+| water       |    85 |
+| bulk ice    |   107 |
+
+Bulk ice is cubic plus hexagonal (42 + 65 = 107). Interfacial is
+ice-like at the surface of those stars and is not in that sum. The
+four labels add to 250.
 
 * The same path in Python
+
+From the same checkout, so the relative path holds:
 
 #+begin_src python
 import pydseams as ds
@@ -30,32 +72,65 @@ print(frame.chill_plus())
 print(frame.cages())
 #+end_src
 
-~Frame.chill_plus~ is the four-neighbour classifier.
-~Frame.cages~ is topological unit matching on six-rings. On this
-mixed frame TUM finds no complete HC or DDC: cage membership is not
-the CHILL+ star.
+=ds.read= picks type 2 when that type is present. =Frame.chill_plus=
+is the four-neighbour classifier. The histogram is cubic 42,
+hexagonal 65, interfacial 58, water 85 (attributes =cubic=,
+=hexagonal=, =interfacial=, and =["water"]=). =Frame.cages= is cage
+membership on the same oxygens: =n_ih= 0, =n_ic= 0, =n_water= 250.
 
-* Cubic mW
+* Cages from the CLI
 
-The 4096-molecule cubic mW dump (~input/traj/mW_cubic.lammpstrj~)
-is the opposite case: every molecule is in a double-diamond cage and
-CHILL+ reports cubic ice.
+Cages ask a different question: does this oxygen belong to a complete
+hexagonal cage (HC, ice Ih, 12 waters) or a complete double-diamond
+cage (DDC, ice Ic, 14 waters)? The search walks primitive six-rings on
+a bonded graph.
+
+#+begin_src bash
+seams cages input/traj/exampleTraj.lammpstrj --type 2
+#+end_src
+
+The default graph is =--graph seeded=: mutual four-nearest seeds,
+union completions. This mixed frame has no complete HC or DDC:
+
+#+begin_example
+nop 250 graph seeded hexagonal 0 cubic 0 water 250
+#+end_example
+
+That is the same zero-cage result as =frame.cages()=.
+
+* Why the two scores differ
+
+CHILL+ is a four-neighbour star. A molecule is cubic or hexagonal when
+its four bonds look like ice, even if those neighbours do not close a
+cage.
+
+Cages are topological unit matching (TUM). A molecule is ice Ih only
+as a member of an HC, ice Ic only as a member of a DDC, and water
+otherwise. Partial ice-like order is water on that score.
+
+On this mixed frame 107 oxygens have a bulk-ice star and 58 more are
+interfacial, yet TUM finds no complete HC or DDC. Local tetrahedral
+order is not cage membership.
+
+* A cubic crystal
+
+The 4096-molecule cubic mW dump (=input/traj/mW_cubic.lammpstrj=, type
+1) is the opposite case: every molecule is in a DDC, and CHILL+
+reports cubic ice.
 
 #+begin_src bash
 seams cages input/traj/mW_cubic.lammpstrj --type 1
 seams chill-plus input/traj/mW_cubic.lammpstrj --type 1
 #+end_src
 
-* Bond graphs for cages
+On a perfect cubic lattice the four cage graphs (=cutoff=, =knn=,
+=knn-union=, =seeded=) coincide. The mixed TIP4P frame is the one that
+separates the two scores.
 
-~seams cages --graph~ selects the neighbour graph:
+* What you can do
 
-| value      | graph                                      |
-|------------+--------------------------------------------|
-| ~cutoff~   | distance cutoff (2020 default)             |
-| ~knn~      | mutual four-nearest                        |
-| ~knn-union~| union four-nearest                         |
-| ~seeded~   | mutual seeds, union completions (default)  |
-
-On a perfect cubic crystal the four graphs coincide. On a disordered
-nucleation dump they do not.
+You can classify any LAMMPS water dump the same two ways: pass
+=--type= for the oxygen (or single-site) type, read CHILL+ as a
+four-neighbour star, and read cages as HC/DDC membership. Use
+=frame.chill_plus()= and =frame.cages()= when you want those scores in
+Python.

--- a/docs/orgmode/tutorials/bulk-ice.org
+++ b/docs/orgmode/tutorials/bulk-ice.org
@@ -44,12 +44,14 @@ CHILL+ looks at each oxygen's four nearest neighbours inside the
 cutoff. Each of those four bonds is staggered or eclipsed from the
 pair correlation ~c_ij~. The star of four labels is the ice type:
 
-| label       | four-neighbour star              |
-|-------------+----------------------------------|
-| cubic       | four staggered                   |
-| hexagonal   | three staggered and one eclipsed |
-| interfacial | ice-like, not cubic or hexagonal |
-| water       | none of the above                |
+| label           | four-neighbour star              |
+|-----------------+----------------------------------|
+| cubic           | four staggered                   |
+| hexagonal       | three staggered and one eclipsed |
+| clathrate       | four eclipsed                    |
+| interClathrate  | three eclipsed                   |
+| interfacial     | ice-like, not one of the above   |
+| water           | fewer than four bonds, or none of the above |
 
 #+begin_src bash
 seams chill-plus input/traj/exampleTraj.lammpstrj --cutoff 3.5 --type 2
@@ -58,20 +60,18 @@ seams chill-plus input/traj/exampleTraj.lammpstrj --cutoff 3.5 --type 2
 Expected output:
 
 #+begin_example
-nop 250 cubic 42 hexagonal 65 interfacial 58 water 85
+nop 250 interClathrate 12 water 238
 #+end_example
 
-| label       | atoms |
-|-------------+-------|
-| cubic       |    42 |
-| hexagonal   |    65 |
-| interfacial |    58 |
-| water       |    85 |
-| bulk ice    |   107 |
+| label          | atoms |
+|----------------+-------|
+| interClathrate |    12 |
+| water          |   238 |
 
-Bulk ice is cubic plus hexagonal (42 + 65 = 107). Interfacial is
-ice-like at the surface of those stars and is not in that sum. The
-four labels add to 250.
+This dump is confined mixed TIP4P. Twelve oxygens have four
+neighbours and three eclipsed bonds. The rest are water. Original
+CHILL (~seams chill~) labels every oxygen water. The four-neighbour
+stars do not close a cubic or hexagonal ice motif.
 
 * Step 3: Cages from the CLI
 
@@ -103,9 +103,9 @@ Cages are topological unit matching (TUM). A molecule is ice Ih only
 as a member of an HC, ice Ic only as a member of a DDC, and water
 otherwise. Partial ice-like order is water on that score.
 
-On this mixed frame 107 oxygens have a bulk-ice star and 58 more are
-interfacial, yet TUM finds no complete HC or DDC. Local tetrahedral
-order is not cage membership.
+On this mixed frame CHILL+ finds twelve interfacial-clathrate
+oxygens and TUM finds no complete HC or DDC. A three-eclipsed star
+is not cage membership.
 
 The longer argument is
 [[file:../explanation/chill-plus-vs-cages.org][CHILL+ versus cages]].
@@ -140,7 +140,7 @@ print(frame.cages())
 Expected print on this fixture:
 
 #+begin_example
-IceCounts(cubic=42, hexagonal=65, interfacial=58, water=85)
+IceCounts(interClathrate=12, water=238)
 CageScore(n_ih=0, n_ic=0, n_water=250)
 #+end_example
 
@@ -169,6 +169,6 @@ repository does not install Python.
 
 * Summary
 
-You read one mixed TIP4P frame, printed the CHILL+ star (42 / 65 / 58
-/ 85), printed the seeded cage score (zero HC, zero DDC), and stated
-why those two answers differ.
+You read one mixed TIP4P frame, printed the CHILL+ star (12
+interfacial clathrate, 238 water), printed the seeded cage score
+(zero HC, zero DDC), and stated why those two answers differ.

--- a/docs/orgmode/tutorials/bulk-ice.org
+++ b/docs/orgmode/tutorials/bulk-ice.org
@@ -6,30 +6,43 @@ staggered/eclipsed star per oxygen) and topological cages (HC/DDC
 membership). The result is a labelled oxygen set and a reason the two
 scores disagree.
 
-Work from a seams-core checkout with =seams= on =PATH=. The dump is
-=input/traj/exampleTraj.lammpstrj=: one frame, 250 TIP4P waters, 750
-atoms, type 2 oxygen and type 1 hydrogen. Both classifiers use the
-oxygens.
+* Prerequisites
 
-Python is a separate package
-([[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]]). The engine
-CLI is not a scripting host.
+- A seams-core checkout. Work from the repository root so
+  ~input/traj/~ is a child.
+- ~seams~ on ~PATH~ (~pixi run build~ produces ~./bbdir/seams~;
+  ~nix build~ produces ~./result/bin/seams~).
+- The in-tree dump ~input/traj/exampleTraj.lammpstrj~ (one frame, 750
+  atoms, 250 TIP4P waters; LAMMPS type 2 oxygen, type 1 hydrogen).
 
-* Read the frame
+Python and Lua are not required. The Frame tutorial lives in
+[[https://d-seams.github.io/PydSEAMSlib/][pydseams]]. Lua is
+[[https://d-seams.github.io/yodaStruct/][dseams]].
+
+* Learning Objectives
+
+By the end of this tutorial you will be able to:
+
+1. Read a LAMMPS dump with ~seams read~ and name the oxygen type.
+2. Run CHILL+ and read the four-neighbour star histogram.
+3. Run cages on the same oxygens and read HC / DDC membership.
+4. State why the two scores disagree on this mixed frame.
+
+* Step 1: Read the frame
 
 #+begin_src bash
 seams read input/traj/exampleTraj.lammpstrj
 #+end_src
 
-The line starts =nop 250 frame 1 box ...=. The CLI guesses oxygen
-(type 2) and falls back to type 1. Pass =--type 2= on the classifiers
-so the type is explicit.
+Expected output starts ~nop 250 frame 1 box ...~. The CLI guesses
+oxygen (type 2, then type 1). Pass ~--type 2~ on the classifiers so
+the type is explicit.
 
-* CHILL+ from the CLI
+* Step 2: CHILL+ from the CLI
 
 CHILL+ looks at each oxygen's four nearest neighbours inside the
 cutoff. Each of those four bonds is staggered or eclipsed from the
-pair correlation =c_ij=. The star of four labels is the ice type:
+pair correlation ~c_ij~. The star of four labels is the ice type:
 
 | label       | four-neighbour star              |
 |-------------+----------------------------------|
@@ -42,7 +55,7 @@ pair correlation =c_ij=. The star of four labels is the ice type:
 seams chill-plus input/traj/exampleTraj.lammpstrj --cutoff 3.5 --type 2
 #+end_src
 
-The line is:
+Expected output:
 
 #+begin_example
 nop 250 cubic 42 hexagonal 65 interfacial 58 water 85
@@ -60,45 +73,27 @@ Bulk ice is cubic plus hexagonal (42 + 65 = 107). Interfacial is
 ice-like at the surface of those stars and is not in that sum. The
 four labels add to 250.
 
-* The same path in Python
-
-From the same checkout, so the relative path holds:
-
-#+begin_src python
-import pydseams as ds
-
-frame = ds.read("input/traj/exampleTraj.lammpstrj")
-print(frame.chill_plus())
-print(frame.cages())
-#+end_src
-
-=ds.read= picks type 2 when that type is present. =Frame.chill_plus=
-is the four-neighbour classifier. The histogram is cubic 42,
-hexagonal 65, interfacial 58, water 85 (attributes =cubic=,
-=hexagonal=, =interfacial=, and =["water"]=). =Frame.cages= is cage
-membership on the same oxygens: =n_ih= 0, =n_ic= 0, =n_water= 250.
-
-* Cages from the CLI
+* Step 3: Cages from the CLI
 
 Cages ask a different question: does this oxygen belong to a complete
 hexagonal cage (HC, ice Ih, 12 waters) or a complete double-diamond
 cage (DDC, ice Ic, 14 waters)? The search walks primitive six-rings on
-a bonded graph.
+a bonded graph. The default graph is ~--graph seeded~: mutual
+four-nearest seeds, union completions.
 
 #+begin_src bash
 seams cages input/traj/exampleTraj.lammpstrj --type 2
 #+end_src
 
-The default graph is =--graph seeded=: mutual four-nearest seeds,
-union completions. This mixed frame has no complete HC or DDC:
+Expected output:
 
 #+begin_example
 nop 250 graph seeded hexagonal 0 cubic 0 water 250
 #+end_example
 
-That is the same zero-cage result as =frame.cages()=.
+This mixed frame has no complete HC or DDC.
 
-* Why the two scores differ
+* Step 4: Why the two scores differ
 
 CHILL+ is a four-neighbour star. A molecule is cubic or hexagonal when
 its four bonds look like ice, even if those neighbours do not close a
@@ -112,10 +107,13 @@ On this mixed frame 107 oxygens have a bulk-ice star and 58 more are
 interfacial, yet TUM finds no complete HC or DDC. Local tetrahedral
 order is not cage membership.
 
-* A cubic crystal
+The longer argument is
+[[file:../explanation/chill-plus-vs-cages.org][CHILL+ versus cages]].
 
-The 4096-molecule cubic mW dump (=input/traj/mW_cubic.lammpstrj=, type
-1) is the opposite case: every molecule is in a DDC, and CHILL+
+* Step 5: A cubic crystal
+
+The 4096-molecule cubic mW dump (~input/traj/mW_cubic.lammpstrj~,
+type 1) is the opposite case: every molecule is in a DDC, and CHILL+
 reports cubic ice.
 
 #+begin_src bash
@@ -123,14 +121,54 @@ seams cages input/traj/mW_cubic.lammpstrj --type 1
 seams chill-plus input/traj/mW_cubic.lammpstrj --type 1
 #+end_src
 
-On a perfect cubic lattice the four cage graphs (=cutoff=, =knn=,
-=knn-union=, =seeded=) coincide. The mixed TIP4P frame is the one that
+On a perfect cubic lattice the four cage graphs (~cutoff~, ~knn~,
+~knn-union~, ~seeded~) coincide. The mixed TIP4P frame is the one that
 separates the two scores.
 
-* What you can do
+* Step 6: The same numbers in Python
 
-You can classify any LAMMPS water dump the same two ways: pass
-=--type= for the oxygen (or single-site) type, read CHILL+ as a
-four-neighbour star, and read cages as HC/DDC membership. Use
-=frame.chill_plus()= and =frame.cages()= when you want those scores in
-Python.
+From the same checkout, so the relative path holds:
+
+#+begin_src python
+import pydseams as ds
+
+frame = ds.read("input/traj/exampleTraj.lammpstrj")
+print(frame.chill_plus())
+print(frame.cages())
+#+end_src
+
+Expected print on this fixture:
+
+#+begin_example
+IceCounts(cubic=42, hexagonal=65, interfacial=58, water=85)
+CageScore(n_ih=0, n_ic=0, n_water=250)
+#+end_example
+
+That is a pointer, not a Frame tutorial. The Frame walkthrough is
+[[https://d-seams.github.io/PydSEAMSlib/][pydseams]]. Lua is
+[[https://d-seams.github.io/yodaStruct/][require("dseams")]]. This
+repository does not install Python.
+
+* Troubleshooting
+
+- ~nop 0~ or an empty histogram: wrong ~--type~. Mixed TIP4P in this
+  tree is type 2. mW is type 1.
+- Unknown command, exit 2: the binary is ~seams~, not ~yodaStruct~.
+  Commands are ~read~, ~chill~, ~chill-plus~, and ~cages~.
+- ~ModuleNotFoundError: pydseams~: this repo does not install Python.
+  ~pip install pydseams~.
+- Lua ~require("dseams")~: that module lives in yodaStruct.
+
+* Next steps
+
+- [[file:../howto/classify-cli.org][Classify a dump you already have]]
+  (frame ranges, ~--graph~, ~--jobs~)
+- [[file:../explanation/chill-plus-vs-cages.org][CHILL+ versus cages]]
+- [[https://d-seams.github.io/PydSEAMSlib/][pydseams Frame tutorial]]
+- [[https://d-seams.github.io/yodaStruct/][Lua read-and-classify]]
+
+* Summary
+
+You read one mixed TIP4P frame, printed the CHILL+ star (42 / 65 / 58
+/ 85), printed the seeded cage score (zero HC, zero DDC), and stated
+why those two answers differ.

--- a/docs/orgmode/tutorials/index.org
+++ b/docs/orgmode/tutorials/index.org
@@ -1,0 +1,20 @@
+#+TITLE: Tutorials
+#+OPTIONS: toc:nil num:nil
+
+A tutorial is a learning path. You finish it with a skill, not a
+lookup table. The one good tutorial on this site classifies the
+in-tree mixed TIP4P dump two ways.
+
+| tutorial | you learn |
+|----------+-----------|
+| [[file:bulk-ice.org][Classify ice on the mixed TIP4P example]] | ~seams read~, CHILL+, cages, and why the scores disagree |
+
+How-tos solve a goal you already have. Reference names flags and
+headers. Explanation is why the two classifiers exist.
+
+#+begin_export rst
+.. toctree::
+   :maxdepth: 1
+
+   bulk-ice
+#+end_export

--- a/docs/orgmode/tutorials/nanotube.org
+++ b/docs/orgmode/tutorials/nanotube.org
@@ -1,33 +1,4 @@
 #+TITLE: Quasi-one-dimensional ice
 #+OPTIONS: toc:nil num:nil
 
-Ice nanotubes and confined prisms are the 2020 quasi-one-dimensional
-path: primitive rings, then prism identification on that ring set.
-
-* Where the code lives
-
-C++: ~topo_one_dim.cpp~ / ~prismAnalysis~. The Catch2 binary
-~topo_one_dim~ exercises the path.
-
-Lua: ~example_lua/iceNanotube/~ in
-[[https://github.com/d-SEAMS/yodaStruct][yodaStruct]] still runs the
-registered prism helpers (~prismAnalysis~, ~ringAnalysis~) through
-~require("dseams")~.
-
-* From Python
-
-There is no separate ~seams nanotube~ subcommand. Load a frame and
-call the compiled registrations on ~pydseams.yoda~ (or the Lua
-helpers) after you have a bonded graph and a ring set. The high-level
-~Frame~ API is CHILL+ and cages; prism analysis stays on ~yoda~.
-
-#+begin_src python
-from pydseams import yoda
-# yoda.prismAnalysis(...) after rings and a neighbour list
-#+end_src
-
-* Trajectories
-
-The 2020 INT dumps live on the
-[[https://figshare.com/projects/d-SEAMS_Datasets/73545][figshare project]].
-Keep paths relative to the directory you invoke ~dseams~ from.
+Classify a frame with CHILL+ and cages in [[file:bulk-ice.org][the mixed TIP4P tutorial]].

--- a/docs/orgmode/tutorials/nanotube.org
+++ b/docs/orgmode/tutorials/nanotube.org
@@ -1,4 +1,7 @@
 #+TITLE: Quasi-one-dimensional ice
 #+OPTIONS: toc:nil num:nil
 
-Classify a frame with CHILL+ and cages in [[file:bulk-ice.org][the mixed TIP4P tutorial]].
+The ~seams~ CLI has no prism command. Confined ice (nanotube and
+monolayer) is [[file:../howto/confined-ice.org][the confined-ice howto]].
+Bulk CHILL+ and cages on the in-tree dump are
+[[file:bulk-ice.org][the mixed TIP4P tutorial]].

--- a/docs/source/Doxyfile_seams.cfg
+++ b/docs/source/Doxyfile_seams.cfg
@@ -32,12 +32,13 @@ USE_MATHJAX             = NO
 GENERATE_LATEX          = NO
 
 # Project Settings
-PROJECT_NAME            = "d-SEAMS"
-PROJECT_NUMBER          = "v2.1.0"
-PROJECT_BRIEF           = "Deferred Structural Elucidation Analysis for Molecular Simulations"
+PROJECT_NAME            = "seams-core"
+PROJECT_NUMBER          = "v2.2.0"
+PROJECT_BRIEF           = "libyodaLib, the C++ engine of d-SEAMS"
 
 # Doxygen Settings
 RECURSIVE              = YES
+# Public headers only. tests/ and src/include/external/ stay out.
 INPUT                  = "../../src/include/internal"
 OUTPUT_DIRECTORY       = "."
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,6 +19,7 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_sitemap",
     "sphinx_design",
+    "sphinxcontrib.mermaid",
 ]
 
 templates_path = ["_templates"]
@@ -35,6 +36,12 @@ intersphinx_mapping = {
 # -- Options for HTML output -------------------------------------------------
 html_theme = "shibuya"
 html_static_path = ["_static"]
+html_css_files = []  # sphinx-design ships its own CSS
+html_js_files = []
+
+# Mermaid: default CDN; diagrams via ``.. mermaid::`` from Org RST export.
+mermaid_version = "11.4.0"
+mermaid_init_js = "mermaid.initialize({startOnLoad:true, theme:'neutral'});"
 
 html_context = {
     "source_type": "github",
@@ -49,6 +56,9 @@ html_theme_options = {
     "accent_color": "teal",
     "dark_code": True,
     "globaltoc_expand_depth": 1,
+    "toctree_collapse": True,
+    "toctree_maxdepth": 3,
+    "toctree_titles_only": True,
     "nav_links": [
         {
             "title": "Ecosystem",

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,6 +18,7 @@ extensions = [
     "myst_parser",
     "sphinx.ext.intersphinx",
     "sphinx_sitemap",
+    "sphinx_design",
 ]
 
 templates_path = ["_templates"]
@@ -28,6 +29,7 @@ intersphinx_mapping = {
     "numpy": ("https://numpy.org/doc/stable", None),
     "ase": ("https://wiki.fysik.dtu.dk/ase/", None),
     "pydseams": ("https://d-seams.github.io/PydSEAMSlib/", None),
+    "luadseams": ("https://d-seams.github.io/yodaStruct/", None),
 }
 
 # -- Options for HTML output -------------------------------------------------
@@ -49,14 +51,27 @@ html_theme_options = {
     "globaltoc_expand_depth": 1,
     "nav_links": [
         {
-            "title": "pydseams",
-            "url": "https://github.com/d-SEAMS/PydSEAMSlib",
-            "external": True,
-        },
-        {
-            "title": "dseams (Lua)",
-            "url": "https://github.com/d-SEAMS/yodaStruct",
-            "external": True,
+            "title": "Ecosystem",
+            "children": [
+                {
+                    "title": "d-SEAMS engine",
+                    "url": "https://docs.dseams.info",
+                    "summary": "libyodaLib and the seams CLI",
+                    "external": True,
+                },
+                {
+                    "title": "pydseams",
+                    "url": "https://d-seams.github.io/PydSEAMSlib/",
+                    "summary": "Python Frame API on yoda",
+                    "external": True,
+                },
+                {
+                    "title": "dseams (Lua)",
+                    "url": "https://d-seams.github.io/yodaStruct/",
+                    "summary": "require(\"dseams\") and Fennel",
+                    "external": True,
+                },
+            ],
         },
     ],
 }
@@ -69,4 +84,4 @@ html_sidebars = {
     ],
 }
 
-html_baseurl = "https://docs.dseams.info"
+html_baseurl = "https://docs.dseams.info/"

--- a/docs/source/doxyrest-config.lua
+++ b/docs/source/doxyrest-config.lua
@@ -1,6 +1,6 @@
 INPUT_FILE = "xml/index.xml"
 OUTPUT_FILE = "api/index.rst"
-INDEX_TITLE = "API Reference"
+INDEX_TITLE = "C++ headers (doxyrest)"
 
 FRAME_DIR_LIST = {
     "../../subprojects/doxyrest/frame/common",

--- a/markdown/bulkTopologicalCriterion.md
+++ b/markdown/bulkTopologicalCriterion.md
@@ -20,7 +20,7 @@ trajectory: "path/to/trajectory/file"
 
 ## Analyzing the Output
 
-Inside the output directory, a file called *clusterStats.dat* contains the cluster statistics for each frame. Inside the *bulkTopo* directory, *cageData.dat* contains the number of HCs, DDCs and mixed rings for each frame. Inside *runOne/bulkTopo/dataFiles*, LAMMPS data files which are numbered according to the frame number are created. These data files can be visualized in [OVITO](https://www.ovito.org/) or [VMD](http://www.ks.uiuc.edu/Research/vmd/), although OVITO is recommended for optimal type visualization.
+Inside the output directory, a file called *clusterStats.dat* contains the cluster statistics for each frame. Inside the *bulkTopo* directory, *cageData.dat* contains the number of HCs, DDCs and mixed rings for each frame. Inside *runOne/bulkTopo/dataFiles*, LAMMPS data files which are numbered according to the frame number are created. These data files are LAMMPS text. View classified frames with [solvis](https://github.com/amritagos/solvis) through `pydseams[solvis]` (`frame.to_solvis()`).
 
 ## References 
 

--- a/markdown/chillPlus.md
+++ b/markdown/chillPlus.md
@@ -22,7 +22,7 @@ trajectory: "path/to/trajectory/file"
 
 ## Analyzing the Output
 
-Inside the output directory, a file called _clusterStats.dat_ contains the cluster statistics for each frame. Each frame is also written out to a LAMMPS trajectory file called _waterChillP.lammpstrj_, containing the classified atoms, and the _largestIce.lammpstrj_, which has the particles in the largest ice cluster. These trajectory files can be visualized in [OVITO](https://www.ovito.org/) or [VMD](http://www.ks.uiuc.edu/Research/vmd/). Inside the _bop_ directory, _chillPlus.txt_ contains the number of particles identified as cubic ice (Ic), hexagonal ice (Ih), interfacial ice (Interfacial), clathrates (Clath), interfacial clathrates (InterClath), water and the total number of molecules (Total).
+Inside the output directory, a file called _clusterStats.dat_ contains the cluster statistics for each frame. Each frame is also written out to a LAMMPS trajectory file called _waterChillP.lammpstrj_, containing the classified atoms, and the _largestIce.lammpstrj_, which has the particles in the largest ice cluster. These trajectory files are LAMMPS text. View classified frames with [solvis](https://github.com/amritagos/solvis) through `pydseams[solvis]` (`frame.to_solvis()`). Inside the _bop_ directory, _chillPlus.txt_ contains the number of particles identified as cubic ice (Ic), hexagonal ice (Ih), interfacial ice (Interfacial), clathrates (Clath), interfacial clathrates (InterClath), water and the total number of molecules (Total).
 
 ## References
 

--- a/markdown/iceNanotube.md
+++ b/markdown/iceNanotube.md
@@ -41,8 +41,8 @@ _topoINT_ directory, a file called _nPrisms.dat_ contains the number of prism
 blocks and the corresponding height% [2], for each frame. Inside
 _runOne/topoINT/dataFiles_, LAMMPS data files which are numbered according to
 the frame number are created. These data files can be visualized in
-[OVITO](https://www.ovito.org/) or [VMD](http://www.ks.uiuc.edu/Research/vmd/),
-although OVITO is recommended for optimal type visualization.
+[solvis](https://github.com/amritagos/solvis) through `pydseams[solvis]`
+(`frame.to_solvis()`). The files are LAMMPS text.
 
 ## References
 

--- a/markdown/monolayer.md
+++ b/markdown/monolayer.md
@@ -37,8 +37,8 @@ Inside the output directory, a directory called _topoMonolayer_ is created. Insi
 _topoMonolayer_ directory, files called _coverageAreaXY.dat_, _coverageAreaXZ.dat_, and _coverageAreaYZ.dat_ contain the number of rings and and the corresponding coverage area% [1], for each frame. Here, the confining sheet is in the XY plane, so the _coverageAreaXY.dat_ contains the coverage area% and quantities of interest. Inside
 _runOne/topoMonolayer/dataFiles_, LAMMPS data files which are numbered according to
 the frame number are created. These data files can be visualized in
-[OVITO](https://www.ovito.org/) or [VMD](http://www.ks.uiuc.edu/Research/vmd/),
-although OVITO is recommended for optimal type visualization.
+[solvis](https://github.com/amritagos/solvis) through `pydseams[solvis]`
+(`frame.to_solvis()`). The files are LAMMPS text.
 
 ## References
 

--- a/markdown/rdf2d.md
+++ b/markdown/rdf2d.md
@@ -48,8 +48,8 @@ Inside the output directory, a directory called _topoMonolayer_ is created. Insi
 _topoMonolayer_ directory, files called _coverageAreaXY.dat_, _coverageAreaXZ.dat_, and _coverageAreaYZ.dat_ contain the number of rings and and the corresponding coverage area% [1], for each frame. Here, the confining sheet is in the XY plane, so the _coverageAreaXY.dat_ contains the coverage area% and quantities of interest. Inside
 _runOne/topoMonolayer/dataFiles_, LAMMPS data files which are numbered according to
 the frame number are created. These data files can be visualized in
-[OVITO](https://www.ovito.org/) or [VMD](http://www.ks.uiuc.edu/Research/vmd/),
-although OVITO is recommended for optimal type visualization.
+[solvis](https://github.com/amritagos/solvis) through `pydseams[solvis]`
+(`frame.to_solvis()`). The files are LAMMPS text.
 
 The output file _rdf.dat_ contains the values of $r$ and $g(r)$ in each column, and can be plotted to obtain the in-plane radial distribution function. For a better and less grainy plot, you should use more frames for the RDF.
 

--- a/meson.build
+++ b/meson.build
@@ -145,6 +145,13 @@ if vesin_dep.found()
   _args += ['-DSEAMS_HAS_VESIN=1']
 endif
 
+linkcell_dep = dependency('linkcell', required: false,
+                          fallback: ['linkcell', 'linkcell_dep'])
+if linkcell_dep.found()
+  _deps += [linkcell_dep]
+  _args += ['-DSEAMS_HAS_LINKCELL=1']
+endif
+
 chemfiles_dep = dependency('chemfiles', required: false)
 if chemfiles_dep.found()
   _deps += [chemfiles_dep]
@@ -309,15 +316,18 @@ if not nauty_opt.disabled()
 endif
 
 # Report which optional backends this build actually got. Each of these
-# degrades silently: without vesin the neighbour search falls back to the
-# brute-force path, and without a reader the corresponding formats are simply
-# absent from the library, with nothing at run time to say so.
+# degrades silently: without vesin the cutoff neighbour search falls
+# back to the brute-force path, without linkcell the k-nearest walk
+# uses the in-tree cell list, and without a reader the corresponding
+# formats are simply absent from the library, with nothing at run time
+# to say so.
 summary({
   'SIMD distance kernel (hwy)': hwy_dep.found(),
   'Shared-memory parallelism (OpenMP)': openmp_found,
   'MPI atom split (Steinhardt)': mpi_found,
   'OpenMP target offload': offload_enabled,
   'Cell-list neighbours (vesin)': vesin_dep.found(),
+  'Periodic k-nearest (linkcell)': linkcell_dep.found(),
   'PDB/GRO/DCD readers (chemfiles)': chemfiles_dep.found(),
   '.con reader (readcon-core)': readcon_dep.found(),
   'IRA/SOFI shape matching (libira)': ira_found,

--- a/pixi.toml
+++ b/pixi.toml
@@ -107,6 +107,7 @@ sphinx = ">=8.0, <9"
 sphinx-sitemap = ">=2.9, <3"
 sphinx-design = ">=0.6, <1"
 myst-parser = ">=4.0, <5"
+sphinxcontrib-mermaid = ">=1.0, <2"
 
 [feature.docs.tasks.setup-doxyrest]
 description = "Clones the doxyrest dependency into the subprojects directory"

--- a/pixi.toml
+++ b/pixi.toml
@@ -105,6 +105,7 @@ doxyrest = ">=2.1"
 shibuya = ">=2025.12, <2027"
 sphinx = ">=8.0, <9"
 sphinx-sitemap = ">=2.9, <3"
+sphinx-design = ">=0.6, <1"
 myst-parser = ">=4.0, <5"
 
 [feature.docs.tasks.setup-doxyrest]

--- a/src/cage_affiliation.cpp
+++ b/src/cage_affiliation.cpp
@@ -42,13 +42,14 @@ std::vector<int> canonicalKey(const std::vector<int> &ringAtoms) {
 }
 
 //! Shared per-frame machinery: the inverted index, sorted ring copies for
-//! fast overlap tests, and mutable ring copies for the condition helpers
-//! (which take non-const references without mutating).
+//! overlap tests, and cached basal/adjacency lists (one sort per ring).
 struct FrameContext {
   const std::vector<std::vector<int>> &rings;
   const std::vector<std::vector<int>> &nList;
   ring::RingSearchIndex index;
   std::vector<std::vector<int>> sortedRings;
+  std::vector<std::vector<int>> basalCand;
+  std::vector<std::vector<int>> adjRings;
   // Scratch for findPrismatic, which appends to a list and stamps a type
   // vector neither of which affiliation reads
   std::vector<int> scratchListHC;
@@ -64,12 +65,22 @@ struct FrameContext {
       }
     }
     index = ring::buildRingSearchIndex(rings, maxAtom + 1);
-    sortedRings.resize(rings.size());
-    for (size_t i = 0; i < rings.size(); i++) {
-      sortedRings[i] = rings[i];
-      std::sort(sortedRings[i].begin(), sortedRings[i].end());
+    const int nR = static_cast<int>(rings.size());
+    sortedRings.resize(static_cast<std::size_t>(nR));
+    for (int i = 0; i < nR; i++) {
+      sortedRings[static_cast<std::size_t>(i)] =
+          rings[static_cast<std::size_t>(i)];
+      std::sort(sortedRings[static_cast<std::size_t>(i)].begin(),
+                sortedRings[static_cast<std::size_t>(i)].end());
     }
-    scratchType.assign(rings.size(), ring::strucType::unclassified);
+    scratchType.assign(static_cast<std::size_t>(nR),
+                       ring::strucType::unclassified);
+    basalCand.resize(static_cast<std::size_t>(nR));
+    adjRings.resize(static_cast<std::size_t>(nR));
+    for (int i = 0; i < nR; i++) {
+      basalCand[static_cast<std::size_t>(i)] = collectBasalCandidates(i);
+      adjRings[static_cast<std::size_t>(i)] = collectAdjacentRings(i);
+    }
   }
 
   [[nodiscard]] bool shareAtoms(int i, int j) const {
@@ -94,9 +105,7 @@ struct FrameContext {
     return index.ringsContainingAtom[atom];
   }
 
-  //! The adjacency neighbourhood A(r): rings containing an atom within one
-  //! bond-hop of an atom of r, excluding r itself; sorted unique
-  [[nodiscard]] std::vector<int> adjacentRings(int r) const {
+  [[nodiscard]] std::vector<int> collectAdjacentRings(int r) const {
     std::vector<int> out;
     for (const int atom : rings[r]) {
       for (const int s : ringsThroughAtom(atom)) {
@@ -127,9 +136,17 @@ struct FrameContext {
     return ring::basalConditions(nList, rings[i], rings[j]);
   }
 
+  [[nodiscard]] const std::vector<int> &adjacentRings(int r) const {
+    static const std::vector<int> empty;
+    if (r < 0 || r >= static_cast<int>(adjRings.size())) {
+      return empty;
+    }
+    return adjRings[static_cast<std::size_t>(r)];
+  }
+
   //! Candidate second-basal rings for i in the findHC gathering order:
   //! rings holding a bond-neighbour of i's first or second atom
-  [[nodiscard]] std::vector<int> basalCandidates(int i) const {
+  [[nodiscard]] std::vector<int> collectBasalCandidates(int i) const {
     std::vector<int> out;
     for (int slot = 0; slot < 2 &&
                        slot < static_cast<int>(rings[i].size());
@@ -149,6 +166,14 @@ struct FrameContext {
     std::sort(out.begin(), out.end());
     out.erase(std::unique(out.begin(), out.end()), out.end());
     return out;
+  }
+
+  [[nodiscard]] const std::vector<int> &basalCandidates(int i) const {
+    static const std::vector<int> empty;
+    if (i < 0 || i >= static_cast<int>(basalCand.size())) {
+      return empty;
+    }
+    return basalCand[static_cast<std::size_t>(i)];
   }
 
   //! Prismatic rings of the ordered passing pair (i, j)
@@ -199,7 +224,7 @@ bool hcAffiliatedOf(FrameContext &ctx, int r,
     if (i == r) {
       continue;
     }
-    const std::vector<int> candidates = ctx.basalCandidates(i);
+    const std::vector<int> &candidates = ctx.basalCandidates(i);
     for (const int j : candidates) {
       if (j == r) {
         continue;
@@ -239,7 +264,7 @@ ring::cageAffiliation(const std::vector<std::vector<int>> &rings,
   // marks its basal rings and its prismatic rings. Sweeping every i covers
   // both directions of every pair once.
   for (size_t i = 0; i < nRings; i++) {
-    const std::vector<int> candidates = ctx.basalCandidates(static_cast<int>(i));
+    const std::vector<int> &candidates = ctx.basalCandidates(static_cast<int>(i));
     for (const int j : candidates) {
       if (!ctx.basalPair(static_cast<int>(i), j)) {
         continue;

--- a/src/cage_affiliation.cpp
+++ b/src/cage_affiliation.cpp
@@ -49,7 +49,8 @@ struct FrameContext {
   ring::RingSearchIndex index;
   std::vector<std::vector<int>> sortedRings;
   std::vector<std::vector<int>> basalCand;
-  std::vector<std::vector<int>> adjRings;
+  mutable std::vector<std::vector<int>> adjRings;
+  mutable std::vector<char> adjReady;
   // Scratch for findPrismatic, which appends to a list and stamps a type
   // vector neither of which affiliation reads
   std::vector<int> scratchListHC;
@@ -77,9 +78,9 @@ struct FrameContext {
                        ring::strucType::unclassified);
     basalCand.resize(static_cast<std::size_t>(nR));
     adjRings.resize(static_cast<std::size_t>(nR));
+    adjReady.assign(static_cast<std::size_t>(nR), 0);
     for (int i = 0; i < nR; i++) {
       basalCand[static_cast<std::size_t>(i)] = collectBasalCandidates(i);
-      adjRings[static_cast<std::size_t>(i)] = collectAdjacentRings(i);
     }
   }
 
@@ -140,6 +141,10 @@ struct FrameContext {
     static const std::vector<int> empty;
     if (r < 0 || r >= static_cast<int>(adjRings.size())) {
       return empty;
+    }
+    if (!adjReady[static_cast<std::size_t>(r)]) {
+      adjRings[static_cast<std::size_t>(r)] = collectAdjacentRings(r);
+      adjReady[static_cast<std::size_t>(r)] = 1;
     }
     return adjRings[static_cast<std::size_t>(r)];
   }

--- a/src/cage_affiliation.cpp
+++ b/src/cage_affiliation.cpp
@@ -49,7 +49,6 @@ struct FrameContext {
   const std::vector<std::vector<int>> &nList;
   ring::RingSearchIndex index;
   std::vector<std::vector<int>> sortedRings;
-  std::vector<std::vector<int>> ringsMut;
   // Scratch for findPrismatic, which appends to a list and stamps a type
   // vector neither of which affiliation reads
   std::vector<int> scratchListHC;
@@ -70,7 +69,6 @@ struct FrameContext {
       sortedRings[i] = rings[i];
       std::sort(sortedRings[i].begin(), sortedRings[i].end());
     }
-    ringsMut = rings;
     scratchType.assign(rings.size(), ring::strucType::unclassified);
   }
 
@@ -126,7 +124,7 @@ struct FrameContext {
     if (i == j || shareAtoms(i, j)) {
       return false;
     }
-    return ring::basalConditions(nList, ringsMut[i], ringsMut[j]);
+    return ring::basalConditions(nList, rings[i], rings[j]);
   }
 
   //! Candidate second-basal rings for i in the findHC gathering order:

--- a/src/cage_affiliation.cpp
+++ b/src/cage_affiliation.cpp
@@ -48,7 +48,8 @@ struct FrameContext {
   const std::vector<std::vector<int>> &nList;
   ring::RingSearchIndex index;
   std::vector<std::vector<int>> sortedRings;
-  std::vector<std::vector<int>> basalCand;
+  mutable std::vector<std::vector<int>> basalCand;
+  mutable std::vector<char> basalReady;
   mutable std::vector<std::vector<int>> adjRings;
   mutable std::vector<char> adjReady;
   // Scratch for findPrismatic, which appends to a list and stamps a type
@@ -79,9 +80,7 @@ struct FrameContext {
     basalCand.resize(static_cast<std::size_t>(nR));
     adjRings.resize(static_cast<std::size_t>(nR));
     adjReady.assign(static_cast<std::size_t>(nR), 0);
-    for (int i = 0; i < nR; i++) {
-      basalCand[static_cast<std::size_t>(i)] = collectBasalCandidates(i);
-    }
+    basalReady.assign(static_cast<std::size_t>(nR), 0);
   }
 
   [[nodiscard]] bool shareAtoms(int i, int j) const {
@@ -177,6 +176,10 @@ struct FrameContext {
     static const std::vector<int> empty;
     if (i < 0 || i >= static_cast<int>(basalCand.size())) {
       return empty;
+    }
+    if (!basalReady[static_cast<std::size_t>(i)]) {
+      basalCand[static_cast<std::size_t>(i)] = collectBasalCandidates(i);
+      basalReady[static_cast<std::size_t>(i)] = 1;
     }
     return basalCand[static_cast<std::size_t>(i)];
   }

--- a/src/franzblau.cpp
+++ b/src/franzblau.cpp
@@ -352,8 +352,8 @@ primitive::ringNetwork(const std::vector<std::vector<int>> &nList, int maxDepth)
   const int nVertices = static_cast<int>(nList.size());
   std::vector<std::vector<int>> adjacency(nVertices);
   for (int i = 0; i < nVertices; i++) {
-    for (size_t j = 1; j < nList[i].size(); j++) {
-      adjacency[i].push_back(nList[i][j]);
+    if (nList[i].size() > 1) {
+      adjacency[i].assign(nList[i].begin() + 1, nList[i].end());
     }
   }
 

--- a/src/franzblau.cpp
+++ b/src/franzblau.cpp
@@ -72,7 +72,7 @@ struct BoundedBalls {
     const int nVertices = static_cast<int>(adjacency.size());
     ball.assign(nVertices, {});
 #ifdef SEAMS_HAS_OPENMP
-#pragma omp parallel if (nVertices >= 256)
+#pragma omp parallel if (nVertices >= 256 && !omp_in_parallel())
 #endif
     {
       std::vector<int> dist(nVertices, -1);
@@ -163,24 +163,34 @@ void levelsFrom(const std::vector<std::vector<int>> &adjacency, int src,
   }
 }
 
-//! All shortest paths src -> target under the level field, excluding src
-void allShortestPaths(const std::vector<std::vector<int>> &adjacency,
-                      const std::vector<int> &lvl, int src, int target,
-                      std::vector<int> cur,
-                      std::vector<std::vector<int>> &out) {
+//! All shortest paths src -> target under the level field, excluding src.
+//! The path is grown in @a cur by push/pop so each hop does not copy.
+void allShortestPathsRec(const std::vector<std::vector<int>> &adjacency,
+                         const std::vector<int> &lvl, int src, int target,
+                         std::vector<int> &cur,
+                         std::vector<std::vector<int>> &out) {
   if (target == src) {
-    std::reverse(cur.begin(), cur.end());
-    out.push_back(std::move(cur));
+    std::vector<int> path = cur;
+    std::reverse(path.begin(), path.end());
+    out.push_back(std::move(path));
     return;
   }
   for (const int w : adjacency[target]) {
     if (w >= 0 && w < static_cast<int>(lvl.size()) && lvl[w] >= 0 &&
         lvl[w] == lvl[target] - 1) {
-      std::vector<int> nxt = cur;
-      nxt.push_back(target);
-      allShortestPaths(adjacency, lvl, src, w, std::move(nxt), out);
+      cur.push_back(target);
+      allShortestPathsRec(adjacency, lvl, src, w, cur, out);
+      cur.pop_back();
     }
   }
+}
+
+void allShortestPaths(const std::vector<std::vector<int>> &adjacency,
+                      const std::vector<int> &lvl, int src, int target,
+                      std::vector<std::vector<int>> &out) {
+  std::vector<int> cur;
+  cur.reserve(8);
+  allShortestPathsRec(adjacency, lvl, src, target, cur, out);
 }
 
 //! Shortest-path criterion over every pair of members, by ball lookup
@@ -251,7 +261,7 @@ void enumerateFromSource(const std::vector<std::vector<int>> &adjacency,
       continue;
     }
     scr.paths.clear();
-    allShortestPaths(adjacency, scr.lvl, src, p, {}, scr.paths);
+    allShortestPaths(adjacency, scr.lvl, src, p, scr.paths);
     // Even rings: two vertex-disjoint shortest paths to an antipodal vertex
     if (2 * scr.lvl[p] >= 3 && 2 * scr.lvl[p] <= maxDepth) {
       for (size_t a = 0; a < scr.paths.size(); a++) {
@@ -278,7 +288,7 @@ void enumerateFromSource(const std::vector<std::vector<int>> &adjacency,
           continue;
         }
         scr.pathsQ.clear();
-        allShortestPaths(adjacency, scr.lvl, src, q, {}, scr.pathsQ);
+        allShortestPaths(adjacency, scr.lvl, src, q, scr.pathsQ);
         for (const auto &pa : scr.paths) {
           for (const auto &pb : scr.pathsQ) {
             std::vector<int> ring{src};
@@ -353,7 +363,7 @@ primitive::ringNetwork(const std::vector<std::vector<int>> &nList, int maxDepth)
   balls.fillAll(adjacency, radius);
 
 #ifdef SEAMS_HAS_OPENMP
-  if (nVertices >= 256) {
+  if (nVertices >= 256 && !omp_in_parallel()) {
     // Sources are independent given the shared read-only balls; per-source
     // collection keeps the output identical to the serial ascending-source
     // order

--- a/src/include/internal/generic.hpp
+++ b/src/include/internal/generic.hpp
@@ -15,10 +15,11 @@
 #ifndef SEAMS_GENERIC_H_
 #define SEAMS_GENERIC_H_
 
+#include <algorithm>
 #include <array>
+#include <cmath>
 #include <filesystem>
 #include <iostream>
-#include <cmath>
 #include <mol_sys.hpp>
 
 // C++20
@@ -94,6 +95,53 @@ inline double calcMedian(std::vector<double> *input) {
   return median;
 }
 
+// Recover H (columns a, b, c) and origin from a LAMMPS dump box with the
+// same mapping as nneigh::lammpsBoxToLcCell: box[0..3] are bound spans,
+// box[3..6] are tilt factors xy, xz, yz, boxLow is the bound lo.
+// Convert each cartesian point to fractional coordinates relative to
+// origin, wrap the fractional difference, and map back through H.
+inline std::array<double, 3> triclinicMinImage(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud, double xi,
+    double yi, double zi, double xj, double yj, double zj) {
+  const auto &box = yCloud.box;
+  const auto &boxLow = yCloud.boxLow;
+  const double xspan = box[0];
+  const double yspan = box[1];
+  const double zspan = box[2];
+  const double xlo_b = boxLow.size() > 0 ? boxLow[0] : 0.0;
+  const double ylo_b = boxLow.size() > 1 ? boxLow[1] : 0.0;
+  const double zlo_b = boxLow.size() > 2 ? boxLow[2] : 0.0;
+  const double xy = box[3];
+  const double xz = box[4];
+  const double yz = box[5];
+  const double xmin = std::min(std::min(0.0, xy), std::min(xz, xy + xz));
+  const double xmax = std::max(std::max(0.0, xy), std::max(xz, xy + xz));
+  const double ymin = std::min(0.0, yz);
+  const double ymax = std::max(0.0, yz);
+  const double lx = xspan - xmax + xmin;
+  const double ly = yspan - ymax + ymin;
+  const double lz = zspan;
+  const double ox = xlo_b - xmin;
+  const double oy = ylo_b - ymin;
+  const double oz = zlo_b;
+
+  auto toFrac = [&](double x, double y, double z) {
+    const double sz = (z - oz) / lz;
+    const double sy = (y - oy - yz * sz) / ly;
+    const double sx = (x - ox - xy * sy - xz * sz) / lx;
+    return std::array<double, 3>{sx, sy, sz};
+  };
+  const auto si = toFrac(xi, yi, zi);
+  const auto sj = toFrac(xj, yj, zj);
+  double dsx = si[0] - sj[0];
+  double dsy = si[1] - sj[1];
+  double dsz = si[2] - sj[2];
+  dsx -= std::round(dsx);
+  dsy -= std::round(dsy);
+  dsz -= std::round(dsz);
+  return {lx * dsx + xy * dsy + xz * dsz, ly * dsy + yz * dsz, lz * dsz};
+}
+
 // Generic function for getting the unwrapped distance
 /**
  *  @brief Inline generic function for obtaining the unwrapped periodic distance
@@ -107,6 +155,13 @@ inline double calcMedian(std::vector<double> *input) {
 inline double
 periodicDistSq(const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
                int iatom, int jatom) {
+  if (yCloud.box.size() >= 6) {
+    const auto dr = triclinicMinImage(
+        yCloud, yCloud.pts[iatom].x, yCloud.pts[iatom].y, yCloud.pts[iatom].z,
+        yCloud.pts[jatom].x, yCloud.pts[jatom].y, yCloud.pts[jatom].z);
+    return dr[0] * dr[0] + dr[1] * dr[1] + dr[2] * dr[2];
+  }
+
   std::array<double, 3> dr;
   double r2 = 0.0; // Squared absolute distance
 
@@ -115,9 +170,8 @@ periodicDistSq(const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
   dr[1] = std::fabs(yCloud.pts[iatom].y - yCloud.pts[jatom].y);
   dr[2] = std::fabs(yCloud.pts[iatom].z - yCloud.pts[jatom].z);
 
-  // Get the squared absolute distance
+  // Three-axis wrap for an orthorhombic length-3 box
   for (int k = 0; k < 3; k++) {
-    // Correct for periodicity
     dr[k] -= yCloud.box[k] * std::round(dr[k] / yCloud.box[k]);
     r2 += dr[k] * dr[k];
   }
@@ -153,6 +207,14 @@ periodicDist(const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
 inline double unWrappedDistFromPoint(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int iatom,
     std::vector<double> singlePoint) {
+  if (yCloud.box.size() >= 6) {
+    const auto dr = triclinicMinImage(yCloud, yCloud.pts[iatom].x,
+                                      yCloud.pts[iatom].y, yCloud.pts[iatom].z,
+                                      singlePoint[0], singlePoint[1],
+                                      singlePoint[2]);
+    return std::sqrt(dr[0] * dr[0] + dr[1] * dr[1] + dr[2] * dr[2]);
+  }
+
   std::array<double, 3> dr;
   double r2 = 0.0; // Squared absolute distance
 
@@ -161,9 +223,8 @@ inline double unWrappedDistFromPoint(
   dr[1] = fabs(yCloud.pts[iatom].y - singlePoint[1]);
   dr[2] = fabs(yCloud.pts[iatom].z - singlePoint[2]);
 
-  // Get the squared absolute distance
+  // Three-axis wrap for an orthorhombic length-3 box
   for (int k = 0; k < 3; k++) {
-    // Correct for periodicity
     dr[k] -= yCloud.box[k] * round(dr[k] / yCloud.box[k]);
     r2 += pow(dr[k], 2.0);
   }
@@ -214,6 +275,12 @@ distance(const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int ia
 inline std::array<double, 3>
 relDist(const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int iatom,
         int jatom) {
+  if (yCloud.box.size() >= 6) {
+    return triclinicMinImage(
+        yCloud, yCloud.pts[iatom].x, yCloud.pts[iatom].y, yCloud.pts[iatom].z,
+        yCloud.pts[jatom].x, yCloud.pts[jatom].y, yCloud.pts[jatom].z);
+  }
+
   std::array<double, 3> dr;
   std::array<double, 3> box = {yCloud.box[0], yCloud.box[1], yCloud.box[2]};
 
@@ -222,9 +289,8 @@ relDist(const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int iat
   dr[1] = yCloud.pts[iatom].y - yCloud.pts[jatom].y;
   dr[2] = yCloud.pts[iatom].z - yCloud.pts[jatom].z;
 
-  // Get the relative distance
+  // Three-axis wrap for an orthorhombic length-3 box
   for (int k = 0; k < 3; k++) {
-    //
     if (dr[k] < -box[k] * 0.5) {
       dr[k] = dr[k] + box[k];
     }

--- a/src/include/internal/neighbours.hpp
+++ b/src/include/internal/neighbours.hpp
@@ -15,6 +15,7 @@
 #ifndef SEAMS_NEIGHBOURS_H_
 #define SEAMS_NEIGHBOURS_H_
 
+#include <algorithm>
 #include <array>
 #include <string>
 #include <utility>
@@ -22,6 +23,10 @@
 
 #include <generic.hpp>
 #include <mol_sys.hpp>
+
+#ifdef SEAMS_HAS_LINKCELL
+#include <linkcell.h>
+#endif
 
 /** @file neighbours.hpp
  *  @brief Header file for neighbour list generation.
@@ -55,6 +60,44 @@
  */
 
 namespace nneigh {
+
+#ifdef SEAMS_HAS_LINKCELL
+/// Map a LAMMPS dump box onto lc_cell.
+///
+/// `box[0..3]` are bound spans (`xhi_bound - xlo_bound`, ...) as
+/// `seams_input` stores them. `boxLow` is the bound lo. Optional
+/// `box[3..6]` are the dump tilt factors `xy, xz, yz`.
+///
+/// The conversion is the LAMMPS dump convention:
+/// `xlo = xlo_bound - min(0, xy, xz, xy+xz)` and
+/// `lx = xhi_bound - xlo_bound - max(...) + min(...)`, then
+/// `a = (lx, 0, 0)`, `b = (xy, ly, 0)`, `c = (xz, yz, lz)`.
+inline lc_cell lammpsBoxToLcCell(const std::vector<double> &box,
+                                 const std::vector<double> &boxLow) {
+  const double xspan = box.size() > 0 ? box[0] : 0.0;
+  const double yspan = box.size() > 1 ? box[1] : 0.0;
+  const double zspan = box.size() > 2 ? box[2] : 0.0;
+  const double xlo_b = boxLow.size() > 0 ? boxLow[0] : 0.0;
+  const double ylo_b = boxLow.size() > 1 ? boxLow[1] : 0.0;
+  const double zlo_b = boxLow.size() > 2 ? boxLow[2] : 0.0;
+  const double xy = box.size() >= 6 ? box[3] : 0.0;
+  const double xz = box.size() >= 6 ? box[4] : 0.0;
+  const double yz = box.size() >= 6 ? box[5] : 0.0;
+  const double xmin = std::min(std::min(0.0, xy), std::min(xz, xy + xz));
+  const double xmax = std::max(std::max(0.0, xy), std::max(xz, xy + xz));
+  const double ymin = std::min(0.0, yz);
+  const double ymax = std::max(0.0, yz);
+  lc_cell c = lc_cell_ortho(xspan - xmax + xmin, yspan - ymax + ymin, zspan);
+  c.bx = xy;
+  c.cx = xz;
+  c.cy = yz;
+  c.ox = xlo_b - xmin;
+  c.oy = ylo_b - ymin;
+  c.oz = zlo_b;
+  return c;
+}
+#endif
+
 //! All these functions use atom IDs and not indices
 
 //! Inefficient @f$O(n^2)@f$ implementation of neighbour lists when there are

--- a/src/include/internal/neighbours.hpp
+++ b/src/include/internal/neighbours.hpp
@@ -25,7 +25,7 @@
 #include <mol_sys.hpp>
 
 #ifdef SEAMS_HAS_LINKCELL
-#include <linkcell.h>
+#include <linkcell.hpp>
 #endif
 
 /** @file neighbours.hpp
@@ -95,6 +95,11 @@ inline lc_cell lammpsBoxToLcCell(const std::vector<double> &box,
   c.oy = ylo_b - ymin;
   c.oz = zlo_b;
   return c;
+}
+
+inline linkcell::Cell lammpsBoxToLinkcell(const std::vector<double> &box,
+                                          const std::vector<double> &boxLow) {
+  return linkcell::Cell(lammpsBoxToLcCell(box, boxLow));
 }
 #endif
 

--- a/src/include/internal/neighbours.hpp
+++ b/src/include/internal/neighbours.hpp
@@ -16,9 +16,9 @@
 #define SEAMS_NEIGHBOURS_H_
 
 #include <array>
-#include <set>
 #include <string>
 #include <utility>
+#include <vector>
 
 #include <generic.hpp>
 #include <mol_sys.hpp>
@@ -186,7 +186,7 @@ private:
   std::vector<double> z0_;
   std::array<double, 3> box0_{};
   std::vector<std::pair<int, int>> candidates_;
-  std::set<std::pair<int, int>> bonded_;
+  std::vector<std::pair<int, int>> bonded_;
   std::vector<std::vector<int>> nList_;
 
   bool mustRebuild(

--- a/src/include/internal/neighbours.hpp
+++ b/src/include/internal/neighbours.hpp
@@ -97,9 +97,10 @@ std::vector<std::vector<int>> getNewNeighbourListByIndex(
  *  shell is mutual and the two coincide; on disordered packings the mutual
  *  graph is sparser, which starves accidental ring structure -- measured on
  *  the dense null, mutual scores zero false crystal where union reaches
- *  2.5%. Nominations are a periodic linked-cell k-nearest search
- *  (Allen and Tildesley): vesin is cutoff-only and KD-trees have no
- *  minimum-image convention. candidateCutoff is only a cell-size hint.
+ *  2.5%. Nominations are a periodic linked-cell k-nearest search via
+ *  linkcell (Allen and Tildesley): vesin is cutoff-only and KD-trees
+ *  have no minimum-image convention. candidateCutoff is only a
+ *  cell-size hint.
  *  On an undistorted tetrahedral lattice with k = 4 this graph equals
  *  the first-shell cutoff graph. Rows are by atom ID with the leading
  *  self entry, like neighListO.

--- a/src/include/internal/neighbours.hpp
+++ b/src/include/internal/neighbours.hpp
@@ -109,6 +109,14 @@ std::vector<std::vector<int>> kNearestNeighbourList(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int k,
     double candidateCutoff, int typeI, bool mutual = true);
 
+/** Mutual and union k-nearest graphs from one candidate search. Seeded
+ *  affiliation needs both; building them separately repeats the cell list.
+ */
+std::pair<std::vector<std::vector<int>>, std::vector<std::vector<int>>>
+kNearestNeighbourPair(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int k,
+    double candidateCutoff, int typeI);
+
 /** The shell-separation certificate for the exact reduction of the k-nearest
  *  graph to the cutoff graph: returns {max_i d_k(i), min_i d_{k+1}(i)} over
  *  particles of the type. When max_i d_k(i) <= rcutoff <= min_i d_{k+1}(i),

--- a/src/include/internal/neighbours.hpp
+++ b/src/include/internal/neighbours.hpp
@@ -97,13 +97,12 @@ std::vector<std::vector<int>> getNewNeighbourListByIndex(
  *  shell is mutual and the two coincide; on disordered packings the mutual
  *  graph is sparser, which starves accidental ring structure -- measured on
  *  the dense null, mutual scores zero false crystal where union reaches
- *  2.5%. Candidates come from the cell list at
- *  candidateCutoff, which must comfortably exceed the k-th neighbour
- *  distance. On an undistorted tetrahedral lattice with k = 4 this graph
- *  equals the first-shell cutoff graph; under thermal distortion it keeps
- *  the neighbour identities a hard cutoff loses, which is what the cage
- *  predicates need. Rows are by atom ID with the leading self entry, like
- *  neighListO.
+ *  2.5%. Nominations are a periodic linked-cell k-nearest search
+ *  (Allen and Tildesley): vesin is cutoff-only and KD-trees have no
+ *  minimum-image convention. candidateCutoff is only a cell-size hint.
+ *  On an undistorted tetrahedral lattice with k = 4 this graph equals
+ *  the first-shell cutoff graph. Rows are by atom ID with the leading
+ *  self entry, like neighListO.
  */
 std::vector<std::vector<int>> kNearestNeighbourList(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int k,

--- a/src/include/internal/topo_bulk.hpp
+++ b/src/include/internal/topo_bulk.hpp
@@ -154,7 +154,8 @@ bool basalNeighbours(const std::vector<std::vector<int>> &nList,
 //! Tests to check that elements of a triplet are not neighbours of a ring
 //! (vector) passed
 bool notNeighboursOfRing(const std::vector<std::vector<int>> &nList,
-                         std::vector<int> &triplet, std::vector<int> &ring);
+                         std::vector<int> &triplet,
+                         const std::vector<int> &ring);
 
 //! Finds the prismatic rings from basal rings iring and jring
 [[nodiscard]] int findPrismatic(const std::vector<std::vector<int>> &rings, std::vector<int> &listHC,

--- a/src/include/internal/topo_bulk.hpp
+++ b/src/include/internal/topo_bulk.hpp
@@ -143,7 +143,8 @@ bool conditionThreeDDC(const std::vector<std::vector<int>> &rings,
 
 //! Tests whether two rings are basal rings (true) or not (false)
 bool basalConditions(const std::vector<std::vector<int>> &nList,
-                     std::vector<int> &basal1, std::vector<int> &basal2);
+                     const std::vector<int> &basal1,
+                     const std::vector<int> &basal2);
 
 //! Tests whether the last two elements of a triplet are neighbours of two atom
 //! IDs passed in

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -638,12 +638,19 @@ std::vector<std::vector<int>> nominateByCellList(
   }
 
   const int maxReach = std::max({nx, ny, nz}) / 2 + 1;
+  std::vector<unsigned> seen(static_cast<std::size_t>(ncell), 0);
+  unsigned stamp = 1;
   for (const int i : owners) {
     std::priority_queue<std::pair<double, int>> heap;
     int ix = 0;
     int iy = 0;
     int iz = 0;
     cellOf(i, ix, iy, iz);
+    ++stamp;
+    if (stamp == 0) {
+      std::fill(seen.begin(), seen.end(), 0);
+      stamp = 1;
+    }
     int reach = 1;
     while (reach <= maxReach) {
       for (int dx = -reach; dx <= reach; dx++) {
@@ -655,8 +662,12 @@ std::vector<std::vector<int>> nominateByCellList(
             if (!shell && reach > 1) {
               continue;
             }
-            int j = head[static_cast<std::size_t>(
-                cellIndex(ix + dx, iy + dy, iz + dz))];
+            const int c = cellIndex(ix + dx, iy + dy, iz + dz);
+            if (seen[static_cast<std::size_t>(c)] == stamp) {
+              continue;
+            }
+            seen[static_cast<std::size_t>(c)] = stamp;
+            int j = head[static_cast<std::size_t>(c)];
             while (j >= 0) {
               if (j != i) {
                 const double d2 = gen::periodicDistSq(yCloud, i, j);

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -29,7 +29,7 @@
 #include <vesin.h>
 #endif
 #ifdef SEAMS_HAS_LINKCELL
-#include <linkcell.h>
+#include <linkcell.hpp>
 #endif
 
 namespace {
@@ -590,12 +590,14 @@ bool nominateByLinkcell(
   if (nSrc == 0) {
     return true;
   }
-  const lc_cell box = nneigh::lammpsBoxToLcCell(yCloud.box, yCloud.boxLow);
-  if (lc_knearest(xyz.data(), static_cast<std::size_t>(n), &box,
-                  static_cast<std::size_t>(k), mask.data(), cellHint,
-                  nom.data()) != 0) {
-    const char *msg = lc_last_error();
-    std::cerr << "linkcell failed: " << (msg ? msg : "unknown")
+  const linkcell::Cell cell =
+      nneigh::lammpsBoxToLinkcell(yCloud.box, yCloud.boxLow);
+  try {
+    linkcell::knearest_into(xyz.data(), static_cast<std::size_t>(n), cell,
+                            static_cast<std::size_t>(k), nom.data(),
+                            nom.size(), mask.data(), cellHint);
+  } catch (const linkcell::Error &e) {
+    std::cerr << "linkcell failed: " << e.what()
               << "; falling back to the in-tree cell list.\n";
     return false;
   }

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -561,12 +561,10 @@ int nneigh::clearNeighbourList(std::vector<std::vector<int>> &nList) {
 namespace {
 
 #ifdef SEAMS_HAS_LINKCELL
-// Packs the cloud and asks linkcell for the k-heap walk. mask drops
-// particles that are not typeI as both sources and candidates. Origin
-// is the dump boxLow so wrapped images match the in-tree MIC.
+// Writes n*k cloud indices, nearest first, unused slots -1.
 bool nominateByLinkcell(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int k,
-    int typeI, double cellHint, std::vector<std::vector<int>> &nominated) {
+    int typeI, double cellHint, std::vector<int> &nom) {
   const int n = yCloud.nop;
   if (n <= 0 || k <= 0 || yCloud.box.size() < 3) {
     return true;
@@ -594,62 +592,47 @@ bool nominateByLinkcell(
     return true;
   }
   lc_cell box = lc_cell_ortho(bx, by, bz);
+  if (yCloud.box.size() >= 6) {
+    box.bx = yCloud.box[3];
+    box.cx = yCloud.box[4];
+    box.cy = yCloud.box[5];
+  }
   if (yCloud.boxLow.size() >= 3) {
     box.ox = yCloud.boxLow[0];
     box.oy = yCloud.boxLow[1];
     box.oz = yCloud.boxLow[2];
   }
-  std::vector<int> out(static_cast<std::size_t>(n) * static_cast<std::size_t>(k),
-                       -1);
-  if (lc_knearest(xyz.data(), n, &box, k, mask.data(), cellHint, out.data()) !=
+  if (lc_knearest(xyz.data(), n, &box, k, mask.data(), cellHint, nom.data()) !=
       0) {
     const char *msg = lc_last_error();
     std::cerr << "linkcell failed: " << (msg ? msg : "unknown")
               << "; falling back to the in-tree cell list.\n";
     return false;
   }
-  for (int i = 0; i < n; i++) {
-    if (mask[static_cast<std::size_t>(i)] == 0) {
-      continue;
-    }
-    auto &row = nominated[static_cast<std::size_t>(i)];
-    row.clear();
-    row.reserve(static_cast<std::size_t>(k));
-    for (int t = 0; t < k; t++) {
-      const int j =
-          out[static_cast<std::size_t>(i) * static_cast<std::size_t>(k) +
-              static_cast<std::size_t>(t)];
-      if (j >= 0) {
-        row.push_back(j);
-      }
-    }
-  }
   return true;
 }
 #endif
 
-// Periodic cell-list k-nearest (Allen and Tildesley). linkcell is the
-// library that owns this walk; vesin is cutoff-only and nanoflann
-// KD-trees have no MIC. The in-tree copy is the fallback when the
-// wrap is absent.
-std::vector<std::vector<int>> nominateByCellList(
+// Packed n*k nominations, nearest first, unused slots -1.
+std::vector<int> nominatePacked(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int k,
     int typeI, double cellHint) {
-  std::vector<std::vector<int>> nominated(
-      static_cast<std::size_t>(yCloud.nop));
-  if (yCloud.nop <= 0 || k <= 0 || yCloud.box.size() < 3) {
-    return nominated;
+  const int n = yCloud.nop;
+  std::vector<int> nom(static_cast<std::size_t>(n) * static_cast<std::size_t>(k),
+                       -1);
+  if (n <= 0 || k <= 0 || yCloud.box.size() < 3) {
+    return nom;
   }
 #ifdef SEAMS_HAS_LINKCELL
-  if (nominateByLinkcell(yCloud, k, typeI, cellHint, nominated)) {
-    return nominated;
+  if (nominateByLinkcell(yCloud, k, typeI, cellHint, nom)) {
+    return nom;
   }
 #endif
   const double bx = yCloud.box[0];
   const double by = yCloud.box[1];
   const double bz = yCloud.box[2];
   if (!(bx > 0.0 && by > 0.0 && bz > 0.0)) {
-    return nominated;
+    return nom;
   }
   const double xlo = yCloud.boxLow.size() >= 3 ? yCloud.boxLow[0] : 0.0;
   const double ylo = yCloud.boxLow.size() >= 3 ? yCloud.boxLow[1] : 0.0;
@@ -768,18 +751,28 @@ std::vector<std::vector<int>> nominateByCellList(
       }
       ++reach;
     }
-    auto &row = nominated[static_cast<std::size_t>(i)];
-    row.resize(heap.size());
-    for (int t = static_cast<int>(row.size()) - 1; t >= 0; t--) {
-      row[static_cast<std::size_t>(t)] = heap.top().second;
+    const int take = std::min(k, static_cast<int>(heap.size()));
+    for (int t = take - 1; t >= 0; t--) {
+      nom[static_cast<std::size_t>(i) * static_cast<std::size_t>(k) +
+          static_cast<std::size_t>(t)] = heap.top().second;
       heap.pop();
     }
   }
-  return nominated;
+  return nom;
 }
 
-bool listsIndex(const std::vector<int> &row, int j) {
-  return std::find(row.begin(), row.end(), j) != row.end();
+bool listsPacked(const std::vector<int> &nom, int n, int k, int i, int j) {
+  if (i < 0 || i >= n) {
+    return false;
+  }
+  const std::size_t base =
+      static_cast<std::size_t>(i) * static_cast<std::size_t>(k);
+  for (int t = 0; t < k; t++) {
+    if (nom[base + static_cast<std::size_t>(t)] == j) {
+      return true;
+    }
+  }
+  return false;
 }
 
 void addUndirectedIDs(
@@ -792,34 +785,67 @@ void addUndirectedIDs(
       yCloud.pts[static_cast<std::size_t>(i)].atomID);
 }
 
-// Mutual: i and j each list the other. Union: either lists the other.
-// k is 4 on ice; a 4-wide scan replaces two red-black trees.
-std::vector<std::vector<int>> symmetrizeNominations(
+void fillGraphFromNom(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
-    const std::vector<std::vector<int>> &nominated, bool mutual) {
+    const std::vector<int> &nom, int k, bool mutual,
+    std::vector<std::vector<int>> &out) {
   const int n = yCloud.nop;
-  std::vector<std::vector<int>> out(static_cast<std::size_t>(n));
+  std::vector<int> deg(static_cast<std::size_t>(n), 0);
   for (int i = 0; i < n; i++) {
+    for (int t = 0; t < k; t++) {
+      const int j =
+          nom[static_cast<std::size_t>(i) * static_cast<std::size_t>(k) +
+              static_cast<std::size_t>(t)];
+      if (j < 0 || j >= n || j == i) {
+        continue;
+      }
+      const bool listed = listsPacked(nom, n, k, j, i);
+      if (mutual) {
+        if (i < j && listed) {
+          deg[static_cast<std::size_t>(i)]++;
+          deg[static_cast<std::size_t>(j)]++;
+        }
+      } else if (i < j || !listed) {
+        deg[static_cast<std::size_t>(i)]++;
+        deg[static_cast<std::size_t>(j)]++;
+      }
+    }
+  }
+  out.assign(static_cast<std::size_t>(n), {});
+  for (int i = 0; i < n; i++) {
+    out[static_cast<std::size_t>(i)].reserve(
+        static_cast<std::size_t>(1 + deg[static_cast<std::size_t>(i)]));
     out[static_cast<std::size_t>(i)].push_back(
         yCloud.pts[static_cast<std::size_t>(i)].atomID);
   }
   for (int i = 0; i < n; i++) {
-    for (const int j : nominated[static_cast<std::size_t>(i)]) {
+    for (int t = 0; t < k; t++) {
+      const int j =
+          nom[static_cast<std::size_t>(i) * static_cast<std::size_t>(k) +
+              static_cast<std::size_t>(t)];
       if (j < 0 || j >= n || j == i) {
         continue;
       }
+      const bool listed = listsPacked(nom, n, k, j, i);
       if (mutual) {
-        if (i < j && listsIndex(nominated[static_cast<std::size_t>(j)], i)) {
+        if (i < j && listed) {
           addUndirectedIDs(out, yCloud, i, j);
         }
       } else if (i < j) {
         addUndirectedIDs(out, yCloud, i, j);
-      } else if (!listsIndex(nominated[static_cast<std::size_t>(j)], i)) {
+      } else if (!listed) {
         addUndirectedIDs(out, yCloud, i, j);
       }
     }
   }
-  return out;
+}
+
+void fillBothGraphsFromNom(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+    const std::vector<int> &nom, int k, std::vector<std::vector<int>> &mutual,
+    std::vector<std::vector<int>> &uni) {
+  fillGraphFromNom(yCloud, nom, k, true, mutual);
+  fillGraphFromNom(yCloud, nom, k, false, uni);
 }
 
 } // namespace
@@ -832,8 +858,10 @@ nneigh::kNearestNeighbourList(
     return {};
   }
   const double hint = candidateCutoff > 0.0 ? 0.75 * candidateCutoff : 3.0;
-  auto nominated = nominateByCellList(yCloud, k, typeI, hint);
-  return symmetrizeNominations(yCloud, nominated, mutual);
+  const auto nom = nominatePacked(yCloud, k, typeI, hint);
+  std::vector<std::vector<int>> out;
+  fillGraphFromNom(yCloud, nom, k, mutual, out);
+  return out;
 }
 
 std::pair<std::vector<std::vector<int>>, std::vector<std::vector<int>>>
@@ -844,9 +872,11 @@ nneigh::kNearestNeighbourPair(
     return {{}, {}};
   }
   const double hint = candidateCutoff > 0.0 ? 0.75 * candidateCutoff : 3.0;
-  auto nominated = nominateByCellList(yCloud, k, typeI, hint);
-  return {symmetrizeNominations(yCloud, nominated, true),
-          symmetrizeNominations(yCloud, nominated, false)};
+  const auto nom = nominatePacked(yCloud, k, typeI, hint);
+  std::vector<std::vector<int>> mutual;
+  std::vector<std::vector<int>> uni;
+  fillBothGraphsFromNom(yCloud, nom, k, mutual, uni);
+  return {std::move(mutual), std::move(uni)};
 }
 
 /**
@@ -1004,26 +1034,50 @@ void nneigh::SkinNeighborList::rebuildCandidates(
 
 void nneigh::SkinNeighborList::refreshBonds(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud) {
-  std::set<std::pair<int, int>> next;
+  std::vector<std::pair<int, int>> next;
+  next.reserve(candidates_.size());
+  const std::size_t m = candidates_.size();
+  std::vector<double> dx(m), dy(m), dz(m), r2(m);
+  for (std::size_t t = 0; t < m; t++) {
+    const int i = candidates_[t].first;
+    const int j = candidates_[t].second;
+    if (i < 0 || j < 0 || i >= yCloud.nop || j >= yCloud.nop) {
+      dx[t] = dy[t] = dz[t] = 0.0;
+      continue;
+    }
+    dx[t] = yCloud.pts[static_cast<std::size_t>(j)].x -
+            yCloud.pts[static_cast<std::size_t>(i)].x;
+    dy[t] = yCloud.pts[static_cast<std::size_t>(j)].y -
+            yCloud.pts[static_cast<std::size_t>(i)].y;
+    dz[t] = yCloud.pts[static_cast<std::size_t>(j)].z -
+            yCloud.pts[static_cast<std::size_t>(i)].z;
+  }
+  if (yCloud.box.size() >= 3 && m > 0) {
+    seams::BatchPeriodicDistSq(dx.data(), dy.data(), dz.data(), yCloud.box[0],
+                               yCloud.box[1], yCloud.box[2], r2.data(), m);
+  }
   if (k_ <= 0) {
-    for (const auto &[i, j] : candidates_) {
+    for (std::size_t t = 0; t < m; t++) {
+      const int i = candidates_[t].first;
+      const int j = candidates_[t].second;
       if (i < 0 || j < 0 || i >= yCloud.nop || j >= yCloud.nop) {
         continue;
       }
-      if (gen::periodicDistSq(yCloud, i, j) <= cutoffSq_) {
-        next.emplace(i, j);
+      if (r2[t] <= cutoffSq_) {
+        next.emplace_back(i, j);
       }
     }
   } else {
     std::vector<std::vector<std::pair<double, int>>> byDist(
         static_cast<std::size_t>(yCloud.nop));
-    for (const auto &[i, j] : candidates_) {
+    for (std::size_t t = 0; t < m; t++) {
+      const int i = candidates_[t].first;
+      const int j = candidates_[t].second;
       if (i < 0 || j < 0 || i >= yCloud.nop || j >= yCloud.nop) {
         continue;
       }
-      const double r2 = gen::periodicDistSq(yCloud, i, j);
-      byDist[static_cast<std::size_t>(i)].emplace_back(r2, j);
-      byDist[static_cast<std::size_t>(j)].emplace_back(r2, i);
+      byDist[static_cast<std::size_t>(i)].emplace_back(r2[t], j);
+      byDist[static_cast<std::size_t>(j)].emplace_back(r2[t], i);
     }
     std::vector<std::vector<int>> nominated(static_cast<std::size_t>(yCloud.nop));
     for (int i = 0; i < yCloud.nop; i++) {
@@ -1048,22 +1102,34 @@ void nneigh::SkinNeighborList::refreshBonds(
             continue;
           }
         }
-        next.emplace(a, b);
+        next.emplace_back(a, b);
       }
     }
+    std::sort(next.begin(), next.end());
+    next.erase(std::unique(next.begin(), next.end()), next.end());
   }
-  std::set<int> touched;
-  for (const auto &p : bonded_) {
-    if (next.count(p) == 0) {
-      touched.insert(p.first);
-      touched.insert(p.second);
+  std::sort(next.begin(), next.end());
+  next.erase(std::unique(next.begin(), next.end()), next.end());
+  std::vector<int> touched;
+  {
+    std::size_t a = 0;
+    std::size_t b = 0;
+    while (a < bonded_.size() || b < next.size()) {
+      if (b == next.size() || (a < bonded_.size() && bonded_[a] < next[b])) {
+        touched.push_back(bonded_[a].first);
+        touched.push_back(bonded_[a].second);
+        ++a;
+      } else if (a == bonded_.size() || next[b] < bonded_[a]) {
+        touched.push_back(next[b].first);
+        touched.push_back(next[b].second);
+        ++b;
+      } else {
+        ++a;
+        ++b;
+      }
     }
-  }
-  for (const auto &p : next) {
-    if (bonded_.count(p) == 0) {
-      touched.insert(p.first);
-      touched.insert(p.second);
-    }
+    std::sort(touched.begin(), touched.end());
+    touched.erase(std::unique(touched.begin(), touched.end()), touched.end());
   }
   changedAtoms_ = static_cast<int>(touched.size());
   bonded_.swap(next);

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -17,7 +17,6 @@
 #include <iostream>
 #include <numeric>
 #include <queue>
-#include <set>
 #include <span>
 #include <stdexcept>
 #include <string>
@@ -591,19 +590,10 @@ bool nominateByLinkcell(
   if (nSrc == 0) {
     return true;
   }
-  lc_cell box = lc_cell_ortho(bx, by, bz);
-  if (yCloud.box.size() >= 6) {
-    box.bx = yCloud.box[3];
-    box.cx = yCloud.box[4];
-    box.cy = yCloud.box[5];
-  }
-  if (yCloud.boxLow.size() >= 3) {
-    box.ox = yCloud.boxLow[0];
-    box.oy = yCloud.boxLow[1];
-    box.oz = yCloud.boxLow[2];
-  }
-  if (lc_knearest(xyz.data(), n, &box, k, mask.data(), cellHint, nom.data()) !=
-      0) {
+  const lc_cell box = nneigh::lammpsBoxToLcCell(yCloud.box, yCloud.boxLow);
+  if (lc_knearest(xyz.data(), static_cast<std::size_t>(n), &box,
+                  static_cast<std::size_t>(k), mask.data(), cellHint,
+                  nom.data()) != 0) {
     const char *msg = lc_last_error();
     std::cerr << "linkcell failed: " << (msg ? msg : "unknown")
               << "; falling back to the in-tree cell list.\n";

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -87,6 +87,10 @@ bool cellListPairs(const molSys::PointCloud<molSys::Point<double>, double> &yClo
                    const std::vector<int> &subset, double rcutoff,
                    std::vector<std::pair<int, int>> &pairs) {
   const size_t nSubset = subset.size();
+  if (nSubset == 0) {
+    pairs.clear();
+    return true;
+  }
   std::vector<std::array<double, 3>> positions(nSubset);
   for (size_t i = 0; i < nSubset; i++) {
     const int idx = subset[i];

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -16,6 +16,7 @@
 #include <cmath>
 #include <iostream>
 #include <numeric>
+#include <queue>
 #include <set>
 #include <span>
 #include <stdexcept>
@@ -556,51 +557,134 @@ int nneigh::clearNeighbourList(std::vector<std::vector<int>> &nList) {
  */
 namespace {
 
-std::vector<std::vector<int>> nominateKNearest(
-    const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
-    const std::vector<std::vector<int>> &candidateRows, int k, int typeI) {
+// Periodic cell-list k-nearest (Allen and Tildesley, Computer Simulation
+// of Liquids). vesin is cutoff-only; nanoflann KD-trees have no MIC, so
+// the linked-cell walk with a k-heap is the right search on a dump cell.
+std::vector<std::vector<int>> nominateByCellList(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int k,
+    int typeI, double cellHint) {
   std::vector<std::vector<int>> nominated(
       static_cast<std::size_t>(yCloud.nop));
-  std::vector<std::pair<double, int>> byDist;
-  for (int i = 0; i < yCloud.nop; i++) {
-    const auto &row = candidateRows[static_cast<std::size_t>(i)];
-    if (row.size() <= 1) {
-      continue;
-    }
-    byDist.clear();
-    for (size_t m = 1; m < row.size(); m++) {
-      const auto it = yCloud.idIndexMap.find(row[m]);
-      if (it == yCloud.idIndexMap.end()) {
-        continue;
-      }
-      byDist.emplace_back(gen::periodicDistSq(yCloud, i, it->second),
-                          it->second);
-    }
-    const size_t keep = std::min(static_cast<size_t>(k), byDist.size());
-    std::partial_sort(byDist.begin(), byDist.begin() + keep, byDist.end());
-    nominated[static_cast<std::size_t>(i)].reserve(keep);
-    for (size_t m = 0; m < keep; m++) {
-      nominated[static_cast<std::size_t>(i)].push_back(byDist[m].second);
-    }
+  if (yCloud.nop <= 0 || k <= 0 || yCloud.box.size() < 3) {
+    return nominated;
   }
+  const double bx = yCloud.box[0];
+  const double by = yCloud.box[1];
+  const double bz = yCloud.box[2];
+  if (!(bx > 0.0 && by > 0.0 && bz > 0.0)) {
+    return nominated;
+  }
+  const double xlo = yCloud.boxLow.size() >= 3 ? yCloud.boxLow[0] : 0.0;
+  const double ylo = yCloud.boxLow.size() >= 3 ? yCloud.boxLow[1] : 0.0;
+  const double zlo = yCloud.boxLow.size() >= 3 ? yCloud.boxLow[2] : 0.0;
+  double edge = cellHint > 0.0 ? cellHint : 3.0;
+  edge = std::min({edge, bx, by, bz});
+  int nx = std::max(1, static_cast<int>(std::floor(bx / edge)));
+  int ny = std::max(1, static_cast<int>(std::floor(by / edge)));
+  int nz = std::max(1, static_cast<int>(std::floor(bz / edge)));
+  const int ncell = nx * ny * nz;
+  const double invx = static_cast<double>(nx) / bx;
+  const double invy = static_cast<double>(ny) / by;
+  const double invz = static_cast<double>(nz) / bz;
+  const double cellMin = std::min({bx / nx, by / ny, bz / nz});
+
+  std::vector<int> head(static_cast<std::size_t>(ncell), -1);
+  std::vector<int> next(static_cast<std::size_t>(yCloud.nop), -1);
+  std::vector<int> owners;
+  owners.reserve(static_cast<std::size_t>(yCloud.nop));
+
+  auto wrap = [](double x, double L) {
+    double t = x / L;
+    t -= std::floor(t);
+    return t * L;
+  };
+  auto cellOf = [&](int iatom, int &ix, int &iy, int &iz) {
+    const auto &p = yCloud.pts[static_cast<std::size_t>(iatom)];
+    const double x = wrap(p.x - xlo, bx);
+    const double y = wrap(p.y - ylo, by);
+    const double z = wrap(p.z - zlo, bz);
+    ix = std::min(nx - 1, std::max(0, static_cast<int>(x * invx)));
+    iy = std::min(ny - 1, std::max(0, static_cast<int>(y * invy)));
+    iz = std::min(nz - 1, std::max(0, static_cast<int>(z * invz)));
+  };
+  auto cellIndex = [&](int ix, int iy, int iz) {
+    ix %= nx;
+    if (ix < 0) {
+      ix += nx;
+    }
+    iy %= ny;
+    if (iy < 0) {
+      iy += ny;
+    }
+    iz %= nz;
+    if (iz < 0) {
+      iz += nz;
+    }
+    return (iz * ny + iy) * nx + ix;
+  };
+
   for (int i = 0; i < yCloud.nop; i++) {
-    if (yCloud.pts[static_cast<std::size_t>(i)].type != typeI ||
-        static_cast<int>(nominated[static_cast<std::size_t>(i)].size()) >=
-            k) {
+    if (yCloud.pts[static_cast<std::size_t>(i)].type != typeI) {
       continue;
     }
-    byDist.clear();
-    for (int j = 0; j < yCloud.nop; j++) {
-      if (j == i || yCloud.pts[static_cast<std::size_t>(j)].type != typeI) {
-        continue;
+    int ix = 0;
+    int iy = 0;
+    int iz = 0;
+    cellOf(i, ix, iy, iz);
+    const int c = cellIndex(ix, iy, iz);
+    next[static_cast<std::size_t>(i)] = head[static_cast<std::size_t>(c)];
+    head[static_cast<std::size_t>(c)] = i;
+    owners.push_back(i);
+  }
+
+  const int maxReach = std::max({nx, ny, nz}) / 2 + 1;
+  for (const int i : owners) {
+    std::priority_queue<std::pair<double, int>> heap;
+    int ix = 0;
+    int iy = 0;
+    int iz = 0;
+    cellOf(i, ix, iy, iz);
+    int reach = 1;
+    while (reach <= maxReach) {
+      for (int dx = -reach; dx <= reach; dx++) {
+        for (int dy = -reach; dy <= reach; dy++) {
+          for (int dz = -reach; dz <= reach; dz++) {
+            const bool shell = (reach == 1) || (std::abs(dx) == reach ||
+                                                std::abs(dy) == reach ||
+                                                std::abs(dz) == reach);
+            if (!shell && reach > 1) {
+              continue;
+            }
+            int j = head[static_cast<std::size_t>(
+                cellIndex(ix + dx, iy + dy, iz + dz))];
+            while (j >= 0) {
+              if (j != i) {
+                const double d2 = gen::periodicDistSq(yCloud, i, j);
+                if (static_cast<int>(heap.size()) < k) {
+                  heap.push({d2, j});
+                } else if (d2 < heap.top().first) {
+                  heap.pop();
+                  heap.push({d2, j});
+                }
+              }
+              j = next[static_cast<std::size_t>(j)];
+            }
+          }
+        }
       }
-      byDist.emplace_back(gen::periodicDistSq(yCloud, i, j), j);
+      if (static_cast<int>(heap.size()) >= k) {
+        const double bound = static_cast<double>(reach) * cellMin;
+        if (heap.top().first <= bound * bound) {
+          break;
+        }
+      }
+      ++reach;
     }
-    const size_t keep = std::min(static_cast<size_t>(k), byDist.size());
-    std::partial_sort(byDist.begin(), byDist.begin() + keep, byDist.end());
-    nominated[static_cast<std::size_t>(i)].clear();
-    for (size_t m = 0; m < keep; m++) {
-      nominated[static_cast<std::size_t>(i)].push_back(byDist[m].second);
+    auto &row = nominated[static_cast<std::size_t>(i)];
+    row.resize(heap.size());
+    for (int t = static_cast<int>(row.size()) - 1; t >= 0; t--) {
+      row[static_cast<std::size_t>(t)] = heap.top().second;
+      heap.pop();
     }
   }
   return nominated;
@@ -608,14 +692,11 @@ std::vector<std::vector<int>> nominateKNearest(
 
 std::vector<std::vector<int>> symmetrizeNominations(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
-    const std::vector<std::vector<int>> &candidateRows,
     const std::vector<std::vector<int>> &nominated, bool mutual) {
   std::vector<std::vector<int>> out(static_cast<std::size_t>(yCloud.nop));
   for (int i = 0; i < yCloud.nop; i++) {
     out[static_cast<std::size_t>(i)].push_back(
-        candidateRows[static_cast<std::size_t>(i)].empty()
-            ? yCloud.pts[static_cast<std::size_t>(i)].atomID
-            : candidateRows[static_cast<std::size_t>(i)][0]);
+        yCloud.pts[static_cast<std::size_t>(i)].atomID);
   }
   std::set<std::pair<int, int>> bonds;
   if (mutual) {
@@ -652,27 +733,25 @@ std::vector<std::vector<int>>
 nneigh::kNearestNeighbourList(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int k,
     double candidateCutoff, int typeI, bool mutual) {
-  std::vector<std::vector<int>> candidateRows =
-      nneigh::neighListO(candidateCutoff, yCloud, typeI);
-  if (candidateRows.empty() || k <= 0) {
-    return candidateRows;
+  if (yCloud.nop <= 0 || k <= 0) {
+    return {};
   }
-  auto nominated = nominateKNearest(yCloud, candidateRows, k, typeI);
-  return symmetrizeNominations(yCloud, candidateRows, nominated, mutual);
+  const double hint = candidateCutoff > 0.0 ? 0.75 * candidateCutoff : 3.0;
+  auto nominated = nominateByCellList(yCloud, k, typeI, hint);
+  return symmetrizeNominations(yCloud, nominated, mutual);
 }
 
 std::pair<std::vector<std::vector<int>>, std::vector<std::vector<int>>>
 nneigh::kNearestNeighbourPair(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int k,
     double candidateCutoff, int typeI) {
-  std::vector<std::vector<int>> candidateRows =
-      nneigh::neighListO(candidateCutoff, yCloud, typeI);
-  if (candidateRows.empty() || k <= 0) {
-    return {candidateRows, candidateRows};
+  if (yCloud.nop <= 0 || k <= 0) {
+    return {{}, {}};
   }
-  auto nominated = nominateKNearest(yCloud, candidateRows, k, typeI);
-  return {symmetrizeNominations(yCloud, candidateRows, nominated, true),
-          symmetrizeNominations(yCloud, candidateRows, nominated, false)};
+  const double hint = candidateCutoff > 0.0 ? 0.75 * candidateCutoff : 3.0;
+  auto nominated = nominateByCellList(yCloud, k, typeI, hint);
+  return {symmetrizeNominations(yCloud, nominated, true),
+          symmetrizeNominations(yCloud, nominated, false)};
 }
 
 /**

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -29,6 +29,9 @@
 #ifdef SEAMS_HAS_VESIN
 #include <vesin.h>
 #endif
+#ifdef SEAMS_HAS_LINKCELL
+#include <linkcell.h>
+#endif
 
 namespace {
 
@@ -557,9 +560,78 @@ int nneigh::clearNeighbourList(std::vector<std::vector<int>> &nList) {
  */
 namespace {
 
-// Periodic cell-list k-nearest (Allen and Tildesley, Computer Simulation
-// of Liquids). vesin is cutoff-only; nanoflann KD-trees have no MIC, so
-// the linked-cell walk with a k-heap is the right search on a dump cell.
+#ifdef SEAMS_HAS_LINKCELL
+// Packs the cloud and asks linkcell for the k-heap walk. mask drops
+// particles that are not typeI as both sources and candidates. Origin
+// is the dump boxLow so wrapped images match the in-tree MIC.
+bool nominateByLinkcell(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int k,
+    int typeI, double cellHint, std::vector<std::vector<int>> &nominated) {
+  const int n = yCloud.nop;
+  if (n <= 0 || k <= 0 || yCloud.box.size() < 3) {
+    return true;
+  }
+  const double bx = yCloud.box[0];
+  const double by = yCloud.box[1];
+  const double bz = yCloud.box[2];
+  if (!(bx > 0.0 && by > 0.0 && bz > 0.0)) {
+    return true;
+  }
+  std::vector<double> xyz(static_cast<std::size_t>(n) * 3);
+  std::vector<int> mask(static_cast<std::size_t>(n), 0);
+  int nSrc = 0;
+  for (int i = 0; i < n; i++) {
+    const auto &p = yCloud.pts[static_cast<std::size_t>(i)];
+    xyz[static_cast<std::size_t>(i) * 3 + 0] = p.x;
+    xyz[static_cast<std::size_t>(i) * 3 + 1] = p.y;
+    xyz[static_cast<std::size_t>(i) * 3 + 2] = p.z;
+    if (p.type == typeI) {
+      mask[static_cast<std::size_t>(i)] = 1;
+      ++nSrc;
+    }
+  }
+  if (nSrc == 0) {
+    return true;
+  }
+  lc_cell box = lc_cell_ortho(bx, by, bz);
+  if (yCloud.boxLow.size() >= 3) {
+    box.ox = yCloud.boxLow[0];
+    box.oy = yCloud.boxLow[1];
+    box.oz = yCloud.boxLow[2];
+  }
+  std::vector<int> out(static_cast<std::size_t>(n) * static_cast<std::size_t>(k),
+                       -1);
+  if (lc_knearest(xyz.data(), n, &box, k, mask.data(), cellHint, out.data()) !=
+      0) {
+    const char *msg = lc_last_error();
+    std::cerr << "linkcell failed: " << (msg ? msg : "unknown")
+              << "; falling back to the in-tree cell list.\n";
+    return false;
+  }
+  for (int i = 0; i < n; i++) {
+    if (mask[static_cast<std::size_t>(i)] == 0) {
+      continue;
+    }
+    auto &row = nominated[static_cast<std::size_t>(i)];
+    row.clear();
+    row.reserve(static_cast<std::size_t>(k));
+    for (int t = 0; t < k; t++) {
+      const int j =
+          out[static_cast<std::size_t>(i) * static_cast<std::size_t>(k) +
+              static_cast<std::size_t>(t)];
+      if (j >= 0) {
+        row.push_back(j);
+      }
+    }
+  }
+  return true;
+}
+#endif
+
+// Periodic cell-list k-nearest (Allen and Tildesley). linkcell is the
+// library that owns this walk; vesin is cutoff-only and nanoflann
+// KD-trees have no MIC. The in-tree copy is the fallback when the
+// wrap is absent.
 std::vector<std::vector<int>> nominateByCellList(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int k,
     int typeI, double cellHint) {
@@ -568,6 +640,11 @@ std::vector<std::vector<int>> nominateByCellList(
   if (yCloud.nop <= 0 || k <= 0 || yCloud.box.size() < 3) {
     return nominated;
   }
+#ifdef SEAMS_HAS_LINKCELL
+  if (nominateByLinkcell(yCloud, k, typeI, cellHint, nominated)) {
+    return nominated;
+  }
+#endif
   const double bx = yCloud.box[0];
   const double by = yCloud.box[1];
   const double bz = yCloud.box[2];

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -554,21 +554,16 @@ int nneigh::clearNeighbourList(std::vector<std::vector<int>> &nList) {
  * @return Row-ordered full neighbour list by atom ID, one row per atom with
  *  the leading self entry, like neighListO.
  */
-std::vector<std::vector<int>>
-nneigh::kNearestNeighbourList(
-    const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int k,
-    double candidateCutoff, int typeI, bool mutual) {
-  std::vector<std::vector<int>> candidateRows =
-      nneigh::neighListO(candidateCutoff, yCloud, typeI);
-  if (candidateRows.empty() || k <= 0) {
-    return candidateRows;
-  }
+namespace {
 
-  // Directed nominations: each atom's k nearest among the candidates
-  std::vector<std::vector<int>> nominated(yCloud.nop);
-  std::vector<std::pair<double, int>> byDist; // (distance^2, neighbour index)
+std::vector<std::vector<int>> nominateKNearest(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+    const std::vector<std::vector<int>> &candidateRows, int k, int typeI) {
+  std::vector<std::vector<int>> nominated(
+      static_cast<std::size_t>(yCloud.nop));
+  std::vector<std::pair<double, int>> byDist;
   for (int i = 0; i < yCloud.nop; i++) {
-    const auto &row = candidateRows[i];
+    const auto &row = candidateRows[static_cast<std::size_t>(i)];
     if (row.size() <= 1) {
       continue;
     }
@@ -583,50 +578,50 @@ nneigh::kNearestNeighbourList(
     }
     const size_t keep = std::min(static_cast<size_t>(k), byDist.size());
     std::partial_sort(byDist.begin(), byDist.begin() + keep, byDist.end());
-    nominated[i].reserve(keep);
+    nominated[static_cast<std::size_t>(i)].reserve(keep);
     for (size_t m = 0; m < keep; m++) {
-      nominated[i].push_back(byDist[m].second);
+      nominated[static_cast<std::size_t>(i)].push_back(byDist[m].second);
     }
   }
-
-  // Exactness fallback: an atom whose k-th neighbour lies beyond the
-  // candidate cutoff got a truncated nomination; recompute those few by a
-  // brute-force scan so the k nearest are exact regardless of the cutoff
   for (int i = 0; i < yCloud.nop; i++) {
-    if (yCloud.pts[i].type != typeI ||
-        static_cast<int>(nominated[i].size()) >= k) {
+    if (yCloud.pts[static_cast<std::size_t>(i)].type != typeI ||
+        static_cast<int>(nominated[static_cast<std::size_t>(i)].size()) >=
+            k) {
       continue;
     }
     byDist.clear();
     for (int j = 0; j < yCloud.nop; j++) {
-      if (j == i || yCloud.pts[j].type != typeI) {
+      if (j == i || yCloud.pts[static_cast<std::size_t>(j)].type != typeI) {
         continue;
       }
       byDist.emplace_back(gen::periodicDistSq(yCloud, i, j), j);
     }
     const size_t keep = std::min(static_cast<size_t>(k), byDist.size());
     std::partial_sort(byDist.begin(), byDist.begin() + keep, byDist.end());
-    nominated[i].clear();
+    nominated[static_cast<std::size_t>(i)].clear();
     for (size_t m = 0; m < keep; m++) {
-      nominated[i].push_back(byDist[m].second);
+      nominated[static_cast<std::size_t>(i)].push_back(byDist[m].second);
     }
   }
+  return nominated;
+}
 
-  // Union symmetrization into ID rows with the leading self entry
-  std::vector<std::vector<int>> out(yCloud.nop);
+std::vector<std::vector<int>> symmetrizeNominations(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+    const std::vector<std::vector<int>> &candidateRows,
+    const std::vector<std::vector<int>> &nominated, bool mutual) {
+  std::vector<std::vector<int>> out(static_cast<std::size_t>(yCloud.nop));
   for (int i = 0; i < yCloud.nop; i++) {
-    out[i].push_back(candidateRows[i].empty() ? yCloud.pts[i].atomID
-                                              : candidateRows[i][0]);
+    out[static_cast<std::size_t>(i)].push_back(
+        candidateRows[static_cast<std::size_t>(i)].empty()
+            ? yCloud.pts[static_cast<std::size_t>(i)].atomID
+            : candidateRows[static_cast<std::size_t>(i)][0]);
   }
   std::set<std::pair<int, int>> bonds;
   if (mutual) {
-    // Intersection symmetrization: a bond requires both nominations. In a
-    // crystal the first shell is mutual, so this equals the union graph
-    // there; on disordered packings one-sided nominations vanish, which is
-    // what starves the accidental ring complexes
     std::set<std::pair<int, int>> directed;
     for (int i = 0; i < yCloud.nop; i++) {
-      for (const int j : nominated[i]) {
+      for (const int j : nominated[static_cast<std::size_t>(i)]) {
         directed.emplace(i, j);
       }
     }
@@ -637,16 +632,47 @@ nneigh::kNearestNeighbourList(
     }
   } else {
     for (int i = 0; i < yCloud.nop; i++) {
-      for (const int j : nominated[i]) {
+      for (const int j : nominated[static_cast<std::size_t>(i)]) {
         bonds.emplace(std::min(i, j), std::max(i, j));
       }
     }
   }
   for (const auto &[i, j] : bonds) {
-    out[i].push_back(yCloud.pts[j].atomID);
-    out[j].push_back(yCloud.pts[i].atomID);
+    out[static_cast<std::size_t>(i)].push_back(
+        yCloud.pts[static_cast<std::size_t>(j)].atomID);
+    out[static_cast<std::size_t>(j)].push_back(
+        yCloud.pts[static_cast<std::size_t>(i)].atomID);
   }
   return out;
+}
+
+} // namespace
+
+std::vector<std::vector<int>>
+nneigh::kNearestNeighbourList(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int k,
+    double candidateCutoff, int typeI, bool mutual) {
+  std::vector<std::vector<int>> candidateRows =
+      nneigh::neighListO(candidateCutoff, yCloud, typeI);
+  if (candidateRows.empty() || k <= 0) {
+    return candidateRows;
+  }
+  auto nominated = nominateKNearest(yCloud, candidateRows, k, typeI);
+  return symmetrizeNominations(yCloud, candidateRows, nominated, mutual);
+}
+
+std::pair<std::vector<std::vector<int>>, std::vector<std::vector<int>>>
+nneigh::kNearestNeighbourPair(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int k,
+    double candidateCutoff, int typeI) {
+  std::vector<std::vector<int>> candidateRows =
+      nneigh::neighListO(candidateCutoff, yCloud, typeI);
+  if (candidateRows.empty() || k <= 0) {
+    return {candidateRows, candidateRows};
+  }
+  auto nominated = nominateKNearest(yCloud, candidateRows, k, typeI);
+  return {symmetrizeNominations(yCloud, candidateRows, nominated, true),
+          symmetrizeNominations(yCloud, candidateRows, nominated, false)};
 }
 
 /**

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -778,39 +778,46 @@ std::vector<std::vector<int>> nominateByCellList(
   return nominated;
 }
 
+bool listsIndex(const std::vector<int> &row, int j) {
+  return std::find(row.begin(), row.end(), j) != row.end();
+}
+
+void addUndirectedIDs(
+    std::vector<std::vector<int>> &out,
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int i,
+    int j) {
+  out[static_cast<std::size_t>(i)].push_back(
+      yCloud.pts[static_cast<std::size_t>(j)].atomID);
+  out[static_cast<std::size_t>(j)].push_back(
+      yCloud.pts[static_cast<std::size_t>(i)].atomID);
+}
+
+// Mutual: i and j each list the other. Union: either lists the other.
+// k is 4 on ice; a 4-wide scan replaces two red-black trees.
 std::vector<std::vector<int>> symmetrizeNominations(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
     const std::vector<std::vector<int>> &nominated, bool mutual) {
-  std::vector<std::vector<int>> out(static_cast<std::size_t>(yCloud.nop));
-  for (int i = 0; i < yCloud.nop; i++) {
+  const int n = yCloud.nop;
+  std::vector<std::vector<int>> out(static_cast<std::size_t>(n));
+  for (int i = 0; i < n; i++) {
     out[static_cast<std::size_t>(i)].push_back(
         yCloud.pts[static_cast<std::size_t>(i)].atomID);
   }
-  std::set<std::pair<int, int>> bonds;
-  if (mutual) {
-    std::set<std::pair<int, int>> directed;
-    for (int i = 0; i < yCloud.nop; i++) {
-      for (const int j : nominated[static_cast<std::size_t>(i)]) {
-        directed.emplace(i, j);
+  for (int i = 0; i < n; i++) {
+    for (const int j : nominated[static_cast<std::size_t>(i)]) {
+      if (j < 0 || j >= n || j == i) {
+        continue;
+      }
+      if (mutual) {
+        if (i < j && listsIndex(nominated[static_cast<std::size_t>(j)], i)) {
+          addUndirectedIDs(out, yCloud, i, j);
+        }
+      } else if (i < j) {
+        addUndirectedIDs(out, yCloud, i, j);
+      } else if (!listsIndex(nominated[static_cast<std::size_t>(j)], i)) {
+        addUndirectedIDs(out, yCloud, i, j);
       }
     }
-    for (const auto &[i, j] : directed) {
-      if (directed.count({j, i})) {
-        bonds.emplace(std::min(i, j), std::max(i, j));
-      }
-    }
-  } else {
-    for (int i = 0; i < yCloud.nop; i++) {
-      for (const int j : nominated[static_cast<std::size_t>(i)]) {
-        bonds.emplace(std::min(i, j), std::max(i, j));
-      }
-    }
-  }
-  for (const auto &[i, j] : bonds) {
-    out[static_cast<std::size_t>(i)].push_back(
-        yCloud.pts[static_cast<std::size_t>(j)].atomID);
-    out[static_cast<std::size_t>(j)].push_back(
-        yCloud.pts[static_cast<std::size_t>(i)].atomID);
   }
   return out;
 }

--- a/src/seams_cli.cpp
+++ b/src/seams_cli.cpp
@@ -188,6 +188,10 @@ int cmdRead(std::ostream &os, Cloud &cloud) {
 }
 
 int cmdChillPlus(std::ostream &os, Cloud &cloud, double cutoff, int typeI) {
+  if (cloud.nop == 0) {
+    printCounts(os, cloud);
+    return 0;
+  }
   const int typ = typeOf(cloud, typeI);
   auto nList = nneigh::neighListO(cutoff, cloud, typ);
   chill::getCorrelPlus(cloud, nList, false);
@@ -197,6 +201,10 @@ int cmdChillPlus(std::ostream &os, Cloud &cloud, double cutoff, int typeI) {
 }
 
 int cmdChill(std::ostream &os, Cloud &cloud, double cutoff, int typeI) {
+  if (cloud.nop == 0) {
+    printCounts(os, cloud);
+    return 0;
+  }
   const int typ = typeOf(cloud, typeI);
   auto nList = nneigh::neighListO(cutoff, cloud, typ);
   chill::getCorrel(cloud, nList, false);
@@ -207,6 +215,13 @@ int cmdChill(std::ostream &os, Cloud &cloud, double cutoff, int typeI) {
 
 int cmdCages(std::ostream &os, Cloud &cloud, double cutoff, int typeI, int k,
              const std::string &graphName) {
+  if (cloud.nop == 0) {
+    os << colorizer.heading("nop") << " 0 "
+       << colorizer.longOption("graph") << " " << graphName << " "
+       << iceColor("hexagonal") << " 0 " << iceColor("cubic") << " 0 "
+       << iceColor("water") << " 0\n";
+    return 0;
+  }
   const int typ = typeOf(cloud, typeI);
   const double cand = cutoff + 1.5;
 

--- a/src/seams_cli.cpp
+++ b/src/seams_cli.cpp
@@ -151,6 +151,11 @@ void printFeatures(std::ostream &os) {
 #else
   line("vesin neighbours", false);
 #endif
+#ifdef SEAMS_HAS_LINKCELL
+  line("linkcell k-nearest", true);
+#else
+  line("linkcell k-nearest", false);
+#endif
 #ifdef SEAMS_HAS_CHEMFILES
   line("chemfiles", true);
 #else

--- a/src/seams_cli.cpp
+++ b/src/seams_cli.cpp
@@ -254,8 +254,9 @@ int cmdCages(std::ostream &os, Cloud &cloud, double cutoff, int typeI, int k,
   };
 
   if (graphName == "seeded") {
-    auto mutual = nneigh::kNearestNeighbourList(cloud, k, cand, typ, true);
-    auto uni = nneigh::kNearestNeighbourList(cloud, k, cand, typ, false);
+    auto graphs = nneigh::kNearestNeighbourPair(cloud, k, cand, typ);
+    const auto &mutual = graphs.first;
+    const auto &uni = graphs.second;
     auto idxS = nneigh::neighbourListByIndex(cloud, mutual);
     auto idxU = nneigh::neighbourListByIndex(cloud, uni);
     auto sixS = sixOf(primitive::ringNetwork(idxS, 6));

--- a/src/seams_input.cpp
+++ b/src/seams_input.cpp
@@ -15,6 +15,8 @@
 #include <algorithm>
 #include <charconv>
 #include <cstdint>
+#include <cstring>
+#include <fcntl.h>
 #include <filesystem>
 #include <fstream>
 #include <generic.hpp>
@@ -22,6 +24,9 @@
 #include <mutex>
 #include <seams_input.hpp>
 #include <string_view>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <unordered_map>
 
 #ifdef SEAMS_HAS_OPENMP
@@ -104,6 +109,7 @@ struct LammpsDumpSession {
   std::ifstream file;
   std::vector<std::uint64_t> offsets;
   int lastFrame = 0;
+  bool fullyIndexed = false;
   std::filesystem::file_time_type mtime{};
   std::uintmax_t size{0};
 
@@ -121,6 +127,7 @@ struct LammpsDumpSession {
     file.open(filename, std::ios::in | std::ios::binary);
     offsets.clear();
     lastFrame = 0;
+    fullyIndexed = false;
     return file.is_open();
   }
 
@@ -132,6 +139,55 @@ struct LammpsDumpSession {
     }
     const auto mt = std::filesystem::last_write_time(path, ec);
     return ec || mt != mtime;
+  }
+
+  // One mmap + memchr walk of ITEM: TIMESTEP. getline was ~0.5 s on the
+  // 103 MB Niu dump; glibc memchr is the SIMD find, no extra library.
+  bool mmapIndexAll() {
+    if (fullyIndexed) {
+      return true;
+    }
+    const int fd = ::open(path.c_str(), O_RDONLY);
+    if (fd < 0) {
+      return false;
+    }
+    struct stat st {};
+    if (::fstat(fd, &st) != 0 || st.st_size <= 0) {
+      ::close(fd);
+      return false;
+    }
+    const auto nbytes = static_cast<std::size_t>(st.st_size);
+    void *map = ::mmap(nullptr, nbytes, PROT_READ, MAP_PRIVATE, fd, 0);
+    ::close(fd);
+    if (map == MAP_FAILED) {
+      return false;
+    }
+#ifdef POSIX_MADV_SEQUENTIAL
+    ::posix_madvise(map, nbytes, POSIX_MADV_SEQUENTIAL);
+#endif
+    offsets.clear();
+    const char *const begin = static_cast<const char *>(map);
+    const char *const end = begin + nbytes;
+    constexpr char kNeedle[] = "ITEM: TIMESTEP";
+    constexpr std::size_t kN = 14;
+    const char *p = begin;
+    while (p + kN <= end) {
+      const void *hit = std::memchr(p, 'I', static_cast<std::size_t>(end - p));
+      if (hit == nullptr) {
+        break;
+      }
+      p = static_cast<const char *>(hit);
+      if (p + kN <= end && std::memcmp(p, kNeedle, kN) == 0 &&
+          (p == begin || p[-1] == '\n')) {
+        offsets.push_back(static_cast<std::uint64_t>(p - begin));
+        p += kN;
+      } else {
+        ++p;
+      }
+    }
+    ::munmap(map, nbytes);
+    fullyIndexed = true;
+    return !offsets.empty();
   }
 
   bool discoverNext() {
@@ -198,7 +254,13 @@ struct LammpsDumpSession {
   }
 
   int nframes() {
-    while (discoverNext()) {
+    if (!fullyIndexed) {
+      mmapIndexAll();
+    }
+    if (!fullyIndexed) {
+      while (discoverNext()) {
+      }
+      fullyIndexed = true;
     }
     return static_cast<int>(offsets.size());
   }
@@ -206,6 +268,9 @@ struct LammpsDumpSession {
   bool ensureIndexed(int frame) {
     if (frame < 1) {
       return false;
+    }
+    if (!fullyIndexed && static_cast<int>(offsets.size()) < frame) {
+      mmapIndexAll();
     }
     while (static_cast<int>(offsets.size()) < frame) {
       if (!discoverNext()) {

--- a/src/seams_input.cpp
+++ b/src/seams_input.cpp
@@ -13,6 +13,7 @@
 //-----------------------------------------------------------------------------------
 
 #include <algorithm>
+#include <charconv>
 #include <cstdint>
 #include <filesystem>
 #include <fstream>
@@ -20,6 +21,7 @@
 #include <memory>
 #include <mutex>
 #include <seams_input.hpp>
+#include <string_view>
 #include <unordered_map>
 
 #ifdef SEAMS_HAS_OPENMP
@@ -47,6 +49,50 @@ void mapAtomIdToIndex(
 
 bool isLammpsTimestep(const std::string &line) {
   return line.size() >= 14 && line.compare(0, 14, "ITEM: TIMESTEP") == 0;
+}
+
+bool isLammpsItem(const std::string &line) {
+  return line.size() >= 5 && line.compare(0, 5, "ITEM:") == 0;
+}
+
+// Locale-independent field scan. istringstream >> double copies the line
+// and walks a facet; from_chars is the C++17 path Lemire measured at
+// gigabyte-per-second scale on the same decimal grammar LAMMPS writes.
+constexpr int kMaxDumpFields = 32;
+
+int parseDumpFields(std::string_view line, double *out, int cap) {
+  const char *p = line.data();
+  const char *const end = p + line.size();
+  int n = 0;
+  while (p < end && n < cap) {
+    while (p < end && (*p == ' ' || *p == '\t' || *p == '\r')) {
+      ++p;
+    }
+    if (p >= end) {
+      break;
+    }
+    double value = 0;
+    const auto parsed = std::from_chars(p, end, value);
+    if (parsed.ec != std::errc{}) {
+      while (p < end && *p != ' ' && *p != '\t') {
+        ++p;
+      }
+      continue;
+    }
+    out[n++] = value;
+    p = parsed.ptr;
+  }
+  return n;
+}
+
+bool parseDumpInt(std::string_view line, int &out) {
+  const char *p = line.data();
+  const char *const end = p + line.size();
+  while (p < end && (*p == ' ' || *p == '\t')) {
+    ++p;
+  }
+  const auto parsed = std::from_chars(p, end, out);
+  return parsed.ec == std::errc{};
 }
 
 // Live dump cursor, matching LAMMPS ReaderNative (rerun keeps FILE* at
@@ -430,7 +476,6 @@ void parseLammpsFrameBody(
     std::array<double, 3> coordHigh) {
   std::string line;
   std::vector<std::string> tokens;
-  std::vector<double> numbers;
   std::vector<double> tilt;
   int nop = -1;
   bool readNOP = false;
@@ -459,62 +504,73 @@ void parseLammpsFrameBody(
       break;
     }
 
-    tokens = gen::tokenizer(line);
-    numbers = gen::tokenizerDouble(line);
+    const bool itemLine = isLammpsItem(line);
+    if (itemLine) {
+      tokens = gen::tokenizer(line);
+    } else {
+      tokens.clear();
+    }
 
-    if (readNOP) {
-      nop = std::stoi(line.data());
-      readNOP = false;
-      if (keep == LammpsKeep::All) {
+    if (readNOP && !itemLine) {
+      if (parseDumpInt(line, nop) && nop >= 0) {
         yCloud.pts.reserve(static_cast<std::size_t>(nop));
-        yCloud.nop = nop;
+        if (keep == LammpsKeep::All) {
+          yCloud.nop = nop;
+        }
       }
+      readNOP = false;
     }
     if (readBox) {
-      if (!tokens.empty() && tokens[0] == "ITEM:") {
+      if (itemLine) {
         readBox = false;
         if (isTriclinic) {
           for (std::size_t k = 0; k < tilt.size(); k++) {
             yCloud.box.push_back(tilt[k]);
           }
         }
-      } else if (numbers.size() >= 2) {
-        yCloud.box.push_back(numbers[1] - numbers[0]);
-        yCloud.boxLow.push_back(numbers[0]);
-        if (numbers.size() == 3) {
-          isTriclinic = true;
-          tilt.push_back(numbers[2]);
+      } else {
+        double fields[kMaxDumpFields];
+        const int n = parseDumpFields(line, fields, kMaxDumpFields);
+        if (n >= 2) {
+          yCloud.box.push_back(fields[1] - fields[0]);
+          yCloud.boxLow.push_back(fields[0]);
+          if (n >= 3) {
+            isTriclinic = true;
+            tilt.push_back(fields[2]);
+          }
         }
       }
     }
-    if (readAtoms && typeIndex >= 0 && xIndex >= 0 && yIndex >= 0 &&
-        zIndex >= 0 &&
-        numbers.size() >
-            static_cast<std::size_t>(
-                std::max({typeIndex, xIndex, yIndex, zIndex, molIndex,
-                          atomIndex}))) {
-      iPoint.type = static_cast<int>(numbers[typeIndex]);
-      iPoint.molID = static_cast<int>(numbers[molIndex]);
-      iPoint.atomID = static_cast<int>(numbers[atomIndex]);
-      iPoint.x = numbers[xIndex];
-      iPoint.y = numbers[yIndex];
-      iPoint.z = numbers[zIndex];
-      if (isSlice) {
-        iPoint.inSlice = sinp::atomInSlice(iPoint.x, iPoint.y, iPoint.z,
-                                           coordLow, coordHigh);
-        if (keep == LammpsKeep::TypeInSlice && !iPoint.inSlice) {
+    if (readAtoms && !itemLine && typeIndex >= 0 && xIndex >= 0 &&
+        yIndex >= 0 && zIndex >= 0) {
+      double fields[kMaxDumpFields];
+      const int n = parseDumpFields(line, fields, kMaxDumpFields);
+      const int need = std::max({typeIndex, xIndex, yIndex, zIndex, molIndex,
+                                 atomIndex});
+      if (n > need) {
+        iPoint.type = static_cast<int>(fields[typeIndex]);
+        iPoint.molID = static_cast<int>(fields[molIndex]);
+        iPoint.atomID = static_cast<int>(fields[atomIndex]);
+        iPoint.x = fields[xIndex];
+        iPoint.y = fields[yIndex];
+        iPoint.z = fields[zIndex];
+        if (isSlice) {
+          iPoint.inSlice = sinp::atomInSlice(iPoint.x, iPoint.y, iPoint.z,
+                                             coordLow, coordHigh);
+          if (keep == LammpsKeep::TypeInSlice && !iPoint.inSlice) {
+            continue;
+          }
+        }
+        if (keep != LammpsKeep::All && iPoint.type != typeFilter) {
           continue;
         }
+        nKept++;
+        yCloud.pts.push_back(iPoint);
+        mapAtomIdToIndex(yCloud);
       }
-      if (keep != LammpsKeep::All && iPoint.type != typeFilter) {
-        continue;
-      }
-      nKept++;
-      yCloud.pts.push_back(iPoint);
-      mapAtomIdToIndex(yCloud);
     }
 
-    if (!tokens.empty() && tokens[0] == "ITEM:" && tokens.size() > 1) {
+    if (itemLine && tokens.size() > 1) {
       if (tokens[1] == "NUMBER") {
         readNOP = true;
       } else if (tokens[1] == "BOX") {

--- a/src/topo_bulk.cpp
+++ b/src/topo_bulk.cpp
@@ -1014,7 +1014,8 @@ std::vector<int> ring::findHC(const std::vector<std::vector<int>> &rings,
  *  for being the basal rings of an HC.
  */
 bool ring::basalConditions(const std::vector<std::vector<int>> &nList,
-                           std::vector<int> &basal1, std::vector<int> &basal2) {
+                           const std::vector<int> &basal1,
+                           const std::vector<int> &basal2) {
   int l1 = basal1[0]; // first element of basal1 ring
   int l2 = basal1[1]; // second element of basal1 ring
   int ringSize = 6;      // Size of the ring; each ring contains 6 elements

--- a/src/topo_bulk.cpp
+++ b/src/topo_bulk.cpp
@@ -1211,7 +1211,7 @@ bool ring::basalNeighbours(const std::vector<std::vector<int>> &nList,
  */
 bool ring::notNeighboursOfRing(const std::vector<std::vector<int>> &nList,
                                std::vector<int> &triplet,
-                               std::vector<int> &ring) {
+                               const std::vector<int> &ring) {
   int iatom; // AtomID of the atom to be searched for inside the neighbour
              // lists
   int jatom; // AtomID of in whose neighbour list iatom will be searched for

--- a/subprojects/linkcell.wrap
+++ b/subprojects/linkcell.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/HaoZeke/linkcell.git
-revision = v0.2.0
+revision = v0.2.1
 depth = 1
 
 [provide]

--- a/subprojects/linkcell.wrap
+++ b/subprojects/linkcell.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+url = https://github.com/HaoZeke/linkcell.git
+revision = v0.1.0
+depth = 1
+
+[provide]
+linkcell = linkcell_dep

--- a/subprojects/linkcell.wrap
+++ b/subprojects/linkcell.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/HaoZeke/linkcell.git
-revision = v0.1.0
+revision = v0.1.1
 depth = 1
 
 [provide]

--- a/subprojects/linkcell.wrap
+++ b/subprojects/linkcell.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/HaoZeke/linkcell.git
-revision = v0.1.2
+revision = v0.2.0
 depth = 1
 
 [provide]

--- a/subprojects/linkcell.wrap
+++ b/subprojects/linkcell.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/HaoZeke/linkcell.git
-revision = v0.1.1
+revision = v0.1.2
 depth = 1
 
 [provide]

--- a/tests/bench_stages.cpp
+++ b/tests/bench_stages.cpp
@@ -67,6 +67,12 @@ int main(int argc, char **argv) {
         (void)knn;
       },
       reps);
+  const double tKnnPair = bestMs(
+      [&]() {
+        auto both = nneigh::kNearestNeighbourPair(cloud, 4, 5.5, typeI);
+        (void)both;
+      },
+      reps);
   const double tRings = bestMs(
       [&]() { rings = primitive::ringNetwork(idx, 6); }, reps);
   six.clear();
@@ -78,8 +84,9 @@ int main(int argc, char **argv) {
   ring::CageAffiliation aff;
   const double tAff = bestMs(
       [&]() { aff = ring::cageAffiliation(six, idx); }, reps);
-  auto knn = nneigh::kNearestNeighbourList(cloud, 4, 5.5, typeI, true);
-  auto uni = nneigh::kNearestNeighbourList(cloud, 4, 5.5, typeI, false);
+  auto knnPair = nneigh::kNearestNeighbourPair(cloud, 4, 5.5, typeI);
+  const auto &knn = knnPair.first;
+  const auto &uni = knnPair.second;
   auto idxS = nneigh::neighbourListByIndex(cloud, knn);
   auto idxU = nneigh::neighbourListByIndex(cloud, uni);
   const double tSeeded = bestMs(
@@ -107,8 +114,8 @@ int main(int argc, char **argv) {
   }
   std::printf("# traj %s frame %d nop %d rings %zu six %zu ddc %d\n",
               traj.c_str(), frame, cloud.nop, rings.size(), six.size(), nDdc);
-  std::printf("io_ms %.3f\nneigh_ms %.3f\nknn_ms %.3f\nrings_ms %.3f\n"
-              "affil_ms %.3f\nseeded_ms %.3f\n",
-              tIo, tNeigh, tKnn, tRings, tAff, tSeeded);
+  std::printf("io_ms %.3f\nneigh_ms %.3f\nknn_ms %.3f\nknn_pair_ms %.3f\n"
+              "rings_ms %.3f\naffil_ms %.3f\nseeded_ms %.3f\n",
+              tIo, tNeigh, tKnn, tKnnPair, tRings, tAff, tSeeded);
   return 0;
 }

--- a/tests/bench_stages.cpp
+++ b/tests/bench_stages.cpp
@@ -1,0 +1,114 @@
+/*
+** Stage times for one frame: I/O, neighbours, rings, affiliation.
+**   bench_stages TRAJ [frame] [atomType] [reps]
+*/
+
+#include <cage_affiliation.hpp>
+#include <franzblau.hpp>
+#include <neighbours.hpp>
+#include <seams_input.hpp>
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <string>
+#include <vector>
+
+namespace {
+using Clock = std::chrono::steady_clock;
+
+template <typename Fn> double bestMs(Fn &&fn, int reps) {
+  double best = std::numeric_limits<double>::max();
+  for (int i = 0; i < reps; i++) {
+    const auto t0 = Clock::now();
+    fn();
+    const auto t1 = Clock::now();
+    const double ms =
+        std::chrono::duration<double, std::milli>(t1 - t0).count();
+    if (ms < best) {
+      best = ms;
+    }
+  }
+  return best;
+}
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::fprintf(stderr,
+                 "usage: bench_stages TRAJ [frame] [atomType] [reps]\n");
+    return 2;
+  }
+  const std::string traj = argv[1];
+  const int frame = argc > 2 ? std::atoi(argv[2]) : 1;
+  const int typeI = argc > 3 ? std::atoi(argv[3]) : 1;
+  const int reps = argc > 4 ? std::atoi(argv[4]) : 3;
+
+  molSys::PointCloud<molSys::Point<double>, double> cloud;
+  const double tIo = bestMs(
+      [&]() { cloud = sinp::readLammpsTrjO(traj, frame, cloud, typeI); },
+      reps);
+  if (cloud.nop == 0) {
+    std::fprintf(stderr, "empty frame %d of %s\n", frame, traj.c_str());
+    return 1;
+  }
+
+  std::vector<std::vector<int>> nList, idx, rings, six;
+  const double tNeigh = bestMs(
+      [&]() {
+        nList = nneigh::neighListO(3.5, cloud, typeI);
+        idx = nneigh::neighbourListByIndex(cloud, nList);
+      },
+      reps);
+  const double tKnn = bestMs(
+      [&]() {
+        auto knn = nneigh::kNearestNeighbourList(cloud, 4, 5.5, typeI, true);
+        (void)knn;
+      },
+      reps);
+  const double tRings = bestMs(
+      [&]() { rings = primitive::ringNetwork(idx, 6); }, reps);
+  six.clear();
+  for (const auto &r : rings) {
+    if (r.size() == 6) {
+      six.push_back(r);
+    }
+  }
+  ring::CageAffiliation aff;
+  const double tAff = bestMs(
+      [&]() { aff = ring::cageAffiliation(six, idx); }, reps);
+  auto knn = nneigh::kNearestNeighbourList(cloud, 4, 5.5, typeI, true);
+  auto uni = nneigh::kNearestNeighbourList(cloud, 4, 5.5, typeI, false);
+  auto idxS = nneigh::neighbourListByIndex(cloud, knn);
+  auto idxU = nneigh::neighbourListByIndex(cloud, uni);
+  const double tSeeded = bestMs(
+      [&]() {
+        auto sR = primitive::ringNetwork(idxS, 6);
+        auto uR = primitive::ringNetwork(idxU, 6);
+        std::vector<std::vector<int>> s6, u6;
+        for (const auto &r : sR) {
+          if (r.size() == 6) {
+            s6.push_back(r);
+          }
+        }
+        for (const auto &r : uR) {
+          if (r.size() == 6) {
+            u6.push_back(r);
+          }
+        }
+        (void)ring::seededCageAffiliation(s6, idxS, u6, idxU);
+      },
+      reps);
+
+  int nDdc = 0;
+  for (const bool f : aff.ddc) {
+    nDdc += f ? 1 : 0;
+  }
+  std::printf("# traj %s frame %d nop %d rings %zu six %zu ddc %d\n",
+              traj.c_str(), frame, cloud.nop, rings.size(), six.size(), nDdc);
+  std::printf("io_ms %.3f\nneigh_ms %.3f\nknn_ms %.3f\nrings_ms %.3f\n"
+              "affil_ms %.3f\nseeded_ms %.3f\n",
+              tIo, tNeigh, tKnn, tRings, tAff, tSeeded);
+  return 0;
+}

--- a/tests/bench_trajectory_incremental.cpp
+++ b/tests/bench_trajectory_incremental.cpp
@@ -88,9 +88,8 @@ int main(int argc, char **argv) {
     molSys::PointCloud<molSys::Point<double>, double> cloud;
     cloud = sinp::readLammpsTrjO(traj, frame, cloud, atomType);
     if (cloud.nop == 0) {
-      std::fprintf(stderr, "could not read frame %d of %s\n", frame,
-                   traj.c_str());
-      return 1;
+      std::printf("%d 0 0 0 0 0 0 0 0 0 0 0 . 0 yes yes\n", frame);
+      continue;
     }
     auto nList = skin.update(cloud);
     auto idx = nneigh::neighbourListByIndex(cloud, nList);

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -163,6 +163,13 @@ executable('walk_seeded', 'walk_seeded.cpp',
   include_directories: _incdirs,
   build_rpath: '$ORIGIN/../src')
 
+executable('walk_graphs', 'walk_graphs.cpp',
+  dependencies: [yds_dep],
+  cpp_args: _args,
+  link_args: _test_link_args,
+  include_directories: _incdirs,
+  build_rpath: '$ORIGIN/../src')
+
 executable('bench_structure_desc', 'bench_structure_desc.cpp',
   dependencies: [yds_dep],
   cpp_args: _args,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -156,6 +156,15 @@ executable('bench_stages', 'bench_stages.cpp',
   include_directories: _incdirs,
   build_rpath: '$ORIGIN/../src')
 
+if linkcell_dep.found()
+  executable('profile_knn', 'profile_knn.cpp',
+    dependencies: [yds_dep],
+    cpp_args: _args,
+    link_args: _test_link_args,
+    include_directories: _incdirs,
+    build_rpath: '$ORIGIN/../src')
+endif
+
 executable('report_ice_graphs', 'report_ice_graphs.cpp',
   dependencies: [yds_dep],
   cpp_args: _args,

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -149,6 +149,13 @@ executable('bench_lammps_walk', 'bench_lammps_walk.cpp',
   include_directories: _incdirs,
   build_rpath: '$ORIGIN/../src')
 
+executable('bench_stages', 'bench_stages.cpp',
+  dependencies: [yds_dep],
+  cpp_args: _args,
+  link_args: _test_link_args,
+  include_directories: _incdirs,
+  build_rpath: '$ORIGIN/../src')
+
 executable('report_ice_graphs', 'report_ice_graphs.cpp',
   dependencies: [yds_dep],
   cpp_args: _args,

--- a/tests/profile_knn.cpp
+++ b/tests/profile_knn.cpp
@@ -1,0 +1,117 @@
+/*
+** Split the k-nearest path: pack, lc_knearest, unpack, symmetrize.
+**   profile_knn TRAJ [frame] [type] [reps]
+*/
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+#include <vector>
+
+#include <linkcell.h>
+#include <neighbours.hpp>
+#include <seams_input.hpp>
+
+namespace {
+using Clock = std::chrono::steady_clock;
+
+double ms(Clock::time_point a, Clock::time_point b) {
+  return std::chrono::duration<double, std::milli>(b - a).count();
+}
+} // namespace
+
+int main(int argc, char **argv) {
+  if (argc < 2) {
+    std::fprintf(stderr, "usage: profile_knn TRAJ [frame] [type] [reps]\n");
+    return 2;
+  }
+  const std::string traj = argv[1];
+  const int frame = argc > 2 ? std::atoi(argv[2]) : 1;
+  const int typeI = argc > 3 ? std::atoi(argv[3]) : 1;
+  const int reps = argc > 4 ? std::atoi(argv[4]) : 20;
+
+  molSys::PointCloud<molSys::Point<double>, double> cloud;
+  cloud = sinp::readLammpsTrjO(traj, frame, cloud, typeI);
+  if (cloud.nop == 0) {
+    std::fprintf(stderr, "empty frame\n");
+    return 1;
+  }
+  const int n = cloud.nop;
+  const int k = 4;
+  const double hint = 0.75 * 5.5;
+
+  double tPack = 0, tLc = 0, tUnpack = 0, tSym = 0, tPair = 0;
+  std::vector<std::vector<int>> nominated(static_cast<std::size_t>(n));
+
+  for (int r = 0; r < reps; r++) {
+    auto a0 = Clock::now();
+    std::vector<double> xyz(static_cast<std::size_t>(n) * 3);
+    std::vector<int> mask(static_cast<std::size_t>(n), 0);
+    for (int i = 0; i < n; i++) {
+      const auto &p = cloud.pts[static_cast<std::size_t>(i)];
+      xyz[static_cast<std::size_t>(i) * 3 + 0] = p.x;
+      xyz[static_cast<std::size_t>(i) * 3 + 1] = p.y;
+      xyz[static_cast<std::size_t>(i) * 3 + 2] = p.z;
+      mask[static_cast<std::size_t>(i)] = p.type == typeI ? 1 : 0;
+    }
+    lc_cell box = lc_cell_ortho(cloud.box[0], cloud.box[1], cloud.box[2]);
+    if (cloud.boxLow.size() >= 3) {
+      box.ox = cloud.boxLow[0];
+      box.oy = cloud.boxLow[1];
+      box.oz = cloud.boxLow[2];
+    }
+    std::vector<int> out(static_cast<std::size_t>(n) * static_cast<std::size_t>(k),
+                         -1);
+    auto a1 = Clock::now();
+    if (lc_knearest(xyz.data(), n, &box, k, mask.data(), hint, out.data()) !=
+        0) {
+      std::fprintf(stderr, "%s\n", lc_last_error());
+      return 1;
+    }
+    auto a2 = Clock::now();
+    for (int i = 0; i < n; i++) {
+      if (mask[static_cast<std::size_t>(i)] == 0) {
+        continue;
+      }
+      auto &row = nominated[static_cast<std::size_t>(i)];
+      row.clear();
+      row.reserve(static_cast<std::size_t>(k));
+      for (int t = 0; t < k; t++) {
+        const int j =
+            out[static_cast<std::size_t>(i) * static_cast<std::size_t>(k) +
+                static_cast<std::size_t>(t)];
+        if (j >= 0) {
+          row.push_back(j);
+        }
+      }
+    }
+    auto a3 = Clock::now();
+    auto both = nneigh::kNearestNeighbourPair(cloud, k, 5.5, typeI);
+    auto a4 = Clock::now();
+    (void)both;
+    tPack += ms(a0, a1);
+    tLc += ms(a1, a2);
+    tUnpack += ms(a2, a3);
+    tPair += ms(a3, a4);
+  }
+
+  // One extra pass: symmetrize only, after a fresh nominate via the public API.
+  {
+    auto nom = nominated;
+    for (int r = 0; r < reps; r++) {
+      auto s0 = Clock::now();
+      auto both = nneigh::kNearestNeighbourPair(cloud, k, 5.5, typeI);
+      (void)both;
+      auto s1 = Clock::now();
+      tSym += ms(s0, s1);
+    }
+  }
+
+  std::printf("# nop %d reps %d\n", n, reps);
+  std::printf("pack_ms %.3f\n", tPack / reps);
+  std::printf("lc_knearest_ms %.3f\n", tLc / reps);
+  std::printf("unpack_ms %.3f\n", tUnpack / reps);
+  std::printf("pair_api_ms %.3f\n", tPair / reps);
+  std::printf("pair_again_ms %.3f\n", tSym / reps);
+  return 0;
+}

--- a/tests/test_bop.cpp
+++ b/tests/test_bop.cpp
@@ -5,6 +5,7 @@
 #include <generic.hpp>
 #include <mol_sys.hpp>
 #include <neighbours.hpp>
+#include <seams_input.hpp>
 #include <steinhardt_device.hpp>
 
 #include <algorithm>
@@ -327,6 +328,31 @@ TEST_CASE("numStaggered counts staggered bonds for an atom", "[bop]") {
   int nStag = chill::numStaggered(cloud, nList, 0);
   REQUIRE(nStag >= 0);
   REQUIRE(nStag <= 4);
+}
+
+TEST_CASE("CHILL+ on the mixed TIP4P example is twelve interClathrate",
+          "[bop][fixture]") {
+  molSys::PointCloud<molSys::Point<double>, double> cloud;
+  cloud = sinp::readLammpsTrjO("traj/exampleTraj.lammpstrj", 1, cloud, 2);
+  REQUIRE(cloud.nop == 250);
+  auto nList = nneigh::neighListO(3.5, cloud, 2);
+  chill::getCorrelPlus(cloud, nList, false);
+  chill::getIceTypePlusNoPrint(cloud, nList, false);
+  int interClath = 0;
+  int water = 0;
+  int other = 0;
+  for (const auto &pt : cloud.pts) {
+    if (pt.iceType == molSys::atom_state_type::interClathrate) {
+      interClath++;
+    } else if (pt.iceType == molSys::atom_state_type::water) {
+      water++;
+    } else {
+      other++;
+    }
+  }
+  REQUIRE(interClath == 12);
+  REQUIRE(water == 238);
+  REQUIRE(other == 0);
 }
 
 TEST_CASE("getIceTypePlusNoPrint classifies without writing", "[bop]") {

--- a/tests/test_cage_affiliation.cpp
+++ b/tests/test_cage_affiliation.cpp
@@ -71,6 +71,25 @@ molSys::PointCloud<molSys::Point<double>, double> hcCloud() {
 
 } // namespace
 
+TEST_CASE("seeded affiliation on an empty framed cloud is empty",
+          "[cage_affiliation]") {
+  molSys::PointCloud<molSys::Point<double>, double> cloud;
+  cloud.nop = 0;
+  cloud.box = {10.0, 10.0, 10.0};
+  cloud.boxLow = {0.0, 0.0, 0.0};
+  auto knn = nneigh::kNearestNeighbourList(cloud, 4, 5.5, 1, true);
+  auto uni = nneigh::kNearestNeighbourList(cloud, 4, 5.5, 1, false);
+  auto idxS = nneigh::neighbourListByIndex(cloud, knn);
+  auto idxU = nneigh::neighbourListByIndex(cloud, uni);
+  auto sixS = sixMembered(primitive::ringNetwork(idxS, 6));
+  auto sixU = sixMembered(primitive::ringNetwork(idxU, 6));
+  const auto seeded = ring::seededCageAffiliation(sixS, idxS, sixU, idxU);
+  REQUIRE(knn.empty());
+  REQUIRE(sixS.empty());
+  REQUIRE(seeded.hc.empty());
+  REQUIRE(seeded.ddc.empty());
+}
+
 TEST_CASE("cageAffiliation matches the greedy classification on mW",
           "[cage_affiliation]") {
   molSys::PointCloud<molSys::Point<double>, double> yCloud;

--- a/tests/test_neighbours.cpp
+++ b/tests/test_neighbours.cpp
@@ -390,6 +390,9 @@ TEST_CASE("neighListO returns empty when the cloud has no atoms",
   REQUIRE(nList.empty());
   auto knn = nneigh::kNearestNeighbourList(cloud, 4, 5.5, 1, true);
   REQUIRE(knn.empty());
+  auto both = nneigh::kNearestNeighbourPair(cloud, 4, 5.5, 1);
+  REQUIRE(both.first.empty());
+  REQUIRE(both.second.empty());
 }
 
 TEST_CASE("k-nearest graph reduces exactly to the cutoff graph when the "
@@ -421,6 +424,17 @@ TEST_CASE("k-nearest graph reduces exactly to the cutoff graph when the "
     std::sort(b.begin(), b.end());
     REQUIRE(a == b);
   }
+}
+
+TEST_CASE("k-nearest pair matches two separate k-nearest builds",
+          "[neighbours]") {
+  molSys::PointCloud<molSys::Point<double>, double> yCloud;
+  yCloud = sinp::readLammpsTrjO("traj/mW_cubic.lammpstrj", 1, yCloud, 1);
+  auto mutual = nneigh::kNearestNeighbourList(yCloud, 4, 5.5, 1, true);
+  auto uni = nneigh::kNearestNeighbourList(yCloud, 4, 5.5, 1, false);
+  auto both = nneigh::kNearestNeighbourPair(yCloud, 4, 5.5, 1);
+  REQUIRE(both.first == mutual);
+  REQUIRE(both.second == uni);
 }
 
 TEST_CASE("k-nearest graph is exact under an undersized candidate cutoff",

--- a/tests/test_neighbours.cpp
+++ b/tests/test_neighbours.cpp
@@ -503,3 +503,65 @@ TEST_CASE("SkinNeighborList default is the mutual four-nearest graph",
     REQUIRE(a == b);
   }
 }
+
+TEST_CASE("empty cloud k-nearest does not throw", "[neighbours]") {
+  molSys::PointCloud<molSys::Point<double>, double> cloud;
+  cloud.box = {10.0, 10.0, 10.0};
+  cloud.nop = 0;
+  auto rows = nneigh::kNearestNeighbourList(cloud, 4, 5.5, 1, true);
+  REQUIRE(rows.empty());
+  auto both = nneigh::kNearestNeighbourPair(cloud, 4, 5.5, 1);
+  REQUIRE(both.first.empty());
+  REQUIRE(both.second.empty());
+}
+
+#ifdef SEAMS_HAS_LINKCELL
+TEST_CASE("LAMMPS dump bounds convert to lattice H",
+          "[neighbours][linkcell]") {
+  // Dump stores bound spans, not edge lengths. These bounds recover
+  // lx=10, ly=11, lz=12, xy=1.5, xz=0.4, yz=-0.2, origin (1,2,3).
+  const lc_cell box = nneigh::lammpsBoxToLcCell(
+      {11.9, 11.2, 12.0, 1.5, 0.4, -0.2}, {1.0, 1.8, 3.0});
+  REQUIRE_THAT(box.ax, Catch::Matchers::WithinAbs(10.0, 1e-12));
+  REQUIRE(box.ay == 0.0);
+  REQUIRE(box.az == 0.0);
+  REQUIRE(box.bx == 1.5);
+  REQUIRE_THAT(box.by, Catch::Matchers::WithinAbs(11.0, 1e-12));
+  REQUIRE(box.bz == 0.0);
+  REQUIRE(box.cx == 0.4);
+  REQUIRE(box.cy == -0.2);
+  REQUIRE(box.cz == 12.0);
+  REQUIRE_THAT(box.ox, Catch::Matchers::WithinAbs(1.0, 1e-12));
+  REQUIRE_THAT(box.oy, Catch::Matchers::WithinAbs(2.0, 1e-12));
+  REQUIRE(box.oz == 3.0);
+}
+
+TEST_CASE("sheared box k-nearest uses the periodic image",
+          "[neighbours][linkcell]") {
+  molSys::PointCloud<molSys::Point<double>, double> cloud;
+  // Bound span 15 with xy=5 recovers lx=10, b=(5, 8.66, 0).
+  cloud.box = {15.0, 8.660254037844386, 10.0, 5.0, 0.0, 0.0};
+  cloud.boxLow = {0.0, 0.0, 0.0};
+  cloud.nop = 2;
+  const double coords[2][3] = {{0.2, 0.1, 1.0}, {9.7, 0.1, 1.0}};
+  for (int i = 0; i < 2; i++) {
+    molSys::Point<double> pt;
+    pt.type = 1;
+    pt.atomID = i + 1;
+    pt.molID = i + 1;
+    pt.x = coords[i][0];
+    pt.y = coords[i][1];
+    pt.z = coords[i][2];
+    cloud.pts.push_back(pt);
+    cloud.idIndexMap[i + 1] = i;
+  }
+  auto knn = nneigh::kNearestNeighbourList(cloud, 1, 5.5, 1, true);
+  REQUIRE(knn.size() == 2);
+  REQUIRE(knn[0].size() >= 2);
+  REQUIRE(knn[1].size() >= 2);
+  REQUIRE(knn[0][0] == 1);
+  REQUIRE(knn[1][0] == 2);
+  REQUIRE(knn[0][1] == 2);
+  REQUIRE(knn[1][1] == 1);
+}
+#endif

--- a/tests/test_neighbours.cpp
+++ b/tests/test_neighbours.cpp
@@ -563,5 +563,8 @@ TEST_CASE("sheared box k-nearest uses the periodic image",
   REQUIRE(knn[1][0] == 2);
   REQUIRE(knn[0][1] == 2);
   REQUIRE(knn[1][1] == 1);
+  // Bound span 15 is not lx. The a-image distance is 0.5.
+  REQUIRE_THAT(gen::periodicDistSq(cloud, 0, 1),
+               Catch::Matchers::WithinAbs(0.25, 1e-9));
 }
 #endif

--- a/tests/test_neighbours.cpp
+++ b/tests/test_neighbours.cpp
@@ -388,6 +388,8 @@ TEST_CASE("neighListO returns empty when the cloud has no atoms",
 
   auto nList = nneigh::neighListO(3.5, cloud, 1);
   REQUIRE(nList.empty());
+  auto knn = nneigh::kNearestNeighbourList(cloud, 4, 5.5, 1, true);
+  REQUIRE(knn.empty());
 }
 
 TEST_CASE("k-nearest graph reduces exactly to the cutoff graph when the "

--- a/tests/test_seams_input.cpp
+++ b/tests/test_seams_input.cpp
@@ -337,6 +337,31 @@ TEST_CASE("readLammpsTrj binds xu yu zu when x y z are absent",
   sinp::dropLammpsDumpIndex(path);
 }
 
+TEST_CASE("readLammpsTrjO parses scientific-notation dump coordinates",
+          "[seams_input]") {
+  auto path = fs::temp_directory_path() / "dseams_test_lammps_sci.lammpstrj";
+  {
+    std::ofstream f(path);
+    f << "ITEM: TIMESTEP\n0\nITEM: NUMBER OF ATOMS\n2\n";
+    f << "ITEM: BOX BOUNDS pp pp pp\n0 1.0e1\n0 1e1\n0 10\n";
+    f << "ITEM: ATOMS id type x y z\n";
+    f << "1 1 1.25e0 2.5E-1 -3.0e0\n";
+    f << "2 1 4.2e1 0 1.5e-1\n";
+  }
+  sinp::dropLammpsDumpIndex(path.string());
+  molSys::PointCloud<molSys::Point<double>, double> yCloud;
+  auto cloud = sinp::readLammpsTrjO(path.string(), 1, yCloud, 1);
+  REQUIRE(cloud.nop == 2);
+  REQUIRE_THAT(cloud.box[0], Catch::Matchers::WithinAbs(10.0, 1e-10));
+  REQUIRE_THAT(cloud.pts[0].x, Catch::Matchers::WithinAbs(1.25, 1e-10));
+  REQUIRE_THAT(cloud.pts[0].y, Catch::Matchers::WithinAbs(0.25, 1e-10));
+  REQUIRE_THAT(cloud.pts[0].z, Catch::Matchers::WithinAbs(-3.0, 1e-10));
+  REQUIRE_THAT(cloud.pts[1].x, Catch::Matchers::WithinAbs(42.0, 1e-10));
+  REQUIRE_THAT(cloud.pts[1].z, Catch::Matchers::WithinAbs(0.15, 1e-10));
+  fs::remove(path);
+  sinp::dropLammpsDumpIndex(path.string());
+}
+
 // -- readBonds tests --
 
 TEST_CASE("readBonds returns empty for nonexistent file", "[seams_input]") {

--- a/tests/test_seams_input.cpp
+++ b/tests/test_seams_input.cpp
@@ -183,6 +183,23 @@ std::string writeUnwrappedDump() {
   f << "7 2 11.5 12.25 -3.0\n";
   return path.string();
 }
+
+std::string writeEmptyMiddleDump() {
+  auto path =
+      fs::temp_directory_path() / "dseams_test_lammps_empty_frame.lammpstrj";
+  std::ofstream f(path);
+  const int counts[3] = {2, 0, 2};
+  for (int frame = 0; frame < 3; ++frame) {
+    f << "ITEM: TIMESTEP\n" << frame << "\n";
+    f << "ITEM: NUMBER OF ATOMS\n" << counts[frame] << "\n";
+    f << "ITEM: BOX BOUNDS pp pp pp\n0 10\n0 10\n0 10\n";
+    f << "ITEM: ATOMS id type x y z\n";
+    for (int i = 0; i < counts[frame]; ++i) {
+      f << (i + 1) << " 1 " << (i + 0.25) << " 0 0\n";
+    }
+  }
+  return path.string();
+}
 } // namespace
 
 TEST_CASE("nLammpsFrames counts ITEM: TIMESTEP markers", "[seams_input]") {
@@ -266,6 +283,42 @@ TEST_CASE("forEachLammpsFrame matches sequential reads", "[seams_input]") {
   REQUIRE_THAT(xs[2], Catch::Matchers::WithinAbs(2.25, 1e-10));
   fs::remove(tiny);
   sinp::dropLammpsDumpIndex(tiny);
+}
+
+TEST_CASE("empty NUMBER OF ATOMS frames are valid snapshots",
+          "[seams_input]") {
+  const auto dump = writeEmptyMiddleDump();
+  sinp::dropLammpsDumpIndex(dump);
+  REQUIRE(sinp::nLammpsFrames(dump) == 3);
+
+  molSys::PointCloud<molSys::Point<double>, double> yCloud;
+  auto first = sinp::readLammpsTrjO(dump, 1, yCloud, 1);
+  REQUIRE(first.nop == 2);
+  REQUIRE(first.box.size() >= 3);
+
+  auto empty = sinp::readLammpsTrjO(dump, 2, yCloud, 1);
+  REQUIRE(empty.nop == 0);
+  REQUIRE(empty.pts.empty());
+  REQUIRE(empty.currentFrame == 2);
+  REQUIRE(empty.box.size() >= 3);
+
+  auto last = sinp::readLammpsTrjO(dump, 3, yCloud, 1);
+  REQUIRE(last.nop == 2);
+  REQUIRE(last.currentFrame == 3);
+
+  std::vector<int> nops(3, -1);
+  sinp::forEachLammpsFrame(
+      dump, 1, 3, 1,
+      [&](int frame, molSys::PointCloud<molSys::Point<double>, double> &cloud) {
+        nops[static_cast<std::size_t>(frame - 1)] = cloud.nop;
+      },
+      1);
+  REQUIRE(nops[0] == 2);
+  REQUIRE(nops[1] == 0);
+  REQUIRE(nops[2] == 2);
+
+  fs::remove(dump);
+  sinp::dropLammpsDumpIndex(dump);
 }
 
 TEST_CASE("readLammpsTrj binds xu yu zu when x y z are absent",

--- a/tests/walk_graphs.cpp
+++ b/tests/walk_graphs.cpp
@@ -3,8 +3,8 @@
 **
 ** SPDX-License-Identifier: MIT
 **
-** Seeded TUM ice score and largest ice cluster on every frame.
-**   walk_seeded TRAJ [lastFrame] [atomType] [stride]
+** Ice cluster size for every published bond graph on each frame.
+**   walk_graphs TRAJ [lastFrame] [atomType] [stride]
 */
 
 #include <cage_affiliation.hpp>
@@ -55,15 +55,14 @@ void unite(std::vector<int> &parent, std::vector<int> &sz, int a, int b) {
   sz[static_cast<std::size_t>(a)] += sz[static_cast<std::size_t>(b)];
 }
 
-void clusterIce(const ring::SeededAtomLabels &lab,
-                const std::vector<std::vector<int>> &idxU, int &nMax,
-                int &nClus) {
-  const int n = static_cast<int>(lab.hc.size());
+void clusterFlags(const std::vector<bool> &hc, const std::vector<bool> &ddc,
+                  const std::vector<std::vector<int>> &idx, int &nIce,
+                  int &nMax, int &nClus) {
+  const int n = static_cast<int>(hc.size());
   std::vector<char> ice(static_cast<std::size_t>(n), 0);
-  int nIce = 0;
+  nIce = 0;
   for (int i = 0; i < n; i++) {
-    if (lab.hc[static_cast<std::size_t>(i)] ||
-        lab.ddc[static_cast<std::size_t>(i)]) {
+    if (hc[static_cast<std::size_t>(i)] || ddc[static_cast<std::size_t>(i)]) {
       ice[static_cast<std::size_t>(i)] = 1;
       ++nIce;
     }
@@ -80,12 +79,11 @@ void clusterIce(const ring::SeededAtomLabels &lab,
   }
   for (int i = 0; i < n; i++) {
     if (!ice[static_cast<std::size_t>(i)] ||
-        static_cast<int>(idxU.size()) <= i) {
+        static_cast<int>(idx.size()) <= i) {
       continue;
     }
-    for (std::size_t k = 1; k < idxU[static_cast<std::size_t>(i)].size();
-         k++) {
-      const int j = idxU[static_cast<std::size_t>(i)][k];
+    for (std::size_t k = 1; k < idx[static_cast<std::size_t>(i)].size(); k++) {
+      const int j = idx[static_cast<std::size_t>(i)][k];
       if (j > i && j < n && ice[static_cast<std::size_t>(j)]) {
         unite(parent, sz, i, j);
       }
@@ -104,21 +102,19 @@ void clusterIce(const ring::SeededAtomLabels &lab,
   }
 }
 
-void countIce(const ring::SeededAtomLabels &lab, int &ih, int &ic, int &both,
-              int &water) {
-  ih = ic = both = water = 0;
-  const int n = static_cast<int>(lab.hc.size());
-  for (int i = 0; i < n; i++) {
-    const bool h = lab.hc[static_cast<std::size_t>(i)];
-    const bool d = lab.ddc[static_cast<std::size_t>(i)];
-    if (h && d) {
-      ++both;
-    } else if (h) {
-      ++ih;
-    } else if (d) {
-      ++ic;
-    } else {
-      ++water;
+void atomsFromRings(const std::vector<std::vector<int>> &six,
+                    const ring::CageAffiliation &aff, int nop,
+                    std::vector<bool> &hc, std::vector<bool> &ddc) {
+  hc.assign(static_cast<std::size_t>(nop), false);
+  ddc.assign(static_cast<std::size_t>(nop), false);
+  for (std::size_t r = 0; r < six.size(); r++) {
+    for (const int a : six[r]) {
+      if (a >= 0 && a < nop) {
+        hc[static_cast<std::size_t>(a)] =
+            hc[static_cast<std::size_t>(a)] || aff.hc[r];
+        ddc[static_cast<std::size_t>(a)] =
+            ddc[static_cast<std::size_t>(a)] || aff.ddc[r];
+      }
     }
   }
 }
@@ -128,7 +124,7 @@ void countIce(const ring::SeededAtomLabels &lab, int &ih, int &ic, int &both,
 int main(int argc, char **argv) {
   if (argc < 2) {
     std::fprintf(stderr,
-                 "usage: walk_seeded TRAJ [lastFrame] [atomType] [stride]\n");
+                 "usage: walk_graphs TRAJ [lastFrame] [atomType] [stride]\n");
     return 2;
   }
   const std::string traj = argv[1];
@@ -145,37 +141,53 @@ int main(int argc, char **argv) {
 
   std::printf("# %s nframes %d last %d stride %d\n", traj.c_str(), nframes,
               last, step);
-  std::printf("# frame nop ih ic both water n_ice n_max n_clus cubicity\n");
+  std::printf("# frame "
+              "cut_ice cut_max cut_clus "
+              "knn_ice knn_max knn_clus "
+              "uni_ice uni_max uni_clus "
+              "seed_ice seed_max seed_clus\n");
 
+  const double cutoff = 3.5;
   const double cand = 5.5;
   const int k = 4;
   for (int frame = 1; frame <= last; frame += step) {
     molSys::PointCloud<molSys::Point<double>, double> cloud;
     cloud = sinp::readLammpsTrjO(traj, frame, cloud, typeI);
     if (cloud.nop == 0) {
-      std::printf("%d 0 0 0 0 0 0 0 0 0.0000\n", frame);
+      std::printf("%d 0 0 0 0 0 0 0 0 0 0 0 0\n", frame);
       continue;
     }
-    auto mutual = nneigh::kNearestNeighbourList(cloud, k, cand, typeI, true);
-    auto uni = nneigh::kNearestNeighbourList(cloud, k, cand, typeI, false);
-    auto idxS = nneigh::neighbourListByIndex(cloud, mutual);
-    auto idxU = nneigh::neighbourListByIndex(cloud, uni);
-    auto sixS = sixOf(primitive::ringNetwork(idxS, 6));
+    const int nop = cloud.nop;
+    auto cutRows = nneigh::neighListO(cutoff, cloud, typeI);
+    auto knnRows = nneigh::kNearestNeighbourList(cloud, k, cand, typeI, true);
+    auto uniRows = nneigh::kNearestNeighbourList(cloud, k, cand, typeI, false);
+    auto idxC = nneigh::neighbourListByIndex(cloud, cutRows);
+    auto idxK = nneigh::neighbourListByIndex(cloud, knnRows);
+    auto idxU = nneigh::neighbourListByIndex(cloud, uniRows);
+    auto sixC = sixOf(primitive::ringNetwork(idxC, 6));
+    auto sixK = sixOf(primitive::ringNetwork(idxK, 6));
     auto sixU = sixOf(primitive::ringNetwork(idxU, 6));
-    const auto seeded = ring::seededCageAffiliation(sixS, idxS, sixU, idxU);
-    int ih = 0;
-    int ic = 0;
-    int both = 0;
-    int water = 0;
-    countIce(seeded, ih, ic, both, water);
-    int nMax = 0;
-    int nClus = 0;
-    clusterIce(seeded, idxU, nMax, nClus);
-    const int nIce = ih + ic + both;
-    const double cub =
-        nIce > 0 ? static_cast<double>(ic + both) / nIce : 0.0;
-    std::printf("%d %d %d %d %d %d %d %d %d %.4f\n", frame, cloud.nop, ih, ic,
-                both, water, nIce, nMax, nClus, cub);
+    const auto affC = ring::cageAffiliation(sixC, idxC);
+    const auto affK = ring::cageAffiliation(sixK, idxK);
+    const auto affU = ring::cageAffiliation(sixU, idxU);
+    const auto seeded = ring::seededCageAffiliation(sixK, idxK, sixU, idxU);
+
+    std::vector<bool> hc, ddc;
+    int ice = 0;
+    int mx = 0;
+    int cl = 0;
+    std::printf("%d", frame);
+    atomsFromRings(sixC, affC, nop, hc, ddc);
+    clusterFlags(hc, ddc, idxC, ice, mx, cl);
+    std::printf(" %d %d %d", ice, mx, cl);
+    atomsFromRings(sixK, affK, nop, hc, ddc);
+    clusterFlags(hc, ddc, idxK, ice, mx, cl);
+    std::printf(" %d %d %d", ice, mx, cl);
+    atomsFromRings(sixU, affU, nop, hc, ddc);
+    clusterFlags(hc, ddc, idxU, ice, mx, cl);
+    std::printf(" %d %d %d", ice, mx, cl);
+    clusterFlags(seeded.hc, seeded.ddc, idxU, ice, mx, cl);
+    std::printf(" %d %d %d\n", ice, mx, cl);
   }
   return 0;
 }

--- a/tests/walk_graphs.cpp
+++ b/tests/walk_graphs.cpp
@@ -159,8 +159,9 @@ int main(int argc, char **argv) {
     }
     const int nop = cloud.nop;
     auto cutRows = nneigh::neighListO(cutoff, cloud, typeI);
-    auto knnRows = nneigh::kNearestNeighbourList(cloud, k, cand, typeI, true);
-    auto uniRows = nneigh::kNearestNeighbourList(cloud, k, cand, typeI, false);
+    auto knnPair = nneigh::kNearestNeighbourPair(cloud, k, cand, typeI);
+    const auto &knnRows = knnPair.first;
+    const auto &uniRows = knnPair.second;
     auto idxC = nneigh::neighbourListByIndex(cloud, cutRows);
     auto idxK = nneigh::neighbourListByIndex(cloud, knnRows);
     auto idxU = nneigh::neighbourListByIndex(cloud, uniRows);

--- a/tests/walk_seeded.cpp
+++ b/tests/walk_seeded.cpp
@@ -156,8 +156,9 @@ int main(int argc, char **argv) {
       std::printf("%d 0 0 0 0 0 0 0 0 0.0000\n", frame);
       continue;
     }
-    auto mutual = nneigh::kNearestNeighbourList(cloud, k, cand, typeI, true);
-    auto uni = nneigh::kNearestNeighbourList(cloud, k, cand, typeI, false);
+    auto graphs = nneigh::kNearestNeighbourPair(cloud, k, cand, typeI);
+    const auto &mutual = graphs.first;
+    const auto &uni = graphs.second;
     auto idxS = nneigh::neighbourListByIndex(cloud, mutual);
     auto idxU = nneigh::neighbourListByIndex(cloud, uni);
     auto sixS = sixOf(primitive::ringNetwork(idxS, 6));


### PR DESCRIPTION
# Description

Cutoff neighbour lists are the 2020 graph. TUM v2 and the seeded affiliation need the *k*-nearest graph, and vesin does not build that: it is a cutoff pair list. nanoflann has no minimum image.

This puts a periodic linked-cell *k*-nearest (`HaoZeke/linkcell` v0.2.1) under `kNearestNeighbourList` / `kNearestNeighbourPair`. Nominations are packed `n*k`. Mutual and union graphs come from one walk. The dump box is the LAMMPS one: `box[0..2]` are bound spans, `box[3..5]` are `xy, xz, yz`, and `periodicDistSq` recovers H the same way.

Empty frames no longer abort the walker. The LAMMPS reader indexes `ITEM` marks with `mmap` and parses atom lines with `from_chars`.

`test_neighbours`: 24 cases, 24749 assertions.

# Changes

- `subprojects/linkcell.wrap` at `v0.2.1`
- `nominatePacked` writes `n*k` through `linkcell::knearest_into`, with the in-tree cell list as fallback
- `lammpsBoxToLcCell` / `triclinicMinImage` map dump bounds to the parallelepiped
- `kNearestNeighbourPair` builds both graphs from one nomination
- Franzblau and affiliation stop rebuilding adjacency until they need it
- Diataxis book: CLI, CHILL+ tutorial, how-tos