### PR TITLE
fix: tilt 2-D RDF uses dump-cell volume

### DIFF
--- a/docs/newsfragments/rdf2d-tilt-volume.bugfix
+++ b/docs/newsfragments/rdf2d-tilt-volume.bugfix
@@ -1,0 +1,3 @@
+In-plane RDF normalization uses the dump-cell volume |det H|
+and the restricted-triclinic in-plane area lx*ly, not the
+product of the particle AABB or of the bound spans.

--- a/src/include/internal/rdf2d.hpp
+++ b/src/include/internal/rdf2d.hpp
@@ -99,7 +99,9 @@ sampleRDF_AA(const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
                  std::vector<int> histogram, double binwidth, int nbin,
                  std::vector<double> volumeLengths, int nIter);
 
-//! Gets the lengths of the volume slice of the quasi-two-dimensional system
+//! Gets the lengths of the volume slice of the quasi-two-dimensional system.
+//! box.size()>=6 returns dump H {lx, ly, lz}; a length-3 box stays the
+//! particle AABB so slab tests keep the occupied extents.
 std::vector<double>
 getSystemLengths(const molSys::PointCloud<molSys::Point<double>, double> &yCloud);
 

--- a/src/rdf2d.cpp
+++ b/src/rdf2d.cpp
@@ -237,17 +237,22 @@ rdf2::sampleRDF_AA(const molSys::PointCloud<molSys::Point<double>, double> &yClo
 int rdf2::normalizeRDF(int nopA, std::vector<double> &rdfValues,
                        std::vector<int> histogram, double binwidth, int nbin,
                        std::vector<double> volumeLengths, int nIter) {
-  //
-  auto height = *std::min_element(
-      volumeLengths.begin(),
-      volumeLengths.end()); // The height or the smallest dimension
-  // double planeArea = rdf2::getPlaneArea(
-  //     volumeLengths);  // The area of the quasi-two-dimensional water
+  // volumeLengths is the particle AABB (box.size()==3) or dump H
+  // {lx, ly, lz} (box.size()>=6). Product of the dump lengths is
+  // nneigh::dumpVolume; Lx*Ly is the restricted-triclinic in-plane
+  // area and Lz is the confined height. A vanishing in-plane product
+  // (AABB of a line or point) keeps the smallest extent as height.
+  const double planeArea = volumeLengths[0] * volumeLengths[1];
+  const double volume =
+      volumeLengths[0] * volumeLengths[1] * volumeLengths[2];
+  const double height =
+      planeArea > 0.0
+          ? volume / planeArea
+          : *std::min_element(volumeLengths.begin(), volumeLengths.end());
   double r;         // Distance for the current bin
   double factor;    // Factor for accounting for the two-dimensional slab
   double binVolume; // Volume of the current bin
-  double volumeDensity =
-      nopA / (volumeLengths[0] * volumeLengths[1] * volumeLengths[2]);
+  double volumeDensity = nopA / volume;
 
   // Loop through every bin
   for (int ibin = 0; ibin < nbin; ibin++) {
@@ -279,14 +284,23 @@ int rdf2::normalizeRDF(int nopA, std::vector<double> &rdfValues,
 
 /**
  * @details Calculates the lengths of the quasi-two-dimensional
- *  system. The smallest length is the 'height'.
+ *  system. A tilt dump (box.size()>=6) returns dump H {lx, ly, lz}.
+ *  A length-3 box returns the particle AABB; the smallest length is
+ *  then the slab height.
  * @param[in] yCloud The molSys::PointCloud struct for the system.
- * @return The length (i.e. the 'height') of the smallest dimension of
- *  quasi-two-dimensional system.
+ * @return {lx, ly, lz} from dumpBoundsToH, or the AABB extents.
  */
 std::vector<double> rdf2::getSystemLengths(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud) {
-  //
+  // Dump tilt: lattice edges from dumpBoundsToH, not the particle
+  // AABB and not the bound-span product.
+  if (yCloud.box.size() >= 6) {
+    double H[3][3];
+    double origin[3];
+    nneigh::dumpBoundsToH(yCloud.box, yCloud.boxLow, H, origin);
+    return {H[0][0], H[1][1], H[2][2]};
+  }
+
   std::vector<double> lengths; // Volume lengths
   std::vector<double>
       rMax; // Max of the coordinates {0 is for x, 1 is for y and 2 is for z}

--- a/tests/test_rdf2d.cpp
+++ b/tests/test_rdf2d.cpp
@@ -3,6 +3,7 @@
 
 #include <generic.hpp>
 #include <mol_sys.hpp>
+#include <neighbours.hpp>
 #include <rdf2d.hpp>
 
 #include <cmath>
@@ -72,6 +73,38 @@ TEST_CASE("getSystemLengths with spread atoms", "[rdf2d]") {
   REQUIRE_THAT(lengths[0], Catch::Matchers::WithinAbs(4.0, 1e-10)); // x: 5-1
   REQUIRE_THAT(lengths[1], Catch::Matchers::WithinAbs(6.0, 1e-10)); // y: 8-2
   REQUIRE_THAT(lengths[2], Catch::Matchers::WithinAbs(6.0, 1e-10)); // z: 7-1
+}
+
+TEST_CASE("getSystemLengths hex-prism uses dump H not bound spans",
+          "[rdf2d]") {
+  molSys::PointCloud<molSys::Point<double>, double> cloud;
+  cloud.box = {15.0, 8.660254037844386, 10.0, 5.0, 0.0, 0.0};
+  cloud.boxLow = {0.0, 0.0, 0.0};
+  cloud.nop = 2;
+  const double coords[2][3] = {{0.2, 0.1, 1.0}, {9.7, 0.1, 1.0}};
+  for (int i = 0; i < 2; i++) {
+    molSys::Point<double> pt;
+    pt.type = 1;
+    pt.atomID = i + 1;
+    pt.x = coords[i][0];
+    pt.y = coords[i][1];
+    pt.z = coords[i][2];
+    cloud.pts.push_back(pt);
+    cloud.idIndexMap[i + 1] = i;
+  }
+  auto lengths = rdf2::getSystemLengths(cloud);
+  REQUIRE(lengths.size() == 3);
+  REQUIRE_THAT(lengths[0], Catch::Matchers::WithinAbs(10.0, 1e-9));
+  REQUIRE_THAT(lengths[1], Catch::Matchers::WithinAbs(8.660254037844386, 1e-9));
+  REQUIRE_THAT(lengths[2], Catch::Matchers::WithinAbs(10.0, 1e-9));
+  const double vol = lengths[0] * lengths[1] * lengths[2];
+  const double dumpVol = nneigh::dumpVolume(cloud);
+  const double planeArea = lengths[0] * lengths[1];
+  const double bound = 15.0 * 8.660254037844386 * 10.0;
+  REQUIRE_THAT(vol, Catch::Matchers::WithinAbs(dumpVol, 1e-9));
+  REQUIRE_THAT(planeArea,
+               Catch::Matchers::WithinAbs(10.0 * 8.660254037844386, 1e-9));
+  REQUIRE(vol < bound - 1.0);
 }
 
 // -- getPlaneArea tests --
@@ -169,6 +202,46 @@ TEST_CASE("normalizeRDF produces non-negative values", "[rdf2d]") {
   for (int i = 0; i < nbin; i++) {
     REQUIRE(rdfValues[i] >= 0.0);
   }
+}
+
+TEST_CASE("normalizeRDF hex-prism density is dumpVolume not span product",
+          "[rdf2d]") {
+  molSys::PointCloud<molSys::Point<double>, double> cloud;
+  cloud.box = {15.0, 8.660254037844386, 10.0, 5.0, 0.0, 0.0};
+  cloud.boxLow = {0.0, 0.0, 0.0};
+  cloud.nop = 2;
+  const double coords[2][3] = {{0.2, 0.1, 1.0}, {9.7, 0.1, 1.0}};
+  for (int i = 0; i < 2; i++) {
+    molSys::Point<double> pt;
+    pt.type = 1;
+    pt.atomID = i + 1;
+    pt.x = coords[i][0];
+    pt.y = coords[i][1];
+    pt.z = coords[i][2];
+    cloud.pts.push_back(pt);
+    cloud.idIndexMap[i + 1] = i;
+  }
+  auto lengths = rdf2::getSystemLengths(cloud);
+  const double dumpVol = nneigh::dumpVolume(cloud);
+  REQUIRE_THAT(lengths[0] * lengths[1] * lengths[2],
+               Catch::Matchers::WithinAbs(dumpVol, 1e-9));
+  REQUIRE_THAT(lengths[0] * lengths[1],
+               Catch::Matchers::WithinAbs(10.0 * 8.660254037844386, 1e-9));
+
+  const int nopA = 2;
+  const int nbin = 5;
+  const double binwidth = 1.0;
+  const int nIter = 1;
+  std::vector<int> histogram = {2, 0, 0, 0, 0};
+  std::vector<double> rdfDump(static_cast<std::size_t>(nbin), 0.0);
+  std::vector<double> rdfSpan(static_cast<std::size_t>(nbin), 0.0);
+  REQUIRE(rdf2::normalizeRDF(nopA, rdfDump, histogram, binwidth, nbin, lengths,
+                             nIter) == 0);
+  REQUIRE(rdf2::normalizeRDF(nopA, rdfSpan, histogram, binwidth, nbin,
+                             {15.0, 8.660254037844386, 10.0}, nIter) == 0);
+  REQUIRE(rdfDump[0] > 0.0);
+  REQUIRE(rdfSpan[0] > 0.0);
+  REQUIRE(rdfDump[0] < rdfSpan[0]);
 }
 
 // -- rdf2Danalysis_AA integration test --

--- a/tests/test_simd.cpp
+++ b/tests/test_simd.cpp
@@ -133,7 +133,8 @@ TEST_CASE("SIMD handles exact half-box displacements", "[simd]") {
 TEST_CASE("ortho SIMD wrap on dump bound spans misses the a-image", "[simd]") {
   // Sheared pair (0.2, 0.1, 1) and (9.7, 0.1, 1) on dump box
   // {15, 8.66, 10, xy=5}. H-image r^2 is 0.25. Independent wrap
-  // on the bound span 15 yields 5.5^2 = 30.25.
+  // on the bound span 15 yields 5.5^2 = 30.25. The kernel is
+  // ortho-only; callers must not pass dump bound spans.
   constexpr size_t n = 1;
   const double dx[n] = {0.2 - 9.7};
   const double dy[n] = {0.1 - 0.1};


### PR DESCRIPTION
# Description

Stacked on #82 (`70da736`). The 2-D RDF still normalized with the particle AABB product. On a tilt dump that is the bound-span volume, not `det H`.

`getSystemLengths` returns dump-cell `{lx, ly, lz}` when `box.size() >= 6`. Ortho slabs keep the AABB path. `BatchPeriodicDistSq` stays ortho-only.

Layer 2 of stack #87. Diff against #82: https://github.com/d-SEAMS/seams-core/compare/feat/2026-08-16-mic-leftovers...fix/2026-08-16-tilt-simd-rdf

# Changes

- `rdf2::getSystemLengths` / `normalizeRDF` on tilt
- tests: hex-prism volume is `dumpVolume`, not `15*ly*10`