### PR TITLE
chore: fetch linkcell from the d-SEAMS org

### DIFF
--- a/subprojects/linkcell.wrap
+++ b/subprojects/linkcell.wrap
@@ -1,5 +1,5 @@
 [wrap-git]
-url = https://github.com/HaoZeke/linkcell.git
+url = https://github.com/d-SEAMS/linkcell.git
 revision = v0.2.1
 depth = 1
 


### PR DESCRIPTION
# Description

`linkcell` lives next to the engine now: `d-SEAMS/linkcell`. `HaoZeke/linkcell` redirects, so old clones keep working. The wrap URL is the org repo.

# Changes

- `subprojects/linkcell.wrap` `url` -> `https://github.com/d-SEAMS/linkcell.git`
- revision stays `v0.2.1`