### PR TITLE
fix: tilt MIC on brute fallback and skin refresh

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Changelog
 Unreleased
 ==========
 
+Version 2.3.3 (2026-08-16)
+===========================
+
+Cutoff fallbacks and the skin Verlet refresh use the dump 3x3
+minimum image, not a diagonal of bound spans.
+
 Version 2.3.2 (2026-08-16)
 ===========================
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "d-SEAMS: Deferred Structural Elucidation Analysis for Molecular Simulations"
 type: software
-version: "2.3.2"
+version: "2.3.3"
 date-released: "2026-08-16"
 license: MIT
 repository-code: "https://github.com/d-SEAMS/seams-core"

--- a/docs/newsfragments/tilt-fallback-skin.feature
+++ b/docs/newsfragments/tilt-fallback-skin.feature
@@ -1,0 +1,3 @@
+Cutoff fallbacks and the skin Verlet refresh use the dump 3x3
+minimum image, not a diagonal of bound spans. ``residentFrameCell``
+is the shared dump-to-device Cell helper.

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 #-----------------------------------------------------------------------------------
 
 project('seams-core', ['cpp', 'c'],
-  version: '2.3.2',
+  version: '2.3.3',
   default_options: ['warning_level=2', 'cpp_std=c++20'],
   meson_version: '>=1.3.0')
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "seams-core"
-version = "2.3.2"
+version = "2.3.3"
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "osx-arm64"]
 authors = ["Rohit Goswami <rgoswami@ieee.org>"]

