### PR TITLE
feat: vesin 3x3 from dump H; gpu_batch uses lammpsBoxToLinkcell on tilt

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,13 @@ Changelog
 Unreleased
 ==========
 
+Version 2.3.2 (2026-08-16)
+===========================
+
+Cutoff lists take the LAMMPS dump 3x3, not a diagonal of bound
+spans. Device ice-score batches pass ``lammpsBoxToLinkcell`` when
+the dump tilt is present. ``linkcell`` wrap pin is v0.3.1.
+
 Version 2.3.1 (2026-08-16)
 ===========================
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "d-SEAMS: Deferred Structural Elucidation Analysis for Molecular Simulations"
 type: software
-version: "2.3.1"
+version: "2.3.2"
 date-released: "2026-08-16"
 license: MIT
 repository-code: "https://github.com/d-SEAMS/seams-core"

--- a/docs/newsfragments/vesin-3x3-gpubatch.feature
+++ b/docs/newsfragments/vesin-3x3-gpubatch.feature
@@ -1,0 +1,3 @@
+Cutoff lists (vesin) take the LAMMPS dump 3x3, not a diagonal of
+bound spans. Device ice-score batches pass
+``lammpsBoxToLinkcell`` when the dump tilt is present.

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 #-----------------------------------------------------------------------------------
 
 project('seams-core', ['cpp', 'c'],
-  version: '2.3.1',
+  version: '2.3.2',
   default_options: ['warning_level=2', 'cpp_std=c++20'],
   meson_version: '>=1.3.0')
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "seams-core"
-version = "2.3.1"
+version = "2.3.2"
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "osx-arm64"]
 authors = ["Rohit Goswami <rgoswami@ieee.org>"]

--- a/src/gpu_batch.cpp
+++ b/src/gpu_batch.cpp
@@ -3,6 +3,7 @@
 
 #ifdef SEAMS_HAS_LINKCELL
 #include <linkcell_gpu.hpp>
+#include <neighbours.hpp>
 #endif
 
 #include <algorithm>
@@ -568,7 +569,8 @@ double msSince(std::chrono::steady_clock::time_point t0) {
 } // namespace
 
 BatchResult analyzeResident(const double *xyz, const double *box, int nAtoms,
-                            int nFrames, double rc) {
+                            int nFrames, double rc, const double *boxLow,
+                            int nBox) {
   BatchResult out;
   const auto cfg = seams::cfg::load();
   out.plan = planBatch(nAtoms, nFrames, 16, 16, cfg.resident);
@@ -644,13 +646,26 @@ BatchResult analyzeResident(const double *xyz, const double *box, int nAtoms,
     const std::size_t kSz = static_cast<std::size_t>(kMax);
     const std::size_t nSz = static_cast<std::size_t>(nAtoms);
     const std::size_t fSz = static_cast<std::size_t>(nF);
-    const linkcell::Cell cell0 =
-        linkcell::Cell::ortho(box[0], box[1], box[2]);
+    linkcell::Cell cell0 = linkcell::Cell::ortho(box[0], box[1], box[2]);
+    const double *frameLens = box;
+    if (boxLow != nullptr || nBox >= 6) {
+      std::vector<double> dump(static_cast<std::size_t>(std::max(nBox, 3)));
+      for (int i = 0; i < nBox && i < static_cast<int>(dump.size()); ++i) {
+        dump[static_cast<std::size_t>(i)] = box[i];
+      }
+      std::vector<double> lo;
+      if (boxLow != nullptr) {
+        lo = {boxLow[0], boxLow[1], boxLow[2]};
+      }
+      cell0 = nneigh::lammpsBoxToLinkcell(dump, lo);
+      frameLens = nullptr;
+    }
     void *q = knn.queue();
     // One multi-frame launch on the workspace stream. Per-frame box
     // walks serialize on the same bin buffers and leave the SMs idle.
     knn.knearest_into_many(xyzDev, nSz, fSz, cell0, kSz, colsDev,
-                           fSz * nSz * kSz, nullptr, cfg.cell, false, box);
+                           fSz * nSz * kSz, nullptr, cfg.cell, false,
+                           frameLens);
     auto launchArgs = [](void **raw, std::size_t n) {
       return std::vector<void *>(raw, raw + n);
     };

--- a/src/include/internal/gpu_batch.hpp
+++ b/src/include/internal/gpu_batch.hpp
@@ -31,10 +31,14 @@ struct BatchResult {
   std::string error;
 };
 
-/** xyz is frame-major, atom, xyz. box is frame-major, three lengths.
+/** xyz is frame-major, atom, xyz.
+ *  box is frame-major three lengths when boxLow is null.
+ *  When boxLow is set, box is one dump box (3 spans or 6 span+tilt)
+ *  shared by every frame.
  *  rc is the cell-list cutoff; 5.5 matches the host k-NN candidate shell. */
 BatchResult analyzeResident(const double *xyz, const double *box, int nAtoms,
-                            int nFrames, double rc = 5.5);
+                            int nFrames, double rc = 5.5,
+                            const double *boxLow = nullptr, int nBox = 3);
 
 } // namespace gpu
 

