### PR TITLE
feat: route remaining cutoff builders through vesin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ Changelog
 Unreleased
 ==========
 
+Version 2.3.1 (2026-08-16)
+===========================
+
+``neighList``, ``halfNeighList``, and the in-plane RDF sampler use
+the vesin cell list (same helper as ``neighListO``). Brute force
+remains the fallback. The GPU ice-score workspace is unchanged.
+
 Version 2.3.0 (2026-08-16)
 ===========================
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "d-SEAMS: Deferred Structural Elucidation Analysis for Molecular Simulations"
 type: software
-version: "2.3.0"
+version: "2.3.1"
 date-released: "2026-08-16"
 license: MIT
 repository-code: "https://github.com/d-SEAMS/seams-core"

--- a/docs/newsfragments/vesin-remaining-builders.feature
+++ b/docs/newsfragments/vesin-remaining-builders.feature
@@ -1,0 +1,4 @@
+``neighList``, ``halfNeighList``, and the in-plane RDF sampler
+use the vesin cell list (same helper as ``neighListO``). Brute
+force remains the fallback. The GPU ice-score workspace is
+unchanged.

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 #-----------------------------------------------------------------------------------
 
 project('seams-core', ['cpp', 'c'],
-  version: '2.3.0',
+  version: '2.3.1',
   default_options: ['warning_level=2', 'cpp_std=c++20'],
   meson_version: '>=1.3.0')
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "seams-core"
-version = "2.3.0"
+version = "2.3.1"
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "osx-arm64"]
 authors = ["Rohit Goswami <rgoswami@ieee.org>"]

