### PR TITLE
docs: align the engine book with 2.3.x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,34 +19,30 @@ some changes or improvements or alternatives.
 
 Some things that will increase the chance that your pull request is accepted:
 
-- Write tests.
-- Follow the commit-style below.
+- Write tests (Catch2; `pixi run test` or `meson test -C bbdir`).
+- Follow Conventional Commits below.
 
-## Commit Style
+## Commit style
 
-A sample **good commit** is:
+Subjects use Conventional Commits:
 
 ```
-fileName: Thing I did
-Some subHeading things
-
-So this change was to do that thing I thought was good. Also there was this
-other person who thought so too, so then I ate a sandwich and we got the code
-done. I am writing this but really, honestly, two people did this.
-
-
-Co-authored-by: Joel Doe <joel@iexistreally.com>
+feat(cli): add --print-config for the twelve-factor table
+fix(neighbours): take the LAMMPS dump 3x3 for cutoff lists
+docs(book): document vesin versus linkcell
 ```
 
-As is evident, the commit should clearly have:
+Prefixes that land here: `feat`, `fix`, `docs`, `chore`, `refactor`,
+`test`. Scope is optional (`cli`, `gpu`, `book`). The 2020
+`fileName: ...` sandwich sample is not the house style.
 
-- The name of the file, or the topic or the subject you have changed or the
-  namespace or the functionality you have added **something:**
-- A line describing **something:**
-- An _(optional)_ subheading with more details
-- An _(optional)_ paragraph or essay on why the change was done and anything else you want to share with the devs.
-- **Co-authorship** IS MANDATORY if applicable. Even if you just had a sandwich with the other person. It won't kill you to share, or to write that.
+Name every co-author with a trailer when the work is shared:
 
-<!-- * Follow our [style guide][style]. -->
+```
+Co-authored-by: Name <email>
+```
 
-<!-- [style]: https://github.com/thoughtbot/guides/tree/master/style -->
+Build with pixi or the Nix flake. The engine binary is `seams`
+(`./bbdir/seams` after `pixi run build`). Python is PydSEAMSlib;
+Lua is yodaStruct. Do not add a `yodaStruct -c` / `conf.yaml`
+driver here.

--- a/docs/orgmode/changelog.org
+++ b/docs/orgmode/changelog.org
@@ -7,8 +7,30 @@ The C++ engine is this repository. Python is ~pydseams~
 
 * Unreleased
 
-The C++ API in the book is Doxygen via doxyrest (=api/index=),
-the same path as rgpot. The hand function tables are gone.
+* 2.3.2
+
+Cutoff lists take the LAMMPS dump 3x3, not a diagonal of bound
+spans. Device ice-score batches pass ~lammpsBoxToLinkcell~ when
+the dump tilt is present. ~linkcell~ wrap pin is v0.3.1.
+
+* 2.3.1
+
+~neighList~, ~halfNeighList~, and the in-plane RDF sampler use
+the vesin cell list (same helper as ~neighListO~). Brute force
+remains the fallback. The GPU ice-score workspace is unchanged.
+
+* 2.3.0
+
+The TUM ice score (mutual four-nearest graph, primitive hexagons,
+HC/DDC) runs as a device-resident frame batch when gpulite and
+~linkcell~ 0.3.0 are present. CHILL and \(q_{lm}\) stay on the
+host. Runtime knobs are twelve-factor: ~SEAMS_CONFIG~ or
+~./seams.env~, then the environment, then CLI flags.
+~seams --print-config~ dumps the table. Examples and the README
+use ~seams~ / ~pydseams~ / ~require("dseams")~; the 2020
+~yodaStruct -c~ / ~conf.yaml~ surface is gone.
+
+The C++ API in the book is Doxygen via doxyrest (=api/index=).
 
 * 2.2.5
 

--- a/docs/orgmode/contributing/index.org
+++ b/docs/orgmode/contributing/index.org
@@ -126,5 +126,5 @@ Install the clang-format hook:
 ./scripts/git-pre-commit-format install
 #+end_src
 