--- a/src/gpu_batch.cpp
+++ b/src/gpu_batch.cpp
@@ -648,18 +648,7 @@ BatchResult analyzeResident(const double *xyz, const double *box, int nAtoms,
     const std::size_t fSz = static_cast<std::size_t>(nF);
     linkcell::Cell cell0 = linkcell::Cell::ortho(box[0], box[1], box[2]);
     const double *frameLens = box;
-    if (boxLow != nullptr || nBox >= 6) {
-      std::vector<double> dump(static_cast<std::size_t>(std::max(nBox, 3)));
-      for (int i = 0; i < nBox && i < static_cast<int>(dump.size()); ++i) {
-        dump[static_cast<std::size_t>(i)] = box[i];
-      }
-      std::vector<double> lo;
-      if (boxLow != nullptr) {
-        lo = {boxLow[0], boxLow[1], boxLow[2]};
-      }
-      cell0 = nneigh::lammpsBoxToLinkcell(dump, lo);
-      frameLens = nullptr;
-    }
+    nneigh::residentFrameCell(box, boxLow, nBox, cell0, frameLens);
     void *q = knn.queue();
     // One multi-frame launch on the workspace stream. Per-frame box
     // walks serialize on the same bin buffers and leave the SMs idle.

--- a/src/include/internal/neighbours.hpp
+++ b/src/include/internal/neighbours.hpp
@@ -123,6 +123,29 @@ inline linkcell::Cell lammpsBoxToLinkcell(const std::vector<double> &box,
                                           const std::vector<double> &boxLow) {
   return linkcell::Cell(lammpsBoxToLcCell(box, boxLow));
 }
+
+/// Cell and optional per-frame ortho lengths for analyzeResident.
+/// boxLow set or nBox >= 6: one dump box via lammpsBoxToLinkcell,
+/// frameLens is null. Otherwise Cell::ortho of box[0..2] and
+/// frameLens is box.
+inline void residentFrameCell(const double *box, const double *boxLow,
+                              int nBox, linkcell::Cell &cell,
+                              const double *&frameLens) {
+  cell = linkcell::Cell::ortho(box[0], box[1], box[2]);
+  frameLens = box;
+  if (boxLow != nullptr || nBox >= 6) {
+    std::vector<double> dump(static_cast<std::size_t>(std::max(nBox, 3)));
+    for (int i = 0; i < nBox && i < static_cast<int>(dump.size()); ++i) {
+      dump[static_cast<std::size_t>(i)] = box[i];
+    }
+    std::vector<double> lo;
+    if (boxLow != nullptr) {
+      lo = {boxLow[0], boxLow[1], boxLow[2]};
+    }
+    cell = lammpsBoxToLinkcell(dump, lo);
+    frameLens = nullptr;
+  }
+}
 #endif
 
 //! All these functions use atom IDs and not indices
@@ -254,7 +277,7 @@ private:
   std::vector<double> x0_;
   std::vector<double> y0_;
   std::vector<double> z0_;
-  std::array<double, 3> box0_{};
+  std::vector<double> box0_;
   std::vector<std::pair<int, int>> candidates_;
   std::vector<std::pair<int, int>> bonded_;
   std::vector<std::vector<int>> nList_;

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -73,6 +73,32 @@ std::vector<int> indexToIDTable(
   return indexToID;
 }
 
+// Ortho SIMD wrap on box[0..2] is wrong for a tilt dump: those
+// entries are bound spans, not lx, ly, lz. gen::periodicDistSq
+// already inverts the dump 3x3 when box.size() >= 6.
+void fillPairDistSq(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int iatom,
+    const int *jatom, std::size_t n, double *dx, double *dy, double *dz,
+    double *distSq) {
+  if (yCloud.box.size() >= 6) {
+    for (std::size_t k = 0; k < n; k++) {
+      distSq[k] = gen::periodicDistSq(yCloud, iatom, jatom[k]);
+    }
+    return;
+  }
+  const double xi = yCloud.pts[static_cast<std::size_t>(iatom)].x;
+  const double yi = yCloud.pts[static_cast<std::size_t>(iatom)].y;
+  const double zi = yCloud.pts[static_cast<std::size_t>(iatom)].z;
+  for (std::size_t k = 0; k < n; k++) {
+    const auto &pj = yCloud.pts[static_cast<std::size_t>(jatom[k])];
+    dx[k] = xi - pj.x;
+    dy[k] = yi - pj.y;
+    dz[k] = zi - pj.z;
+  }
+  seams::BatchPeriodicDistSq(dx, dy, dz, yCloud.box[0], yCloud.box[1],
+                             yCloud.box[2], distSq, n);
+}
+
 #ifdef SEAMS_HAS_VESIN
 /**
  * @details Runs the vesin cell list over the particles named by @a subset and
@@ -326,9 +352,6 @@ nneigh::neighListO(double rcutoff,
   nList = seedWithSelfIDs(indexToID, yCloud.nop);
 
   const double rcutoffSq = rcutoff * rcutoff;
-  const double bx = yCloud.box[0];
-  const double by = yCloud.box[1];
-  const double bz = yCloud.box[2];
 
   // Scratch buffers for the batched distance kernel, sized once for the
   // largest batch and reused across iatom
@@ -346,21 +369,8 @@ nneigh::neighListO(double rcutoff,
       continue;
     }
 
-    const double xi = yCloud.pts[iatom].x;
-    const double yi = yCloud.pts[iatom].y;
-    const double zi = yCloud.pts[iatom].z;
-    for (size_t jj = 0; jj < remaining; jj++) {
-      const int jatom = typeIIndices[ii + 1 + jj];
-      dx[jj] = xi - yCloud.pts[jatom].x;
-      dy[jj] = yi - yCloud.pts[jatom].y;
-      dz[jj] = zi - yCloud.pts[jatom].z;
-    }
-
-    // Batch compute squared periodic distances (SIMD when available)
-    seams::BatchPeriodicDistSq(std::span(dx).first(remaining),
-                               std::span(dy).first(remaining),
-                               std::span(dz).first(remaining), bx, by, bz,
-                               std::span(distSq).first(remaining));
+    fillPairDistSq(yCloud, iatom, typeIIndices.data() + ii + 1, remaining,
+                   dx.data(), dy.data(), dz.data(), distSq.data());
 
     // Filter by cutoff and update neighbour lists
     for (size_t jj = 0; jj < remaining; jj++) {
@@ -492,34 +502,20 @@ std::vector<std::vector<int>> nneigh::getNewNeighbourListByIndex(
   // -------------------------------------------------------
   // Compare squared distances so that the per-pair square root is avoided
   const double cutoffSq = cutoff * cutoff;
-  const double bx = yCloud.box[0];
-  const double by = yCloud.box[1];
-  const double bz = yCloud.box[2];
 
   // Scratch buffers for the batched distance kernel, sized once for the
   // largest batch and reused across iatom
   std::vector<double> dx(yCloud.nop), dy(yCloud.nop), dz(yCloud.nop);
   std::vector<double> distSq(yCloud.nop);
+  std::vector<int> allIdx(static_cast<std::size_t>(yCloud.nop));
+  std::iota(allIdx.begin(), allIdx.end(), 0);
 
   // Loop through every iatom and find nearest neighbours within cutoff
   for (int iatom = 0; iatom < yCloud.nop - 1; iatom++) {
     const size_t remaining = static_cast<size_t>(yCloud.nop - iatom - 1);
 
-    const double xi = yCloud.pts[iatom].x;
-    const double yi = yCloud.pts[iatom].y;
-    const double zi = yCloud.pts[iatom].z;
-    for (size_t jj = 0; jj < remaining; jj++) {
-      const int jatom = iatom + 1 + static_cast<int>(jj);
-      dx[jj] = xi - yCloud.pts[jatom].x;
-      dy[jj] = yi - yCloud.pts[jatom].y;
-      dz[jj] = zi - yCloud.pts[jatom].z;
-    }
-
-    // Batch compute squared periodic distances (SIMD when available)
-    seams::BatchPeriodicDistSq(std::span(dx).first(remaining),
-                               std::span(dy).first(remaining),
-                               std::span(dz).first(remaining), bx, by, bz,
-                               std::span(distSq).first(remaining));
+    fillPairDistSq(yCloud, iatom, allIdx.data() + iatom + 1, remaining,
+                   dx.data(), dy.data(), dz.data(), distSq.data());
 
     // Update the neighbour indices for iatom and jatom both (full list)
     for (size_t jj = 0; jj < remaining; jj++) {
@@ -669,6 +665,37 @@ std::vector<int> nominatePacked(
     return nom;
   }
 #endif
+  std::vector<int> owners;
+  owners.reserve(static_cast<std::size_t>(n));
+  for (int i = 0; i < n; i++) {
+    if (yCloud.pts[static_cast<std::size_t>(i)].type == typeI) {
+      owners.push_back(i);
+    }
+  }
+  if (yCloud.box.size() >= 6) {
+    for (const int i : owners) {
+      std::priority_queue<std::pair<double, int>> heap;
+      for (const int j : owners) {
+        if (j == i) {
+          continue;
+        }
+        const double d2 = gen::periodicDistSq(yCloud, i, j);
+        if (static_cast<int>(heap.size()) < k) {
+          heap.push({d2, j});
+        } else if (d2 < heap.top().first) {
+          heap.pop();
+          heap.push({d2, j});
+        }
+      }
+      const int take = std::min(k, static_cast<int>(heap.size()));
+      for (int t = take - 1; t >= 0; t--) {
+        nom[static_cast<std::size_t>(i) * static_cast<std::size_t>(k) +
+            static_cast<std::size_t>(t)] = heap.top().second;
+        heap.pop();
+      }
+    }
+    return nom;
+  }
   const double bx = yCloud.box[0];
   const double by = yCloud.box[1];
   const double bz = yCloud.box[2];
@@ -691,8 +718,6 @@ std::vector<int> nominatePacked(
 
   std::vector<int> head(static_cast<std::size_t>(ncell), -1);
   std::vector<int> next(static_cast<std::size_t>(yCloud.nop), -1);
-  std::vector<int> owners;
-  owners.reserve(static_cast<std::size_t>(yCloud.nop));
 
   auto wrap = [](double x, double L) {
     double t = x / L;
@@ -724,10 +749,7 @@ std::vector<int> nominatePacked(
     return (iz * ny + iy) * nx + ix;
   };
 
-  for (int i = 0; i < yCloud.nop; i++) {
-    if (yCloud.pts[static_cast<std::size_t>(i)].type != typeI) {
-      continue;
-    }
+  for (const int i : owners) {
     int ix = 0;
     int iy = 0;
     int iz = 0;
@@ -735,7 +757,6 @@ std::vector<int> nominatePacked(
     const int c = cellIndex(ix, iy, iz);
     next[static_cast<std::size_t>(i)] = head[static_cast<std::size_t>(c)];
     head[static_cast<std::size_t>(c)] = i;
-    owners.push_back(i);
   }
 
   const int maxReach = std::max({nx, ny, nz}) / 2 + 1;
@@ -1001,9 +1022,11 @@ bool nneigh::SkinNeighborList::mustRebuild(
   if (static_cast<int>(x0_.size()) != yCloud.nop || yCloud.box.size() < 3) {
     return true;
   }
-  for (int k = 0; k < 3; k++) {
-    if (std::fabs(yCloud.box[k] - box0_[static_cast<std::size_t>(k)]) >
-        1e-8) {
+  if (yCloud.box.size() != box0_.size()) {
+    return true;
+  }
+  for (std::size_t k = 0; k < yCloud.box.size(); k++) {
+    if (std::fabs(yCloud.box[k] - box0_[k]) > 1e-8) {
       return true;
     }
   }
@@ -1070,7 +1093,7 @@ void nneigh::SkinNeighborList::rebuildCandidates(
     y0_[static_cast<std::size_t>(i)] = yCloud.pts[i].y;
     z0_[static_cast<std::size_t>(i)] = yCloud.pts[i].z;
   }
-  box0_ = {yCloud.box[0], yCloud.box[1], yCloud.box[2]};
+  box0_ = yCloud.box;
 }
 
 void nneigh::SkinNeighborList::refreshBonds(
@@ -1093,7 +1116,17 @@ void nneigh::SkinNeighborList::refreshBonds(
     dz[t] = yCloud.pts[static_cast<std::size_t>(j)].z -
             yCloud.pts[static_cast<std::size_t>(i)].z;
   }
-  if (yCloud.box.size() >= 3 && m > 0) {
+  if (yCloud.box.size() >= 6 && m > 0) {
+    for (std::size_t t = 0; t < m; t++) {
+      const int i = candidates_[t].first;
+      const int j = candidates_[t].second;
+      if (i < 0 || j < 0 || i >= yCloud.nop || j >= yCloud.nop) {
+        r2[t] = 0.0;
+        continue;
+      }
+      r2[t] = gen::periodicDistSq(yCloud, i, j);
+    }
+  } else if (yCloud.box.size() >= 3 && m > 0) {
     seams::BatchPeriodicDistSq(dx.data(), dy.data(), dz.data(), yCloud.box[0],
                                yCloud.box[1], yCloud.box[2], r2.data(), m);
   }

--- a/tests/test_neighbours.cpp
+++ b/tests/test_neighbours.cpp
@@ -608,4 +608,38 @@ TEST_CASE("tilt dump cutoff list finds the a-image pair", "[neighbours]") {
       std::find(byIndex[0].begin() + 1, byIndex[0].end(), 1) !=
       byIndex[0].end();
   REQUIRE(idx01);
+
+  nneigh::SkinNeighborList skin(1.0, 0.5, 1, nneigh::BondGraph::Cutoff);
+  const auto &skinList = skin.update(cloud);
+  REQUIRE(skin.lastRebuilt());
+  const bool skin01 =
+      std::find(skinList[0].begin() + 1, skinList[0].end(), 2) !=
+      skinList[0].end();
+  REQUIRE(skin01);
+  cloud.box[3] = 4.0;
+  skin.update(cloud);
+  REQUIRE(skin.lastRebuilt());
 }
+
+#ifdef SEAMS_HAS_LINKCELL
+TEST_CASE("residentFrameCell uses dump H when nBox is 6", "[neighbours]") {
+  const double box[6] = {15.0, 8.660254037844386, 10.0, 5.0, 0.0, 0.0};
+  linkcell::Cell cell = linkcell::Cell::ortho(1.0, 1.0, 1.0);
+  const double *frameLens = box;
+  nneigh::residentFrameCell(box, nullptr, 6, cell, frameLens);
+  REQUIRE(frameLens == nullptr);
+  REQUIRE_THAT(cell.a[0], Catch::Matchers::WithinAbs(10.0, 1e-12));
+  REQUIRE_THAT(cell.b[0], Catch::Matchers::WithinAbs(5.0, 1e-12));
+}
+
+TEST_CASE("residentFrameCell stays ortho for three lengths", "[neighbours]") {
+  const double box[3] = {10.0, 11.0, 12.0};
+  linkcell::Cell cell = linkcell::Cell::ortho(1.0, 1.0, 1.0);
+  const double *frameLens = nullptr;
+  nneigh::residentFrameCell(box, nullptr, 3, cell, frameLens);
+  REQUIRE(frameLens == box);
+  REQUIRE_THAT(cell.a[0], Catch::Matchers::WithinAbs(10.0, 1e-12));
+  REQUIRE_THAT(cell.b[1], Catch::Matchers::WithinAbs(11.0, 1e-12));
+  REQUIRE_THAT(cell.c[2], Catch::Matchers::WithinAbs(12.0, 1e-12));
+}
+#endif

--- a/tests/test_rdf2d.cpp
+++ b/tests/test_rdf2d.cpp
@@ -123,6 +123,30 @@ TEST_CASE("sampleRDF_AA produces histogram with correct bin count", "[rdf2d]") {
   REQUIRE(hist[1] == 0);
 }
 
+TEST_CASE("sampleRDF_AA histograms the tilt a-image pair", "[rdf2d]") {
+  molSys::PointCloud<molSys::Point<double>, double> cloud;
+  cloud.box = {15.0, 8.660254037844386, 10.0, 5.0, 0.0, 0.0};
+  cloud.boxLow = {0.0, 0.0, 0.0};
+  cloud.nop = 2;
+  const double coords[2][3] = {{0.2, 0.1, 1.0}, {9.7, 0.1, 1.0}};
+  for (int i = 0; i < 2; i++) {
+    molSys::Point<double> pt;
+    pt.type = 1;
+    pt.atomID = i + 1;
+    pt.x = coords[i][0];
+    pt.y = coords[i][1];
+    pt.z = coords[i][2];
+    cloud.pts.push_back(pt);
+    cloud.idIndexMap[i + 1] = i;
+  }
+  const double cutoff = 1.0;
+  const double binwidth = 0.1;
+  const int nbin = 10;
+  auto hist = rdf2::sampleRDF_AA(cloud, cutoff, binwidth, nbin);
+  REQUIRE(hist.size() == static_cast<std::size_t>(nbin));
+  REQUIRE(hist[5] == 2);
+}
+
 // -- normalizeRDF tests --
 
 TEST_CASE("normalizeRDF produces non-negative values", "[rdf2d]") {


### PR DESCRIPTION
# Description

#72 hands vesin the dump 3x3. The brute fallback, the skin Verlet refresh, and `analyzeResident`'s only caller still treated `box[0..2]` as orthorhombic periods. On a LAMMPS tilt dump those are bound spans, not `lx, ly, lz`. The hex-prism a-image pair is 0.5 away; `BatchPeriodicDistSq` on the span measures 5.5 and drops it.

`neighListO`, `getNewNeighbourListByIndex`, and `SkinNeighborList::refreshBonds` use `gen::periodicDistSq` when the dump carries tilt. `mustRebuild` compares the full dump box, so a tilt-only change rebuilds candidates. The in-tree `nominatePacked` fallback does not bin a sheared dump on bound spans. `residentFrameCell` is the shared dump-to-device Cell helper.

# Changes

- `fillPairDistSq` / tilt branch in `neighListO` and `getNewNeighbourListByIndex`
- `SkinNeighborList::refreshBonds` and `mustRebuild`
- `nominatePacked` sheared fallback
- `nneigh::residentFrameCell`
- tests: skin a-image, tilt-only rebuild, RDF bin at r=0.5, `residentFrameCell` nBox=6 vs 3
- 2.3.3