### PR TITLE
docs: list linkcell with the rest of the suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ Scripting front ends are separate packages:
 - Python: `pydseams` ([PydSEAMSlib](https://github.com/d-SEAMS/PydSEAMSlib))
 - Lua/Fennel: `dseams` ([yodaStruct](https://github.com/d-SEAMS/yodaStruct))
 
+Periodic k-nearest neighbour search is
+[linkcell](https://github.com/d-SEAMS/linkcell).
+
 Build with `pixi run setup && pixi run build && pixi run test`, or with
 the Nix flake: `nix build` and `nix develop`.
 

--- a/docs/orgmode/explanation/architecture.org
+++ b/docs/orgmode/explanation/architecture.org
@@ -1,14 +1,16 @@
-#+TITLE: Three repositories
+#+TITLE: Repositories
 #+OPTIONS: toc:nil num:nil
 
-d-SEAMS 2 is not a monolith. The classifier is one C++ library. Each
-language ships its own package against that library.
+d-SEAMS 2 is not a monolith. The classifier is one C++ library.
+Neighbour search is linkcell. Each language ships its own package
+against that library.
 
 | repository | product | role |
 |------------+---------+------|
 | [[https://github.com/d-SEAMS/seams-core][seams-core]] | ~libyodaLib~, ~seams~ | C++ engine and CLI |
 | [[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]] | ~pydseams~ | Python helpers on ~yoda~ |
 | [[https://github.com/d-SEAMS/yodaStruct][yodaStruct]] | ~dseams~ | Lua/Fennel library |
+| [[https://github.com/d-SEAMS/linkcell][linkcell]] | ~lc_*~ | Periodic linked-cell k-nearest neighbours |
 
 The front ends take seams-core as a Meson subproject (static library)
 or as a flake input. They do not vendor a second engine.
@@ -32,7 +34,9 @@ schedules.
        PY[pydseams Frame]
        LUA["require(\"dseams\")"]
      end
+     LC[linkcell]
      DUMP[LAMMPS / XYZ / chemfiles / con] --> LIB
+     LC --> LIB
      LIB --> CLI
      LIB --> PY
      LIB --> LUA

--- a/docs/orgmode/index.org
+++ b/docs/orgmode/index.org
@@ -74,8 +74,8 @@ Scripting front ends are separate packages:
   [[https://github.com/d-SEAMS/yodaStruct][yodaStruct]]),
   ~require("dseams")~
 
-The header *Ecosystem* menu on every page jumps between the three
-Shibuya sites.
+The header *Ecosystem* menu on every page jumps between the engine,
+the bindings, and linkcell.
 
 Build with a Nix flake (~nix build~, ~nix develop~) or with
 ~pixi run setup && pixi run build && pixi run test~.
@@ -94,7 +94,9 @@ Build with a Nix flake (~nix build~, ~nix develop~) or with
        PY[pydseams Frame]
        LUA["require(\"dseams\")"]
      end
+     LC[linkcell]
      DUMP[LAMMPS / XYZ / chemfiles / con] --> LIB
+     LC --> LIB
      LIB --> CLI
      LIB --> PY
      LIB --> LUA
@@ -167,6 +169,7 @@ framework.
 
 - [[https://d-seams.github.io/PydSEAMSlib/][pydseams]] :: Python Frame API on ~yoda~
 - [[https://d-seams.github.io/yodaStruct/][dseams (Lua)]] :: ~require("dseams")~ and Fennel
+- [[https://github.com/d-SEAMS/linkcell][linkcell]] :: periodic linked-cell k-nearest neighbours
 - [[https://dseams.info][dseams.info]] :: project site
 
 * License

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -88,6 +88,12 @@ html_theme_options = {
                     "summary": "require(\"dseams\") and Fennel",
                     "external": True,
                 },
+                {
+                    "title": "linkcell",
+                    "url": "https://github.com/d-SEAMS/linkcell",
+                    "summary": "Periodic linked-cell k-nearest neighbours",
+                    "external": True,
+                },
             ],
         },
     ],


### PR DESCRIPTION
# Description

Related projects, the Ecosystem menu, and the architecture map listed the engine and the two language bindings. Neighbour search is linkcell.

# Changes

- Related projects and Ecosystem include d-SEAMS/linkcell
- Suite mermaid and architecture table
- README