-Commit subjects follow ~fileName: description of change~. See
-~CONTRIBUTING.md~ in the repository root.
+Commit subjects follow Conventional Commits (~feat~, ~fix~, ~docs~,
+~chore~). Do not use the 2020 ~fileName: ...~ sandwich sample.

--- a/docs/orgmode/explanation/architecture.org
+++ b/docs/orgmode/explanation/architecture.org
@@ -2,8 +2,9 @@
 #+OPTIONS: toc:nil num:nil
 
 d-SEAMS 2 is not a monolith. The classifier is one C++ library.
-Neighbour search is linkcell. Each language ships its own package
-against that library.
+Cutoff neighbour lists are optional vesin (brute-force fallback).
+Periodic k-nearest graphs are optional linkcell. Each language
+ships its own package against that library.
 
 | repository | product | role |
 |------------+---------+------|
@@ -12,7 +13,7 @@ against that library.
 | [[https://github.com/d-SEAMS/yodaStruct][yodaStruct]] | ~dseams~ | Lua/Fennel library |
 | [[https://github.com/d-SEAMS/linkcell][linkcell]] | ~lc_*~ | Periodic linked-cell k-nearest neighbours |
 
-The front ends take seams-core as a Meson subproject (static library)
+The front ends take seams-core as a Meson subproject (~libyodaLib~)
 or as a flake input. They do not vendor a second engine.
 
 A language binding that lived in the engine tree would force every
@@ -34,9 +35,13 @@ schedules.
        PY[pydseams Frame]
        LUA["require(\"dseams\")"]
      end
-     LC[linkcell]
+     LC[linkcell k-NN]
+     VE[vesin cutoff]
+     GPU[gpulite TUM batch]
      DUMP[LAMMPS / XYZ / chemfiles / con] --> LIB
      LC --> LIB
+     VE --> LIB
+     GPU --> LIB
      LIB --> CLI
      LIB --> PY
      LIB --> LUA
@@ -61,6 +66,36 @@ There is no ~yodaStruct~ executable in any of the three repositories.
 The 2020 CMake Nix derivation of ~yodaStruct~ is gone.
 ~-Dwith_python=true~ and ~-Dwith_lua=enabled~ are Meson errors that
 name PydSEAMSlib and yodaStruct.
+
+* Neighbour backends
+
+- *vesin* (optional, ~SEAMS_HAS_VESIN~): cutoff pair lists
+  (~neighList~, ~neighListO~). Brute force if the wrap is off.
+- *linkcell* (optional, ~SEAMS_HAS_LINKCELL~): periodic k-NN for
+  ~knn~ / ~knn-union~ / ~seeded~ graphs and the device TUM walk.
+  Not a drop-in for vesin cutoff lists.
+
+~seams --features~ prints both.
+
+* Device paths
+
+Optional CUDA via gpulite (~-Dwith_gpulite~) runs the TUM ice score
+only: linkcell k-NN, mutual four-nearest graph, primitive six-rings,
+HC/DDC. CHILL and \(q_{lm}\) stay on the host.
+
+OpenMP target offload is a second GPU path, Steinhardt-only, meson
+off by default (~-Dwith_openmp_offload~, ~SEAMS_OFFLOAD~). It is
+not gpulite.
+
+* Runtime knobs
+
+Defaults live in the binary. An optional dotenv (~SEAMS_CONFIG~ or
+~./seams.env~) fills unset keys. The process environment wins the
+file; CLI flags win the environment. ~seams --print-config~ dumps
+the table. Keys: ~SEAMS_FRAME~ / ~LAST~ / ~JOBS~ / ~TYPE~ /
+~CUTOFF~ / ~K~ / ~GRAPH~ / ~RESIDENT~ / ~CELL~ / ~OFFLOAD~,
+~LINKCELL_TPP~ / ~BLOCK~, ~YODA_FENNEL_PATH~ / ~YODA_LUA_PATH~.
+Analysis choice is not this table.
 
 * Ice score and the CHILL+ star
 

--- a/docs/orgmode/explanation/chill-plus-vs-cages.org
+++ b/docs/orgmode/explanation/chill-plus-vs-cages.org
@@ -6,12 +6,13 @@ and they do not imply each other.
 
 * Four-neighbour star
 
-CHILL and CHILL+ (~seams chill~ / ~seams chill-plus~,
-~chill::getCorrelPlus~ / ~getIceTypePlus~) look at the four-neighbour
-star. They compute bond-order correlations ~c_ij~ on the four nearest
-neighbours of each oxygen (or each mW site) and label the atom cubic,
-hexagonal, interfacial, clathrate, or water from the staggered and
-eclipsed pattern of that star.
+CHILL (~seams chill~, ~chill::getCorrel~ / ~getIceTypeNoPrint~) and
+CHILL+ (~seams chill-plus~, ~chill::getCorrelPlus~ /
+~getIceTypePlusNoPrint~) look at the four-neighbour star. Both stay
+on the host. They compute bond-order correlations ~c_ij~ on the four
+nearest neighbours of each oxygen (or each mW site) and label the
+atom cubic, hexagonal, interfacial, clathrate, or water from the
+staggered and eclipsed pattern of that star.
 
 A molecule is cubic or hexagonal when its four bonds look like ice,
 even if those neighbours do not close a cage.
@@ -31,6 +32,11 @@ four-neighbour star.
 
 This is topological unit matching (TUM). The methods paper is the
 2020 JCIM article (see [[file:citation.org][Citation]]).
+
+The GPU path (~gpu::analyzeResident~) is that TUM ice score only:
+~linkcell::gpu~ k-nearest, the mutual four-nearest graph, primitive
+six-rings, and HC/DDC affiliation. CHILL, CHILL+, and \(q_{lm}\)
+stay on the host. Only cage labels come back.
 
 * Why they disagree
 

--- a/docs/orgmode/howto/confined-ice.org
+++ b/docs/orgmode/howto/confined-ice.org
@@ -12,7 +12,7 @@ Use a scripting front end:
 
 - Lua examples under ~example_lua/iceNanotube/~ in
   [[https://github.com/d-SEAMS/yodaStruct][yodaStruct]]
-- ~Frame.find_prisms~ and ~Frame.find_polygons~ in
+- ~Frame.find_prisms~ and ~Frame.monolayer_rings~ in
   [[https://d-seams.github.io/PydSEAMSlib/][pydseams]]
 
 External dumps (figshare project 73545):

--- a/docs/orgmode/howto/install.org
+++ b/docs/orgmode/howto/install.org
@@ -14,7 +14,8 @@ pixi run build
 #+end_src
 
 The default pixi lock includes Highway and chemfiles. Optional pixi
-environments: ~ira~, ~sphericart~, ~nauty~, ~mpi~, ~docs~.
+environments: ~ira~, ~sphericart~, ~nauty~, ~mpi~, ~docs~,
+~formalanalysis~, ~repro~.
 
 * Nix flake
 
@@ -25,10 +26,11 @@ nix develop
 nix run . -- read input/traj/exampleTraj.lammpstrj
 #+end_src
 
-The flake turns Eigen, BLAS/LAPACK, Catch2, and Highway on when
-nixpkgs provides them. Optional wrap-git backends (vesin, chemfiles,
-readcon-core, IRA, sphericart, nauty, MPI) stay off unless the package
-is already in the closure. Binary cache: ~cachix use dseams~.
+The flake links Eigen, BLAS/LAPACK, Catch2, and Highway from nixpkgs.
+Wrap-git backends (vesin, readcon-core, linkcell) and chemfiles stay
+off unless the package is already in the closure. IRA, sphericart,
+nauty, and MPI stay off. vesin is cutoff; linkcell is k-NN. Binary
+cache: ~cachix use dseams~.
 
 The flake on/off table lives on [[file:../reference/nix.org][Nix]].
 

--- a/docs/orgmode/howto/troubleshooting.org
+++ b/docs/orgmode/howto/troubleshooting.org
@@ -11,6 +11,9 @@
 | ~--jobs~ does nothing useful | OpenMP off | ~seams --features~ |
 | ~ModuleNotFoundError: pydseams~ | Wrong repository | PydSEAMSlib, not ~pixi run~ in seams-core |
 | Looking for ~yodaStruct -c lua_inputs/config.yml~ | 2020 executable | ~seams~ here; Lua library in yodaStruct |
+| ~seams: command not found~ | Binary not on ~PATH~ | After ~pixi run build~ / ~meson compile -C bbdir~ the binary is ~./bbdir/seams~. Install with ~pixi run install~ or ~meson install~ |
+| Meson rejects ~-Dwith_python=true~ or ~-Dwith_lua=enabled~ | Bindings are other repos | Build PydSEAMSlib or yodaStruct; engine Meson is ~-Dwith_python=false~ |
+| Wrap pin / ~nodownload~ miss | Flake does not fetch wrap-git | Pins live in ~subprojects/~ (~linkcell~ v0.3.1, ~vesin~ v0.5.7, ~readcon-core~ v0.14.0, ~gpulite~). The flake uses ~mesonAutoFeatures=disabled~ and wrap ~nodownload~ |
 
 When you file an issue, include ~seams --version~, ~seams --features~,
 the command line, and a minimal dump.

--- a/docs/orgmode/quickstart.org
+++ b/docs/orgmode/quickstart.org
@@ -49,6 +49,29 @@ them. Optional wrap-git backends stay off unless a package is already
 in the closure. ~pixi~ enables what conda-forge put in the environment
 (Highway and chemfiles are in the default pixi lock).
 
+* Runtime knobs
+
+Knobs that change between machines and jobs are twelve-factor. They
+are not compiled in and they are not ~conf.yaml~. Defaults live in
+the binary. An optional dotenv file (~SEAMS_CONFIG~ or
+~./seams.env~) fills unset variables. The process environment wins
+over the file. CLI flags win over the environment.
+
+#+begin_src bash
+cp seams.env.example seams.env
+seams --print-config
+seams --frame 1 --last 100 --jobs 8 --type 2 --graph seeded \
+  cages input/traj/exampleTraj.lammpstrj
+#+end_src
+
+The same values can be ~SEAMS_FRAME~, ~SEAMS_LAST~, ~SEAMS_JOBS~,
+~SEAMS_TYPE~, ~SEAMS_CUTOFF~, ~SEAMS_K~, ~SEAMS_GRAPH~, plus
+~SEAMS_RESIDENT~, ~SEAMS_CELL~, ~SEAMS_OFFLOAD~, ~LINKCELL_TPP~,
+~LINKCELL_BLOCK~. ~OMP_NUM_THREADS~ and ~CUDA_VISIBLE_DEVICES~ keep
+their usual meaning. Analysis choice (which ~seams~ command, which
+~pydseams~ call, which ~require("dseams")~ script) is not this
+table.
+
 * CHILL+ and cages
 
 #+begin_src bash

--- a/docs/orgmode/reference/api.org
+++ b/docs/orgmode/reference/api.org
@@ -30,7 +30,8 @@ Four fronts, one engine (~libyodaLib~). Flags live on
    =api/index.rst~ with title ~API Reference~.
 
 The book includes that tree as =api/index= (Reference toctree), not
-as a second hand list of functions.
+as a second hand list of functions. The generated pages are the
+API; the header table below is only a map onto those pages.
 
 #+begin_export rst
 .. toctree::
@@ -38,59 +39,6 @@ as a second hand list of functions.
    :caption: C++ (doxygen)
 
    ../api/index
-#+end_export
-
-The groups below are Breathe of the same XML. That is the interned
-API, not a hand table.
-
-#+begin_export rst
-.. doxygengroup:: nneigh
-   :members:
-   :content-only:
-
-.. doxygengroup:: chill
-   :members:
-   :content-only:
-
-.. doxygengroup:: primitive
-   :members:
-   :content-only:
-
-.. doxygengroup:: ring
-   :members:
-   :content-only:
-
-.. doxygengroup:: prism3
-   :members:
-   :content-only:
-
-.. doxygengroup:: cage
-   :members:
-   :content-only:
-
-.. doxygengroup:: bond
-   :members:
-   :content-only:
-
-.. doxygengroup:: sinp
-   :members:
-   :content-only:
-
-.. doxygengroup:: clump
-   :members:
-   :content-only:
-
-.. doxygengroup:: gen
-   :members:
-   :content-only:
-
-.. doxygengroup:: rdf2
-   :members:
-   :content-only:
-
-.. doxygengroup:: molSys
-   :members:
-   :content-only:
 #+end_export
 
 * Headers

--- a/docs/orgmode/reference/cli.org
+++ b/docs/orgmode/reference/cli.org
@@ -64,9 +64,19 @@ initializers (Argum does not write defaults into the help).
 | ~-c~, ~--cutoff ANGSTROM~ | ~3.5~ | ~Neighbour cutoff~ |
 | ~-k N~ | ~4~ | ~k for knn / seeded cages~ |
 | ~--graph KIND~ | ~seeded~ | ~Bond graph for cages: cutoff \| knn \| knn-union \| seeded~ |
+| ~--config FILE~ | ~SEAMS_CONFIG~ or ~./seams.env~ | Dotenv of ~SEAMS_*~ / ~LINKCELL_*~ knobs. Env wins over the file |
+| ~--print-config~ | | Print the resolved runtime knobs and exit |
+| ~--tpp N~ | ~0~ (occupancy picker) | Threads per particle for the device k-NN (~LINKCELL_TPP~) |
+| ~--block N~ | ~0~ (occupancy picker) | CUDA block size (~LINKCELL_BLOCK~ / ~SEAMS_BLOCK~) |
+| ~--resident FRAC~ | ~0.80~ | Fraction of free device memory for a resident batch (~SEAMS_RESIDENT~) |
+| ~--cell ANGSTROM~ | ~3~ | Link-cell hint so NPT frames share a grid (~SEAMS_CELL~) |
 
-~--help~, ~--version~, and ~--features~ print and exit 0 before any
-file is opened.
+~--help~, ~--version~, ~--features~, and ~--print-config~ print and
+exit 0 before any file is opened.
+
+~--tpp~, ~--block~, ~--resident~, and ~--cell~ apply to the device
+TUM ice score (~seams cages~) only. CHILL and \(q_{lm}\) stay on
+the host.
 
 ~--cutoff~ is in Angstrom. ~-k~ also applies to ~knn-union~ (the
 same ~k~ feeds ~nneigh::kNearestNeighbourList~). ~--graph~ is used
@@ -100,6 +110,30 @@ and is not a ~BondGraph~ enumerator. Any other name throws
 knn, knn-union)~) and ~cages~ exits 2.
 
 Candidate cutoff for the knn graphs is ~--cutoff + 1.5~.
+
+* Runtime knobs
+
+Defaults live in the binary. An optional dotenv (~SEAMS_CONFIG~ or
+~./seams.env~) fills unset keys. The process environment wins the
+file; CLI flags win the environment. ~seams --print-config~ dumps
+the table.
+
+| variable | default |
+|----------+---------|
+| ~SEAMS_FRAME~ / ~SEAMS_LAST~ | ~1~ / ~0~ |
+| ~SEAMS_JOBS~ | ~1~ |
+| ~SEAMS_TYPE~ | ~0~ |
+| ~SEAMS_CUTOFF~ | ~3.5~ |
+| ~SEAMS_K~ | ~4~ |
+| ~SEAMS_GRAPH~ | ~seeded~ |
+| ~SEAMS_RESIDENT~ | ~0.80~ |
+| ~SEAMS_CELL~ | ~3.0~ |
+| ~SEAMS_TPP~ / ~LINKCELL_TPP~ | occupancy picker (~0~) |
+| ~SEAMS_BLOCK~ / ~LINKCELL_BLOCK~ | occupancy picker (~0~) |
+| ~SEAMS_OFFLOAD~ | ~false~ |
+| ~YODA_FENNEL_PATH~ / ~YODA_LUA_PATH~ | empty |
+
+Analysis choice (which command) is not this table.
 
 * File suffix
 
@@ -138,6 +172,7 @@ line is ~NAME: enabled~ or ~NAME: disabled~.
 | ~MPI~ | ~SEAMS_HAS_MPI~ |
 | ~Highway SIMD~ | ~SEAMS_HAS_HWY~ |
 | ~vesin neighbours~ | ~SEAMS_HAS_VESIN~ |
+| ~linkcell k-nearest~ | ~SEAMS_HAS_LINKCELL~ |
 | ~chemfiles~ | ~SEAMS_HAS_CHEMFILES~ |
 | ~readcon-core~ | ~SEAMS_HAS_READCON~ |
 | ~IRA/SOFI~ | ~SEAMS_HAS_IRA~ |
@@ -177,7 +212,7 @@ Color roles on this binary:
 
 | code | when |
 |------+------|
-| ~0~ | success, including ~--help~ / ~--version~ / ~--features~ |
+| ~0~ | success, including ~--help~ / ~--version~ / ~--features~ / ~--print-config~ |
 | ~2~ | parse error, missing command or file, unknown command, unknown ~--graph~ |
 
 * Examples

--- a/docs/orgmode/reference/glossary.org
+++ b/docs/orgmode/reference/glossary.org
@@ -16,3 +16,5 @@
 | ~nop~ | Number of particles in the analysed cloud |
 | TUM | Topological unit matching |
 | ~PointCloud~ | Positions, types, box, and per-atom labels |
+| vesin | Optional cutoff cell list (~neighList~ / ~neighListO~); brute force if not built |
+| linkcell | Optional periodic k-NN (~nominateByLinkcell~); ~knn~ / ~seeded~ graphs and device TUM, not a drop-in for vesin |

--- a/docs/orgmode/tutorials/nanotube.org
+++ b/docs/orgmode/tutorials/nanotube.org
@@ -2,6 +2,8 @@
 #+OPTIONS: toc:nil num:nil
 
 The ~seams~ CLI has no prism command. Confined ice (nanotube and
-monolayer) is [[file:../howto/confined-ice.org][the confined-ice howto]].
+monolayer) is [[file:../howto/confined-ice.org][the confined-ice howto]]:
+~pydseams.Frame.find_prisms~ / ~monolayer_rings~, or the yodaStruct
+Lua examples under ~example_lua/iceNanotube/~.
 Bulk CHILL+ and cages on the in-tree dump are
 [[file:bulk-ice.org][the mixed TIP4P tutorial]].

--- a/markdown/chillPlus.md
+++ b/markdown/chillPlus.md
@@ -5,8 +5,9 @@ This repository is the C++ engine.
 
 Figshare:
 [CHILL LAMMPS Trajectory](https://figshare.com/articles/CHILL_LAMMPS_Trajectory/11448720)
-(`nucleation.lammpstrj`, 4096 molecules of ice Ic). CHILL+ labels
-every oxygen cubic on that lattice.
+(`mW_cubic.lammpstrj`, 4096 type-1 mW sites of ice Ic). CHILL+
+labels every site cubic on that lattice. `nucleation.lammpstrj` is
+a different figshare deposit.
 
 The 1.x driver (`yodaStruct -c`, `conf.yaml`, `lua_inputs/`) is gone.
 Use `seams`, `pydseams`, or `require("dseams")`.
@@ -14,18 +15,19 @@ Use `seams`, `pydseams`, or `require("dseams")`.
 ## CLI
 
 ```bash
-seams chill-plus nucleation.lammpstrj --cutoff 3.5 --type 2
+seams chill-plus mW_cubic.lammpstrj --cutoff 3.5 --type 1
 ```
 
-Counts print to stdout (cubic, hexagonal, interfacial, clathrate,
-water).
+Counts print to stdout (`cubic`, `hexagonal`, `water`,
+`interfacial`, `clathrate`, `interClathrate`, `reCubic`, `reHex`,
+`unclassified`).
 
 ## Python
 
 ```python
 import pydseams as ds
 
-frame = ds.read("nucleation.lammpstrj")
+frame = ds.read("mW_cubic.lammpstrj")
 print(frame.chill_plus())
 ```
 
@@ -33,7 +35,7 @@ print(frame.chill_plus())
 
 ```lua
 local dseams = require("dseams")
-local cloud = dseams.read("nucleation.lammpstrj", {type = 2})
+local cloud = dseams.read("mW_cubic.lammpstrj", {type = 1})
 print(dseams.chill_plus(cloud, {cutoff = 3.5}))
 ```
 

--- a/markdown/examples.md
+++ b/markdown/examples.md
@@ -1,7 +1,15 @@
-# Nucleation
+# Examples
 
-The files for this example are [here on figshare](https://figshare.com/articles/Nucleation_LAMMPS_Trajectory/11448702).
+The five 1.x figshare demonstrations live as 2.x pages next to this
+file. Use `seams`, `pydseams`, or `require("dseams")`. The 2020
+`yodaStruct -c` / `conf.yaml` driver is gone.
 
-```{.lua}
-print("Add details")
-```
+- [CHILL+ on a cubic lattice](chillPlus.md) (`mW_cubic.lammpstrj`)
+- [Bulk HC / DDC cages](bulkTopologicalCriterion.md) (nucleation dump, figshare [11448702](https://figshare.com/articles/Nucleation_LAMMPS_Trajectory/11448702))
+- [Ice nanotube](iceNanotube.md)
+- [Monolayer](monolayer.md)
+- [In-plane RDF](rdf2d.md)
+
+Books: [docs.dseams.info](https://docs.dseams.info),
+[pydseams](https://d-seams.github.io/PydSEAMSlib/),
+[dseams](https://d-seams.github.io/yodaStruct/).

--- a/markdown/monolayer.md
+++ b/markdown/monolayer.md
@@ -23,8 +23,10 @@ Pass the sheet area for the system you downloaded.
 
 ## Lua
 
-1.x scripts: `example_lua/monolayer/` in
-[yodaStruct](https://github.com/d-SEAMS/yodaStruct).
+The library call is `require("dseams")` plus
+`dseams.core.ringAnalysis`. The 1.x scripts under
+`example_lua/monolayer/` still use the 2020 globals; rewrite them.
+Do not run `yodaStruct -c`.
 
 ## References
 

--- a/markdown/rdf2d.md
+++ b/markdown/rdf2d.md
@@ -14,16 +14,18 @@ The `seams` CLI has no RDF command.
 ```python
 import pydseams as ds
 
-frame = ds.read("dump.lammpstrj")
-lines = frame.rdf_2d(output_dir="output/", cutoff=12.0, binwidth=0.05)
+frame = ds.read("dump-320.lammpstrj")
+r, g = frame.rdf_2d(output_dir="output/", cutoff=12.0, binwidth=0.05)
 ```
 
-The engine writes `topoMonolayer/rdf.dat` under `output_dir`.
+`rdf_2d` returns bin centres and `g(r)`. The engine also writes
+`topoMonolayer/rdf.dat` under `output_dir`.
 
 ## Lua
 
-1.x scripts: the RDF helper in
-[yodaStruct](https://github.com/d-SEAMS/yodaStruct) `example_lua/`.
+Compiled name: `dseams.core.calcRDF`. There is no
+`require("dseams")` RDF helper. The 1.x scripts under
+`example_lua/rdf2D-example/` still use the 2020 globals.
 
 ## References
 


### PR DESCRIPTION
The org book still stopped at 2.2.5 and treated neighbour search as
linkcell only. This catches the pages up to the 2.3.x surface.

- Changelog headings for 2.3.0 (twelve-factor + TUM device path),
  2.3.1 (vesin remaining builders), and 2.3.2 (3x3 dump box).
- Quickstart and CLI document `SEAMS_CONFIG` / `seams.env` / CLI
  flags, including `--print-config`, `--tpp`, `--block`, `--resident`,
  `--cell`. Device knobs are TUM ice score only.
- Architecture and glossary keep vesin (cutoff) and linkcell (k-NN)
  as distinct backends.
- Contributing and root `CONTRIBUTING.md` use Conventional Commits.
  The 2020 sandwich sample is gone.
- Leftover markdown uses `mW_cubic.lammpstrj --type 1` for the
  CHILL+ figshare dump. Confined ice names `Frame.monolayer_rings`.

JCIM 2020 preferred citation is unchanged.