--- a/src/include/internal/gpu_batch.hpp
+++ b/src/include/internal/gpu_batch.hpp
@@ -32,9 +32,10 @@ struct BatchResult {
 };
 
 /** xyz is frame-major, atom, xyz.
- *  box is frame-major three lengths when boxLow is null.
- *  When boxLow is set, box is one dump box (3 spans or 6 span+tilt)
- *  shared by every frame.
+ *  box is frame-major three lengths when boxLow is null and nBox is 3.
+ *  When boxLow is set or nBox is at least 6, box is one dump box
+ *  (3 spans or 6 span+tilt) shared by every frame and the device walk
+ *  uses lammpsBoxToLinkcell.
  *  rc is the cell-list cutoff; 5.5 matches the host k-NN candidate shell. */
 BatchResult analyzeResident(const double *xyz, const double *box, int nAtoms,
                             int nFrames, double rc = 5.5,

--- a/src/include/internal/neighbours.hpp
+++ b/src/include/internal/neighbours.hpp
@@ -62,19 +62,14 @@
 
 namespace nneigh {
 
-#ifdef SEAMS_HAS_LINKCELL
-/// Map a LAMMPS dump box onto lc_cell.
+/// LAMMPS dump bound spans to restricted triclinic H (rows a, b, c).
 ///
-/// `box[0..3]` are bound spans (`xhi_bound - xlo_bound`, ...) as
-/// `seams_input` stores them. `boxLow` is the bound lo. Optional
-/// `box[3..6]` are the dump tilt factors `xy, xz, yz`.
-///
-/// The conversion is the LAMMPS dump convention:
-/// `xlo = xlo_bound - min(0, xy, xz, xy+xz)` and
-/// `lx = xhi_bound - xlo_bound - max(...) + min(...)`, then
-/// `a = (lx, 0, 0)`, `b = (xy, ly, 0)`, `c = (xz, yz, lz)`.
-inline lc_cell lammpsBoxToLcCell(const std::vector<double> &box,
-                                 const std::vector<double> &boxLow) {
+/// `box[0..2]` are `xhi_bound - xlo_bound` etc. Optional `box[3..5]`
+/// are tilt `xy, xz, yz`. `boxLow` is the bound lo. Inverse of
+/// `xlo_bound = xlo + min(0, xy, xz, xy+xz)`.
+inline void dumpBoundsToH(const std::vector<double> &box,
+                          const std::vector<double> &boxLow, double H[3][3],
+                          double origin[3]) {
   const double xspan = box.size() > 0 ? box[0] : 0.0;
   const double yspan = box.size() > 1 ? box[1] : 0.0;
   const double zspan = box.size() > 2 ? box[2] : 0.0;
@@ -88,13 +83,39 @@ inline lc_cell lammpsBoxToLcCell(const std::vector<double> &box,
   const double xmax = std::max(std::max(0.0, xy), std::max(xz, xy + xz));
   const double ymin = std::min(0.0, yz);
   const double ymax = std::max(0.0, yz);
-  lc_cell c = lc_cell_ortho(xspan - xmax + xmin, yspan - ymax + ymin, zspan);
-  c.bx = xy;
-  c.cx = xz;
-  c.cy = yz;
-  c.ox = xlo_b - xmin;
-  c.oy = ylo_b - ymin;
-  c.oz = zlo_b;
+  H[0][0] = xspan - xmax + xmin;
+  H[0][1] = 0.0;
+  H[0][2] = 0.0;
+  H[1][0] = xy;
+  H[1][1] = yspan - ymax + ymin;
+  H[1][2] = 0.0;
+  H[2][0] = xz;
+  H[2][1] = yz;
+  H[2][2] = zspan;
+  origin[0] = xlo_b - xmin;
+  origin[1] = ylo_b - ymin;
+  origin[2] = zlo_b;
+}
+
+#ifdef SEAMS_HAS_LINKCELL
+/// Map a LAMMPS dump box onto lc_cell.
+inline lc_cell lammpsBoxToLcCell(const std::vector<double> &box,
+                                 const std::vector<double> &boxLow) {
+  double H[3][3], o[3];
+  dumpBoundsToH(box, boxLow, H, o);
+  lc_cell c = lc_cell_ortho(H[0][0], H[1][1], H[2][2]);
+  c.ax = H[0][0];
+  c.ay = H[0][1];
+  c.az = H[0][2];
+  c.bx = H[1][0];
+  c.by = H[1][1];
+  c.bz = H[1][2];
+  c.cx = H[2][0];
+  c.cy = H[2][1];
+  c.cz = H[2][2];
+  c.ox = o[0];
+  c.oy = o[1];
+  c.oz = o[2];
   return c;
 }
 

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -100,10 +100,9 @@ bool cellListPairs(const molSys::PointCloud<molSys::Point<double>, double> &yClo
     positions[i] = {yCloud.pts[idx].x, yCloud.pts[idx].y, yCloud.pts[idx].z};
   }
 
-  // Box matrix (row-major, diagonal for orthorhombic)
-  double box[3][3] = {{yCloud.box[0], 0.0, 0.0},
-                      {0.0, yCloud.box[1], 0.0},
-                      {0.0, 0.0, yCloud.box[2]}};
+  double box[3][3];
+  double origin[3];
+  nneigh::dumpBoundsToH(yCloud.box, yCloud.boxLow, box, origin);
   bool periodic[3] = {true, true, true};
 
   VesinOptions options;

--- a/src/rdf2d.cpp
+++ b/src/rdf2d.cpp
@@ -12,6 +12,7 @@
 // If not, see <https://opensource.org/licenses/MIT>.
 //-----------------------------------------------------------------------------------
 
+#include <neighbours.hpp>
 #include <rdf2d.hpp>
 
 #ifdef SEAMS_HAS_VESIN
@@ -139,9 +140,9 @@ rdf2::sampleRDF_AA(const molSys::PointCloud<molSys::Point<double>, double> &yClo
       positions[static_cast<size_t>(i)] = {
           yCloud.pts[i].x, yCloud.pts[i].y, yCloud.pts[i].z};
     }
-    double box[3][3] = {{yCloud.box[0], 0.0, 0.0},
-                        {0.0, yCloud.box[1], 0.0},
-                        {0.0, 0.0, yCloud.box[2]}};
+    double box[3][3];
+    double origin[3];
+    nneigh::dumpBoundsToH(yCloud.box, yCloud.boxLow, box, origin);
     bool periodic[3] = {true, true, true};
     VesinOptions options{};
     options.cutoff = cutoff;

--- a/subprojects/linkcell.wrap
+++ b/subprojects/linkcell.wrap
@@ -1,6 +1,6 @@
 [wrap-git]
 url = https://github.com/d-SEAMS/linkcell.git
-revision = v0.3.0
+revision = v0.3.1
 depth = 1
 
 [provide]

--- a/tests/test_neighbours.cpp
+++ b/tests/test_neighbours.cpp
@@ -573,3 +573,39 @@ TEST_CASE("sheared box k-nearest uses the periodic image",
                Catch::Matchers::WithinAbs(0.25, 1e-9));
 }
 #endif
+
+TEST_CASE("tilt dump cutoff list finds the a-image pair", "[neighbours]") {
+  molSys::PointCloud<molSys::Point<double>, double> cloud;
+  cloud.box = {15.0, 8.660254037844386, 10.0, 5.0, 0.0, 0.0};
+  cloud.boxLow = {0.0, 0.0, 0.0};
+  cloud.nop = 2;
+  const double coords[2][3] = {{0.2, 0.1, 1.0}, {9.7, 0.1, 1.0}};
+  for (int i = 0; i < 2; i++) {
+    molSys::Point<double> pt;
+    pt.type = 1;
+    pt.atomID = i + 1;
+    pt.molID = i + 1;
+    pt.x = coords[i][0];
+    pt.y = coords[i][1];
+    pt.z = coords[i][2];
+    cloud.pts.push_back(pt);
+    cloud.idIndexMap[i + 1] = i;
+  }
+  auto nList = nneigh::neighListO(1.0, cloud, 1);
+  REQUIRE(nList.size() == 2);
+  REQUIRE(nList[0][0] == 1);
+  REQUIRE(nList[1][0] == 2);
+  const bool zeroHasOne =
+      std::find(nList[0].begin() + 1, nList[0].end(), 2) != nList[0].end();
+  const bool oneHasZero =
+      std::find(nList[1].begin() + 1, nList[1].end(), 1) != nList[1].end();
+  REQUIRE(zeroHasOne);
+  REQUIRE(oneHasZero);
+
+  auto byIndex = nneigh::getNewNeighbourListByIndex(cloud, 1.0);
+  REQUIRE(byIndex[0][0] == 0);
+  const bool idx01 =
+      std::find(byIndex[0].begin() + 1, byIndex[0].end(), 1) !=
+      byIndex[0].end();
+  REQUIRE(idx01);
+}


### PR DESCRIPTION
# Description

Cutoff lists were still handing vesin a diagonal of the dump bound spans. A LAMMPS tilt dump is not that box. `cellListPairs` and the in-plane RDF now fill the vesin 3x3 from `dumpBoundsToH` (rows a, b, c; Howto_triclinic inversion). The nList contract is unchanged.

Device ice-score batches pass `lammpsBoxToLinkcell` when the dump tilt or box origin is present, and stay on the ortho frame-major lengths otherwise. Wrap pin is linkcell v0.3.1.

# Changes

- `nneigh::dumpBoundsToH` is the shared dump-to-H conversion
- `cellListPairs` / `sampleRDF_AA` use that 3x3
- `gpu::analyzeResident` takes optional `boxLow` and `nBox`
- test: tilt dump cutoff list finds the a-image pair
- `subprojects/linkcell.wrap` is v0.3.1
- 2.3.2