### PR TITLE
docs: quote mermaid node labels

### DIFF
--- a/docs/orgmode/explanation/architecture.org
+++ b/docs/orgmode/explanation/architecture.org
@@ -35,10 +35,10 @@ schedules.
        PY[pydseams Frame]
        LUA["require(\"dseams\")"]
      end
-     LC[linkcell k-NN]
-     VE[vesin cutoff]
-     GPU[gpulite TUM batch]
-     DUMP[LAMMPS / XYZ / chemfiles / con] --> LIB
+     LC["linkcell k-NN"]
+     VE["vesin cutoff"]
+     GPU["gpulite TUM batch"]
+     DUMP["LAMMPS / XYZ / chemfiles / con"] --> LIB
      LC --> LIB
      VE --> LIB
      GPU --> LIB


### PR DESCRIPTION
Hyphens and slashes in unquoted flowchart labels are not reliable. Engine CI already exports org.