### PR TITLE
chore: cut 2.2.5 against linkcell v0.2.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,11 @@ Changelog
 Version 2.2.5 (2026-08-16)
 ===========================
 
-``subprojects/linkcell.wrap`` is v0.2.3. A static ``libyodaLib.a``
-no longer passes ``liblinkcell.so`` to ``ar``.
+``subprojects/linkcell.wrap`` is v0.2.4. A static ``libyodaLib.a``
+no longer passes ``liblinkcell.so`` to ``ar``. Wrap consumers link
+the static archive, so ``pydseams.yoda`` does not need
+``liblinkcell`` at import time. Dump doubles parse with ``strtod``
+on Apple libc++.
 
 Version 2.2.4 (2026-08-16)
 ===========================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,12 @@
 Changelog
 =========
 
+Version 2.2.5 (2026-08-16)
+===========================
+
+``subprojects/linkcell.wrap`` is v0.2.3. A static ``libyodaLib.a``
+no longer passes ``liblinkcell.so`` to ``ar``.
+
 Version 2.2.4 (2026-08-16)
 ===========================
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "d-SEAMS: Deferred Structural Elucidation Analysis for Molecular Simulations"
 type: software
-version: "2.2.4"
+version: "2.2.5"
 date-released: "2026-08-16"
 license: MIT
 repository-code: "https://github.com/d-SEAMS/seams-core"