--- a/src/include/internal/neighbours.hpp
+++ b/src/include/internal/neighbours.hpp
@@ -38,9 +38,10 @@
  */
 
 /** @brief Functions for building neighbour lists.
- * This namespace contains functions that build neighbour lists (using
- * brute-force), saving either the atom IDs or atom indices (according to a
- * PointCloud) in a row-ordered vector of vectors.
+ * This namespace contains functions that build neighbour lists (vesin
+ * cell list, with a brute-force fallback), saving either the atom IDs
+ * or atom indices (according to a PointCloud) in a row-ordered vector
+ * of vectors.
  * Whether the atom IDs or atom indices (i.e. the indices of the elements in the
  * vector pts inside the PointCloud) are saved, the neighbour lists are
  * constructed such that the first element is the 'central atom', whose
@@ -105,20 +106,20 @@ inline linkcell::Cell lammpsBoxToLinkcell(const std::vector<double> &box,
 
 //! All these functions use atom IDs and not indices
 
-//! Inefficient @f$O(n^2)@f$ implementation of neighbour lists when there are
-//! two different types of atoms The neighbour list does not differentiate
+//! Full neighbour list for pairs of type I and type J (vesin cell list,
+//! brute-force fallback). The neighbour list does not differentiate
 //! between the types of atoms
 std::vector<std::vector<int>> neighList(
     double rcutoff, const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
     int typeI, int typeJ);
 
-//! Inefficient @f$O(n^2)@f$ implementation of neighbour lists
+//! Full neighbour list for one type (vesin cell list, brute-force fallback)
 //! You can only use this for neighbour lists with one type
 std::vector<std::vector<int>> neighListO(
     double rcutoff, const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
     int typeI);
 
-//! Inefficient @f$O(n^2)@f$ implementation of neighbour lists
+//! Half neighbour list for one type (vesin cell list, brute-force fallback)
 //! You can only use this for neighbour lists with one type
 std::vector<std::vector<int>> halfNeighList(
     double rcutoff, const molSys::PointCloud<molSys::Point<double>, double> &yCloud,

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -199,8 +199,8 @@ void appendNeighbourID(std::vector<std::vector<int>> &nList,
 
 /**
  * @details Function for building neighbour lists for each
- *  particle. Inefficient brute-force \f$ O(n^2) \f$ implementation.
- *  This generates the full neighbour list, by ID.
+ *  particle. Vesin cell list when built with SEAMS_HAS_VESIN, else
+ *  brute-force \f$ O(n^2) \f$. This generates the full neighbour list, by ID.
  * @param[in] rcutoff Distance cutoff, within which two atoms are neighbours.
  * @param[in] yCloud The input molSys::PointCloud
  * @param[in] typeI Type ID of particles of type I.
@@ -217,6 +217,33 @@ nneigh::neighList(double rcutoff,
 
   const std::vector<int> indexToID = indexToIDTable(yCloud);
   std::vector<std::vector<int>> nList = seedWithSelfIDs(indexToID, yCloud.nop);
+
+#ifdef SEAMS_HAS_VESIN
+  {
+    std::vector<int> subset;
+    subset.reserve(static_cast<size_t>(yCloud.nop));
+    for (int i = 0; i < yCloud.nop; i++) {
+      const int t = yCloud.pts[i].type;
+      if (t == typeI || t == typeJ) {
+        subset.push_back(i);
+      }
+    }
+    std::vector<std::pair<int, int>> pairs;
+    if (cellListPairs(yCloud, subset, rcutoff, pairs)) {
+      for (const auto &[iatom, jatom] : pairs) {
+        const int ti = yCloud.pts[iatom].type;
+        const int tj = yCloud.pts[jatom].type;
+        const bool mixed = (ti == typeI && tj == typeJ) ||
+                           (ti == typeJ && tj == typeI);
+        if (!mixed) {
+          continue;
+        }
+        appendNeighbourID(nList, indexToID, iatom, jatom);
+      }
+      return nList;
+    }
+  }
+#endif
 
   // Compare squared distances so that the per-pair square root is avoided
   const double rcutoffSq = rcutoff * rcutoff;
@@ -352,9 +379,10 @@ nneigh::neighListO(double rcutoff,
 
 /**
  * @details Function for building neighbour lists for each
- *  particle of only one type. Inefficient brute-force \f$ O(n^2) \f$
- *  implementation. This generates the half neighbour list, by ID. This function
- *  will only work for building a neighbour list between one type of particles.
+ *  particle of only one type. Vesin cell list when built with
+ *  SEAMS_HAS_VESIN, else brute-force \f$ O(n^2) \f$. This generates the
+ *  half neighbour list, by ID. This function will only work for building a
+ *  neighbour list between one type of particles.
  * @param[in] rcutoff Distance cutoff, within which two atoms are neighbours.
  * @param[in] yCloud The input molSys::PointCloud
  * @param[in] typeI Type ID of the \f$ i^{th} \f$ particle type.
@@ -370,6 +398,28 @@ nneigh::halfNeighList(double rcutoff,
 
   const std::vector<int> indexToID = indexToIDTable(yCloud);
   std::vector<std::vector<int>> nList = seedWithSelfIDs(indexToID, yCloud.nop);
+
+#ifdef SEAMS_HAS_VESIN
+  {
+    std::vector<int> typeIIndices;
+    for (int i = 0; i < yCloud.nop; i++) {
+      if (yCloud.pts[i].type == typeI) {
+        typeIIndices.push_back(i);
+      }
+    }
+    std::vector<std::pair<int, int>> pairs;
+    if (cellListPairs(yCloud, typeIIndices, rcutoff, pairs)) {
+      // Half list: keep the lower cloud index as the owner, matching the
+      // brute walk that only writes j into i when i < j.
+      for (const auto &[iatom, jatom] : pairs) {
+        if (iatom < jatom) {
+          appendNeighbourID(nList, indexToID, iatom, jatom);
+        }
+      }
+      return nList;
+    }
+  }
+#endif
 
   // Compare squared distances so that the per-pair square root is avoided
   const double rcutoffSq = rcutoff * rcutoff;

--- a/src/rdf2d.cpp
+++ b/src/rdf2d.cpp
@@ -14,6 +14,10 @@
 
 #include <rdf2d.hpp>
 
+#ifdef SEAMS_HAS_VESIN
+#include <vesin.h>
+#endif
+
 // -----------------------------------------------------------------------------------------------------
 // IN-PLANE RDF
 // -----------------------------------------------------------------------------------------------------
@@ -126,6 +130,65 @@ rdf2::sampleRDF_AA(const molSys::PointCloud<molSys::Point<double>, double> &yClo
 
   // Init the histogram to 0
   histogram.resize(nbin);
+
+#ifdef SEAMS_HAS_VESIN
+  if (yCloud.nop > 0 && yCloud.box.size() >= 3) {
+    std::vector<std::array<double, 3>> positions(
+        static_cast<size_t>(yCloud.nop));
+    for (int i = 0; i < yCloud.nop; i++) {
+      positions[static_cast<size_t>(i)] = {
+          yCloud.pts[i].x, yCloud.pts[i].y, yCloud.pts[i].z};
+    }
+    double box[3][3] = {{yCloud.box[0], 0.0, 0.0},
+                        {0.0, yCloud.box[1], 0.0},
+                        {0.0, 0.0, yCloud.box[2]}};
+    bool periodic[3] = {true, true, true};
+    VesinOptions options{};
+    options.cutoff = cutoff;
+    options.full = true;
+    options.sorted = false;
+    options.algorithm = VesinAutoAlgorithm;
+    options.return_shifts = false;
+    options.return_distances = true;
+    options.return_vectors = false;
+    VesinNeighborList neighbors;
+    const char *error_message = nullptr;
+    VesinDevice device = {VesinCPU, 0};
+    const int status = vesin_neighbors(
+        reinterpret_cast<const double (*)[3]>(positions.data()),
+        static_cast<size_t>(yCloud.nop), box, periodic, device, options,
+        &neighbors, &error_message);
+    if (status == 0 && neighbors.distances != nullptr) {
+      for (size_t k = 0; k < neighbors.length; k++) {
+        const int iatom = static_cast<int>(neighbors.pairs[k][0]);
+        const int jatom = static_cast<int>(neighbors.pairs[k][1]);
+        if (iatom >= jatom) {
+          continue;
+        }
+        const double r_ij = neighbors.distances[k];
+        if (r_ij > cutoff) {
+          continue;
+        }
+        int ibin = static_cast<int>(r_ij / binwidth);
+        if (ibin < 0) {
+          continue;
+        }
+        if (ibin >= nbin) {
+          ibin = nbin - 1;
+        }
+        histogram[static_cast<size_t>(ibin)] += 2;
+      }
+      vesin_free(&neighbors);
+      return histogram;
+    }
+    if (status != 0) {
+      std::cerr << "Vesin failed: "
+                << (error_message ? error_message : "unknown")
+                << "; falling back to brute force.\n";
+    }
+    vesin_free(&neighbors);
+  }
+#endif
 
   // Loop through pairs of atoms
   for (int iatom = 0; iatom < yCloud.nop - 1; iatom++) {

--- a/tests/test_neighbours.cpp
+++ b/tests/test_neighbours.cpp
@@ -165,6 +165,11 @@ TEST_CASE("neighList produces neighbour list for two atom types",
       std::find(nList[0].begin() + 1, nList[0].end(), 1) != nList[0].end();
   REQUIRE(found1);
 
+  // Same-type pair 0-2 is inside the cutoff but must not appear on an I-J list
+  bool foundSameType =
+      std::find(nList[0].begin() + 1, nList[0].end(), 2) != nList[0].end();
+  REQUIRE_FALSE(foundSameType);
+
   // Atom 3 (type 2, far away) should have no type-1 neighbours within cutoff
   REQUIRE(nList[3].size() == 1); // only self
 }


### PR DESCRIPTION
# Description

neighList, halfNeighList, and the in-plane RDF sampler use the same vesin cell list as neighListO. Brute force stays the fallback. Mixed I-J lists still drop same-type pairs. The GPU ice-score workspace is unchanged.

# Changes

- nneigh::neighList / halfNeighList
- rdf2::sampleRDF_AA
- test: I-J list does not keep a same-type pair inside the cutoff
- 2.3.1