### PR TITLE
chore: cut 2.2.4 with linkcell v0.2.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,10 +2,16 @@
 Changelog
 =========
 
-Version 2.2.4 (2026-08-15)
+Version 2.2.4 (2026-08-16)
 ===========================
 
-Docs orgmode covers the ~seams~ CLI, the Nix flake, and the
+Periodic *k*-nearest graphs via ``d-SEAMS/linkcell`` v0.2.2.
+``kNearestNeighbourList`` / ``kNearestNeighbourPair`` write packed
+``n*k`` nominations. Mutual and union come from one walk. The LAMMPS
+dump box is bound spans plus ``xy, xz, yz``; ``periodicDistSq``
+recovers H. Empty frames no longer abort the walker.
+
+Docs orgmode covers the ``seams`` CLI, the Nix flake, and the
 three-repo split. Tutorials use the live APIs.
 
 Version 2.2.3 (2026-08-15)

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "d-SEAMS: Deferred Structural Elucidation Analysis for Molecular Simulations"
 type: software
-version: "2.2.0"
-date-released: "2026-08-15"
+version: "2.2.4"
+date-released: "2026-08-16"
 license: MIT
 repository-code: "https://github.com/d-SEAMS/seams-core"
 url: https://dseams.info

--- a/docs/orgmode/changelog.org
+++ b/docs/orgmode/changelog.org
@@ -7,6 +7,12 @@ The C++ engine is this repository. Python is ~pydseams~
 
 * 2.2.4
 
+Periodic /k/-nearest graphs via [[https://github.com/d-SEAMS/linkcell][d-SEAMS/linkcell]] v0.2.2.
+~kNearestNeighbourList~ / ~kNearestNeighbourPair~ write packed
+~n*k~ nominations. Mutual and union come from one walk. The LAMMPS
+dump box is bound spans plus ~xy, xz, yz~; ~periodicDistSq~ recovers
+H. Empty frames no longer abort the walker.
+
 Docs orgmode covers the ~seams~ CLI, the Nix flake, and the
 three-repo split.
 

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 #-----------------------------------------------------------------------------------
 
 project('seams-core', ['cpp', 'c'],
-  version: '2.2.0',
+  version: '2.2.4',
   default_options: ['warning_level=2', 'cpp_std=c++20'],
   meson_version: '>=1.3.0')
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "seams-core"
-version = "2.1.0"
+version = "2.2.4"
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "osx-arm64"]
 authors = ["Rohit Goswami <rgoswami@ieee.org>"]

--- a/subprojects/linkcell.wrap
+++ b/subprojects/linkcell.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/d-SEAMS/linkcell.git
-revision = v0.2.1
+revision = v0.2.2
 depth = 1
 
 [provide]


### PR DESCRIPTION
# Description

2.2.4 is the release that ships the periodic k-nearest walk. The wrap is d-SEAMS/linkcell v0.2.2. meson, CITATION, and the changelog say 2.2.4.

# Changes

- CHANGELOG.rst / docs/orgmode/changelog.org: packed n*k, dump-box H, empty frames
- meson / CITATION / pixi: 2.2.4
- linkcell.wrap revision v0.2.2