--- a/docs/orgmode/changelog.org
+++ b/docs/orgmode/changelog.org
@@ -5,6 +5,11 @@ The C++ engine is this repository. Python is ~pydseams~
 ([[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]]). Lua is
 ~require("dseams")~ ([[https://github.com/d-SEAMS/yodaStruct][yodaStruct]]).
 
+* 2.2.5
+
+~subprojects/linkcell.wrap~ is v0.2.3. A static ~libyodaLib.a~
+no longer passes ~liblinkcell.so~ to ~ar~.
+
 * 2.2.4
 
 Periodic /k/-nearest graphs via [[https://github.com/d-SEAMS/linkcell][d-SEAMS/linkcell]] v0.2.2.

--- a/docs/orgmode/changelog.org
+++ b/docs/orgmode/changelog.org
@@ -7,8 +7,9 @@ The C++ engine is this repository. Python is ~pydseams~
 
 * 2.2.5
 
-~subprojects/linkcell.wrap~ is v0.2.3. A static ~libyodaLib.a~
-no longer passes ~liblinkcell.so~ to ~ar~.
+~subprojects/linkcell.wrap~ is v0.2.4. A static ~libyodaLib.a~
+no longer passes ~liblinkcell.so~ to ~ar~. Wrap consumers link
+the static archive. Dump doubles parse with ~strtod~ on Apple libc++.
 
 * 2.2.4
 

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 #-----------------------------------------------------------------------------------
 
 project('seams-core', ['cpp', 'c'],
-  version: '2.2.4',
+  version: '2.2.5',
   default_options: ['warning_level=2', 'cpp_std=c++20'],
   meson_version: '>=1.3.0')
 

--- a/pixi.lock
+++ b/pixi.lock
@@ -498,6 +498,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/2c/daca29684cbe9fd4bc711f8246da3c10adca1ccc4d24436b17572eb2590e/roman_numerals_py-4.1.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/27/83/859ecdd180cacc13b1f7e857abf8582a64552ea7a061057a6c716e790fce/sphinxcontrib_qthelp-2.0.0-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/30/cf/45dd359f6ca0c3762ce0490f681da242f0530c49c81050c035c016bfdd3a/sphinx_design-0.7.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/31/53/136e9eca6e0b9dc0e1962e2c908fbea2e5ac000c2a2fbd9a35797958c48b/sphinx-8.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/35/7a/987e583882f985fe4d7323774889ec58049171828b58c2217e7f79cdf44e/sphinxcontrib_devhelp-2.0.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/37/ae/06d7dfc5633c7250fefc61fd624990aa2c37e3495c08a2f23968b1acb23e/shibuya-2026.1.9-py3-none-any.whl
@@ -519,6 +520,7 @@ environments:
       - pypi: https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c2/42/4c8646762ee83602e3fb3fbe774c2fac12f317deb0b5dbeeedd2d3ba4b77/sphinxcontrib_jsmath-1.0.1-py2.py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/c8/78/3565d011c61f5a43488987ee32b6f3f656e7f107ac2782dd57bdd7d91d9a/snowballstemmer-3.0.1-py3-none-any.whl
+      - pypi: https://files.pythonhosted.org/packages/d1/39/8b54299ffa00e597d3b0b4d042241a0a0b22cb429ad007ccfb9c1745b4d1/sphinxcontrib_mermaid-1.2.3-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e1/fb/e496f16fa11fbe2dbdd0b5e306ede153dfed050aae4766fc89d500720dc7/sphinx_last_updated_by_git-0.3.8-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/e4/94/3c57e8b1985e755c48972e2ecd59526d4bf0b52a1fe805bc52a8e98cb92d/sphinx_sitemap-2.9.0-py3-none-any.whl
       - pypi: https://files.pythonhosted.org/packages/fb/86/dd6e5db36df29e76c7a7699123569a4a18c1623ce68d826ed96c62643cae/mdit_py_plugins-0.5.0-py3-none-any.whl
@@ -8982,6 +8984,29 @@ packages:
   - pytest ; extra == 'dev'
   - setuptools ; extra == 'dev'
   requires_python: '>=3.9'
+- pypi: https://files.pythonhosted.org/packages/30/cf/45dd359f6ca0c3762ce0490f681da242f0530c49c81050c035c016bfdd3a/sphinx_design-0.7.0-py3-none-any.whl
+  name: sphinx-design
+  version: 0.7.0
+  sha256: f82bf179951d58f55dca78ab3706aeafa496b741a91b1911d371441127d64282
+  requires_dist:
+  - sphinx>=7,<10
+  - pre-commit>=3,<4 ; extra == 'code-style'
+  - myst-parser>=4,<6 ; extra == 'rtd'
+  - myst-parser>=4,<6 ; extra == 'testing'
+  - pytest~=8.3 ; extra == 'testing'
+  - pytest-cov ; extra == 'testing'
+  - pytest-regressions ; extra == 'testing'
+  - defusedxml ; extra == 'testing'
+  - pytest~=8.3 ; extra == 'testing-no-myst'
+  - pytest-cov ; extra == 'testing-no-myst'
+  - pytest-regressions ; extra == 'testing-no-myst'
+  - defusedxml ; extra == 'testing-no-myst'
+  - furo~=2024.7.18 ; extra == 'theme-furo'
+  - sphinx-immaterial~=0.12.2 ; extra == 'theme-im'
+  - pydata-sphinx-theme~=0.15.2 ; extra == 'theme-pydata'
+  - sphinx-rtd-theme~=2.0 ; extra == 'theme-rtd'
+  - sphinx-book-theme~=1.1 ; extra == 'theme-sbt'
+  requires_python: '>=3.11'
 - pypi: https://files.pythonhosted.org/packages/31/53/136e9eca6e0b9dc0e1962e2c908fbea2e5ac000c2a2fbd9a35797958c48b/sphinx-8.2.3-py3-none-any.whl
   name: sphinx
   version: 8.2.3
@@ -9474,6 +9499,19 @@ packages:
   version: 3.0.1
   sha256: 6cd7b3897da8d6c9ffb968a6781fa6532dce9c3618a4b127d920dab764a19064
   requires_python: '!=3.0.*,!=3.1.*,!=3.2.*'
+- pypi: https://files.pythonhosted.org/packages/d1/39/8b54299ffa00e597d3b0b4d042241a0a0b22cb429ad007ccfb9c1745b4d1/sphinxcontrib_mermaid-1.2.3-py3-none-any.whl
+  name: sphinxcontrib-mermaid
+  version: 1.2.3
+  sha256: 5be782b27026bef97bfb15ccb2f7868b674a1afc0982b54cb149702cfc25aa02
+  requires_dist:
+  - sphinx
+  - pyyaml
+  - defusedxml ; extra == 'test'
+  - myst-parser ; extra == 'test'
+  - pytest ; extra == 'test'
+  - ruff ; extra == 'test'
+  - sphinx ; extra == 'test'
+  requires_python: '>=3.8'
 - pypi: https://files.pythonhosted.org/packages/e1/fb/e496f16fa11fbe2dbdd0b5e306ede153dfed050aae4766fc89d500720dc7/sphinx_last_updated_by_git-0.3.8-py3-none-any.whl
   name: sphinx-last-updated-by-git
   version: 0.3.8

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "seams-core"
-version = "2.2.4"
+version = "2.2.5"
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "osx-arm64"]
 authors = ["Rohit Goswami <rgoswami@ieee.org>"]

--- a/src/seams_input.cpp
+++ b/src/seams_input.cpp
@@ -14,7 +14,9 @@
 
 #include <algorithm>
 #include <charconv>
+#include <cstddef>
 #include <cstdint>
+#include <cstdlib>
 #include <cstring>
 #include <fcntl.h>
 #include <filesystem>
@@ -77,15 +79,36 @@ int parseDumpFields(std::string_view line, double *out, int cap) {
       break;
     }
     double value = 0;
-    const auto parsed = std::from_chars(p, end, value);
-    if (parsed.ec != std::errc{}) {
-      while (p < end && *p != ' ' && *p != '\t') {
-        ++p;
+    const char *next = p;
+    if constexpr (requires(const char *a, const char *b, double v) {
+                    std::from_chars(a, b, v);
+                  }) {
+      const auto parsed = std::from_chars(p, end, value);
+      if (parsed.ec != std::errc{}) {
+        while (p < end && *p != ' ' && *p != '\t') {
+          ++p;
+        }
+        continue;
       }
-      continue;
+      next = parsed.ptr;
+    } else {
+      char buf[64];
+      const auto ntok = std::min<std::size_t>(static_cast<std::size_t>(end - p),
+                                              sizeof(buf) - 1);
+      std::memcpy(buf, p, ntok);
+      buf[ntok] = '\0';
+      char *endp = nullptr;
+      value = std::strtod(buf, &endp);
+      if (endp == buf) {
+        while (p < end && *p != ' ' && *p != '\t') {
+          ++p;
+        }
+        continue;
+      }
+      next = p + (endp - buf);
     }
     out[n++] = value;
-    p = parsed.ptr;
+    p = next;
   }
   return n;
 }

--- a/src/seams_input.cpp
+++ b/src/seams_input.cpp
@@ -79,36 +79,23 @@ int parseDumpFields(std::string_view line, double *out, int cap) {
       break;
     }
     double value = 0;
-    const char *next = p;
-    if constexpr (requires(const char *a, const char *b, double v) {
-                    std::from_chars(a, b, v);
-                  }) {
-      const auto parsed = std::from_chars(p, end, value);
-      if (parsed.ec != std::errc{}) {
-        while (p < end && *p != ' ' && *p != '\t') {
-          ++p;
-        }
-        continue;
+    // libc++ on the macOS 11 conda SDK deletes from_chars(double).
+    // Dump fields are C-locale decimals; copy one token and use strtod.
+    char buf[64];
+    const auto ntok = std::min<std::size_t>(static_cast<std::size_t>(end - p),
+                                            sizeof(buf) - 1);
+    std::memcpy(buf, p, ntok);
+    buf[ntok] = '\0';
+    char *endp = nullptr;
+    value = std::strtod(buf, &endp);
+    if (endp == buf) {
+      while (p < end && *p != ' ' && *p != '\t') {
+        ++p;
       }
-      next = parsed.ptr;
-    } else {
-      char buf[64];
-      const auto ntok = std::min<std::size_t>(static_cast<std::size_t>(end - p),
-                                              sizeof(buf) - 1);
-      std::memcpy(buf, p, ntok);
-      buf[ntok] = '\0';
-      char *endp = nullptr;
-      value = std::strtod(buf, &endp);
-      if (endp == buf) {
-        while (p < end && *p != ' ' && *p != '\t') {
-          ++p;
-        }
-        continue;
-      }
-      next = p + (endp - buf);
+      continue;
     }
     out[n++] = value;
-    p = next;
+    p += (endp - buf);
   }
   return n;
 }

--- a/subprojects/linkcell.wrap
+++ b/subprojects/linkcell.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/d-SEAMS/linkcell.git
-revision = v0.2.2
+revision = v0.2.3
 depth = 1
 
 [provide]

--- a/subprojects/linkcell.wrap
+++ b/subprojects/linkcell.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/d-SEAMS/linkcell.git
-revision = v0.2.3
+revision = v0.2.4
 depth = 1
 
 [provide]


### PR DESCRIPTION
# Description

linkcell 0.2.3 stops a static libyodaLib.a from passing liblinkcell.so to ar. That is the PydSEAMS / yoda archive failure on 2.2.4.

# Changes

- wrap: linkcell v0.2.3
- version: 2.2.5