### PR TITLE
feat: site::Table kinds and ionCloud COM vertices

### DIFF
--- a/docs/newsfragments/site-table.feature
+++ b/docs/newsfragments/site-table.feature
@@ -1,0 +1,3 @@
+Site chemistry is a ``site::Table`` of LAMMPS types and optional atom-ID
+overrides, not an extension of ``atom_state_type``. ``site::ionCloud``
+collapses each cation or anion ``molID`` to one unwrapped COM vertex.

--- a/src/include/internal/site.hpp
+++ b/src/include/internal/site.hpp
@@ -1,0 +1,72 @@
+//-----------------------------------------------------------------------------------
+// d-SEAMS - Deferred Structural Elucidation Analysis for Molecular Simulations
+// SPDX-License-Identifier: MIT
+//-----------------------------------------------------------------------------------
+
+#ifndef SEAMS_SITE_H_
+#define SEAMS_SITE_H_
+
+#include <mol_sys.hpp>
+
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+/** @file site.hpp
+ *  @brief Per-atom site chemistry, separate from CHILL ice labels.
+ *
+ *  LAMMPS type IDs are not chemistry. A Table maps type (and optional
+ *  atom-ID override) to Kind. Family is an input, not an inference.
+ */
+
+namespace site {
+
+enum class Kind {
+  unspecified,
+  cationHead,
+  anion,
+  tail,
+  donorH,
+  acceptor,
+  polar,
+  apolar,
+  waterO,
+  waterH,
+  solvent
+};
+
+enum class Family {
+  waterIce,
+  ionicLiquid,
+  moltenSalt,
+  des,
+  electrolyte,
+  confinedIL,
+  confinedWater,
+  networkFormer
+};
+
+struct Table {
+  Family family = Family::waterIce;
+  std::unordered_map<int, Kind> typeToKind;
+  std::unordered_map<int, Kind> atomOverride;
+
+  Kind of(const molSys::Point<double> &p) const;
+  Kind ofType(int typeId) const;
+};
+
+std::vector<int>
+indicesOf(const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+          const Table &table, Kind kind);
+
+int lammpsTypeOfKind(const Table &table, Kind kind);
+
+molSys::PointCloud<molSys::Point<double>, double>
+ionCloud(const molSys::PointCloud<molSys::Point<double>, double> &src,
+         const Table &table);
+
+Table parseSiteSpec(std::string_view spec);
+
+} // namespace site
+
+#endif // SEAMS_SITE_H_

--- a/src/meson.build
+++ b/src/meson.build
@@ -27,6 +27,7 @@ ydslib_sources = files(
   'seams_output.cpp',
   'selection.cpp',
   'shapeMatch.cpp',
+  'site.cpp',
   'steinhardt_parallel.cpp',
   'topo_bulk.cpp',
   'voronoi_qlm.cpp',

--- a/src/site.cpp
+++ b/src/site.cpp
@@ -1,0 +1,289 @@
+//-----------------------------------------------------------------------------------
+// d-SEAMS - Deferred Structural Elucidation Analysis for Molecular Simulations
+// SPDX-License-Identifier: MIT
+//-----------------------------------------------------------------------------------
+
+#include <site.hpp>
+
+#include <generic.hpp>
+#include <mol_sys.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+namespace site {
+
+namespace {
+
+using Cloud = molSys::PointCloud<molSys::Point<double>, double>;
+
+std::string trim(std::string_view s) {
+  const auto begin = s.find_first_not_of(" \t\n\r");
+  if (begin == std::string_view::npos) {
+    return {};
+  }
+  const auto end = s.find_last_not_of(" \t\n\r");
+  return std::string(s.substr(begin, end - begin + 1));
+}
+
+Kind kindFromName(std::string_view name) {
+  if (name == "unspecified") {
+    return Kind::unspecified;
+  }
+  if (name == "cationHead") {
+    return Kind::cationHead;
+  }
+  if (name == "anion") {
+    return Kind::anion;
+  }
+  if (name == "tail") {
+    return Kind::tail;
+  }
+  if (name == "donorH") {
+    return Kind::donorH;
+  }
+  if (name == "acceptor") {
+    return Kind::acceptor;
+  }
+  if (name == "polar") {
+    return Kind::polar;
+  }
+  if (name == "apolar") {
+    return Kind::apolar;
+  }
+  if (name == "waterO") {
+    return Kind::waterO;
+  }
+  if (name == "waterH") {
+    return Kind::waterH;
+  }
+  if (name == "solvent") {
+    return Kind::solvent;
+  }
+  throw std::invalid_argument("unknown site kind '" + std::string(name) + "'");
+}
+
+Family familyFromName(std::string_view name) {
+  if (name == "waterIce") {
+    return Family::waterIce;
+  }
+  if (name == "ionicLiquid") {
+    return Family::ionicLiquid;
+  }
+  if (name == "moltenSalt") {
+    return Family::moltenSalt;
+  }
+  if (name == "des") {
+    return Family::des;
+  }
+  if (name == "electrolyte") {
+    return Family::electrolyte;
+  }
+  if (name == "confinedIL") {
+    return Family::confinedIL;
+  }
+  if (name == "confinedWater") {
+    return Family::confinedWater;
+  }
+  if (name == "networkFormer") {
+    return Family::networkFormer;
+  }
+  throw std::invalid_argument("unknown site family '" + std::string(name) +
+                              "'");
+}
+
+bool isIonKind(Kind k) {
+  return k == Kind::cationHead || k == Kind::anion;
+}
+
+bool matchesKind(Kind have, Kind want) {
+  if (want == Kind::polar) {
+    return have == Kind::cationHead || have == Kind::anion ||
+           have == Kind::polar;
+  }
+  if (want == Kind::apolar) {
+    return have == Kind::tail || have == Kind::apolar;
+  }
+  return have == want;
+}
+
+int indexOfAtom(const Cloud &src, int atomID) {
+  const auto it = src.idIndexMap.find(atomID);
+  if (it != src.idIndexMap.end()) {
+    return it->second;
+  }
+  const int n = static_cast<int>(src.pts.size());
+  for (int i = 0; i < n; ++i) {
+    if (src.pts[i].atomID == atomID) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+} // namespace
+
+Kind Table::of(const molSys::Point<double> &p) const {
+  if (const auto it = atomOverride.find(p.atomID); it != atomOverride.end()) {
+    return it->second;
+  }
+  return ofType(p.type);
+}
+
+Kind Table::ofType(int typeId) const {
+  if (const auto it = typeToKind.find(typeId); it != typeToKind.end()) {
+    return it->second;
+  }
+  return Kind::unspecified;
+}
+
+std::vector<int> indicesOf(const Cloud &yCloud, const Table &table,
+                           Kind kind) {
+  std::vector<int> out;
+  const int n = static_cast<int>(yCloud.pts.size());
+  out.reserve(static_cast<size_t>(n));
+  for (int i = 0; i < n; ++i) {
+    if (matchesKind(table.of(yCloud.pts[i]), kind)) {
+      out.push_back(i);
+    }
+  }
+  return out;
+}
+
+int lammpsTypeOfKind(const Table &table, Kind kind) {
+  int found = 0;
+  int typeId = -1;
+  for (const auto &[id, mapped] : table.typeToKind) {
+    if (mapped == kind) {
+      ++found;
+      typeId = id;
+    }
+  }
+  if (found != 1) {
+    throw std::runtime_error("site kind does not map to a unique LAMMPS type");
+  }
+  return typeId;
+}
+
+Cloud ionCloud(const Cloud &src, const Table &table) {
+  Cloud out;
+  out.box = src.box;
+  out.boxLow = src.boxLow;
+  out.currentFrame = src.currentFrame;
+
+  auto &mutableSrc = const_cast<Cloud &>(src);
+  const auto molMap = molSys::createMolIDAtomIDMultiMap(mutableSrc);
+
+  std::vector<int> molOrder;
+  std::unordered_set<int> seenMol;
+  molOrder.reserve(src.pts.size());
+  for (const auto &pt : src.pts) {
+    if (seenMol.insert(pt.molID).second) {
+      molOrder.push_back(pt.molID);
+    }
+  }
+
+  for (const int molID : molOrder) {
+    std::vector<int> ions;
+    const auto range = molMap.equal_range(molID);
+    for (auto it = range.first; it != range.second; ++it) {
+      const int idx = indexOfAtom(src, it->second);
+      if (idx < 0) {
+        continue;
+      }
+      if (isIonKind(table.of(src.pts[idx]))) {
+        ions.push_back(idx);
+      }
+    }
+    if (ions.empty()) {
+      continue;
+    }
+    std::sort(ions.begin(), ions.end());
+    const Kind ionKind = table.of(src.pts[ions.front()]);
+    ions.erase(std::remove_if(ions.begin(), ions.end(),
+                              [&](int idx) {
+                                return table.of(src.pts[idx]) != ionKind;
+                              }),
+               ions.end());
+    if (ions.empty()) {
+      continue;
+    }
+
+    molSys::Point<double> vertex = src.pts[ions.front()];
+    vertex.type = (ionKind == Kind::cationHead) ? 1 : 2;
+    vertex.molID = molID;
+    if (ions.size() > 1) {
+      const int ref = ions.front();
+      double sx = src.pts[ref].x;
+      double sy = src.pts[ref].y;
+      double sz = src.pts[ref].z;
+      for (size_t k = 1; k < ions.size(); ++k) {
+        const auto dr = gen::relDist(src, ions[k], ref);
+        sx += src.pts[ref].x + dr[0];
+        sy += src.pts[ref].y + dr[1];
+        sz += src.pts[ref].z + dr[2];
+      }
+      const double inv = 1.0 / static_cast<double>(ions.size());
+      vertex.x = sx * inv;
+      vertex.y = sy * inv;
+      vertex.z = sz * inv;
+    }
+
+    const int outIdx = static_cast<int>(out.pts.size());
+    out.idIndexMap[vertex.atomID] = outIdx;
+    out.pts.push_back(std::move(vertex));
+  }
+
+  out.nop = static_cast<int>(out.pts.size());
+  return out;
+}
+
+Table parseSiteSpec(std::string_view spec) {
+  Table table;
+  size_t start = 0;
+  while (start <= spec.size()) {
+    const size_t comma = spec.find(',', start);
+    const auto raw =
+        spec.substr(start, comma == std::string_view::npos ? std::string_view::npos
+                                                           : comma - start);
+    start = (comma == std::string_view::npos) ? spec.size() + 1 : comma + 1;
+    const std::string token = trim(raw);
+    if (token.empty()) {
+      continue;
+    }
+    const auto eq = token.find('=');
+    if (eq == std::string::npos) {
+      throw std::invalid_argument("site spec token '" + token +
+                                  "' is not key=value");
+    }
+    const std::string key = trim(token.substr(0, eq));
+    const std::string val = trim(token.substr(eq + 1));
+    if (key.empty() || val.empty()) {
+      throw std::invalid_argument("site spec token '" + token +
+                                  "' is not key=value");
+    }
+    if (key == "family") {
+      table.family = familyFromName(val);
+      continue;
+    }
+    size_t consumed = 0;
+    int typeId = 0;
+    try {
+      typeId = std::stoi(key, &consumed);
+    } catch (const std::exception &) {
+      throw std::invalid_argument("site spec type '" + key +
+                                  "' is not an integer");
+    }
+    if (consumed != key.size()) {
+      throw std::invalid_argument("site spec type '" + key +
+                                  "' is not an integer");
+    }
+    table.typeToKind[typeId] = kindFromName(val);
+  }
+  return table;
+}
+
+} // namespace site

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -32,6 +32,7 @@ test_sources = {
   'cage_affiliation': 'test_cage_affiliation.cpp',
   'gpu_residency': 'test_gpu_residency.cpp',
   'config': 'test_config.cpp',
+  'site': 'test_site.cpp',
 }
 
 if readcon_dep.found()

--- a/tests/test_site.cpp
+++ b/tests/test_site.cpp
@@ -1,0 +1,191 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <generic.hpp>
+#include <mol_sys.hpp>
+#include <site.hpp>
+
+#include <stdexcept>
+
+namespace {
+
+using Cloud = molSys::PointCloud<molSys::Point<double>, double>;
+
+Cloud makeCloud() {
+  Cloud cloud;
+  cloud.box = {10.0, 10.0, 10.0};
+  cloud.boxLow = {0.0, 0.0, 0.0};
+  cloud.currentFrame = 1;
+  return cloud;
+}
+
+void addAtom(Cloud &cloud, int atomID, int molID, int type, double x, double y,
+             double z) {
+  molSys::Point<double> pt;
+  pt.atomID = atomID;
+  pt.molID = molID;
+  pt.type = type;
+  pt.x = x;
+  pt.y = y;
+  pt.z = z;
+  cloud.idIndexMap[atomID] = static_cast<int>(cloud.pts.size());
+  cloud.pts.push_back(pt);
+  cloud.nop = static_cast<int>(cloud.pts.size());
+}
+
+} // namespace
+
+TEST_CASE("type map and atom-ID override", "[site]") {
+  site::Table table;
+  table.typeToKind[1] = site::Kind::cationHead;
+  table.typeToKind[2] = site::Kind::anion;
+  table.atomOverride[17] = site::Kind::tail;
+
+  molSys::Point<double> head;
+  head.type = 1;
+  head.atomID = 3;
+  REQUIRE(table.of(head) == site::Kind::cationHead);
+  REQUIRE(table.ofType(1) == site::Kind::cationHead);
+
+  molSys::Point<double> overridden;
+  overridden.type = 1;
+  overridden.atomID = 17;
+  REQUIRE(table.of(overridden) == site::Kind::tail);
+  REQUIRE(table.ofType(1) == site::Kind::cationHead);
+
+  molSys::Point<double> unknown;
+  unknown.type = 9;
+  unknown.atomID = 99;
+  REQUIRE(table.of(unknown) == site::Kind::unspecified);
+  REQUIRE(table.ofType(9) == site::Kind::unspecified);
+}
+
+TEST_CASE("type 1 is not chemistry", "[site]") {
+  site::Table table;
+  REQUIRE(table.family == site::Family::waterIce);
+  REQUIRE(table.ofType(1) == site::Kind::unspecified);
+
+  molSys::Point<double> pt;
+  pt.type = 1;
+  pt.atomID = 1;
+  REQUIRE(table.of(pt) == site::Kind::unspecified);
+
+  table.family = site::Family::ionicLiquid;
+  REQUIRE(table.of(pt) == site::Kind::unspecified);
+
+  table.typeToKind[1] = site::Kind::waterO;
+  REQUIRE(table.of(pt) == site::Kind::waterO);
+
+  table.typeToKind[1] = site::Kind::cationHead;
+  REQUIRE(table.of(pt) == site::Kind::cationHead);
+}
+
+TEST_CASE("indicesOf polar is non-empty on a three-tag table", "[site]") {
+  site::Table table;
+  table.typeToKind[1] = site::Kind::cationHead;
+  table.typeToKind[2] = site::Kind::anion;
+  table.typeToKind[3] = site::Kind::tail;
+
+  auto cloud = makeCloud();
+  addAtom(cloud, 1, 1, 1, 1.0, 0.0, 0.0);
+  addAtom(cloud, 2, 2, 2, 2.0, 0.0, 0.0);
+  addAtom(cloud, 3, 1, 3, 3.0, 0.0, 0.0);
+  addAtom(cloud, 4, 1, 3, 4.0, 0.0, 0.0);
+
+  const auto polar = site::indicesOf(cloud, table, site::Kind::polar);
+  REQUIRE(polar.size() == 2);
+  REQUIRE(polar[0] == 0);
+  REQUIRE(polar[1] == 1);
+
+  const auto apolar = site::indicesOf(cloud, table, site::Kind::apolar);
+  REQUIRE(apolar.size() == 2);
+  REQUIRE(apolar[0] == 2);
+  REQUIRE(apolar[1] == 3);
+
+  REQUIRE(site::indicesOf(cloud, table, site::Kind::cationHead).size() == 1);
+  REQUIRE(site::indicesOf(cloud, table, site::Kind::tail).size() == 2);
+}
+
+TEST_CASE("ionCloud COM matches hand-unwrapped two-atom molecule", "[site]") {
+  site::Table table;
+  table.typeToKind[1] = site::Kind::cationHead;
+  table.typeToKind[2] = site::Kind::anion;
+  table.typeToKind[3] = site::Kind::tail;
+  table.typeToKind[4] = site::Kind::donorH;
+
+  auto cloud = makeCloud();
+  // Cation: two head atoms split across the periodic seam, plus a tail
+  // and a donorH that must not enter the COM.
+  addAtom(cloud, 10, 7, 1, 0.5, 1.0, 2.0);
+  addAtom(cloud, 11, 7, 1, 9.5, 1.0, 2.0);
+  addAtom(cloud, 12, 7, 3, 3.0, 4.0, 5.0);
+  addAtom(cloud, 13, 7, 4, 0.6, 1.1, 2.1);
+  // Monatomic anion.
+  addAtom(cloud, 20, 8, 2, 4.0, 5.0, 6.0);
+
+  const auto ions = site::ionCloud(cloud, table);
+  REQUIRE(ions.nop == 2);
+  REQUIRE(ions.box == cloud.box);
+  REQUIRE(ions.boxLow == cloud.boxLow);
+  REQUIRE(ions.currentFrame == cloud.currentFrame);
+
+  REQUIRE(ions.pts[0].type == 1);
+  REQUIRE(ions.pts[0].molID == 7);
+  // First atom at 0.5; second unwraps across L=10 to -0.5; COM x = 0.
+  REQUIRE_THAT(ions.pts[0].x, Catch::Matchers::WithinAbs(0.0, 1e-12));
+  REQUIRE_THAT(ions.pts[0].y, Catch::Matchers::WithinAbs(1.0, 1e-12));
+  REQUIRE_THAT(ions.pts[0].z, Catch::Matchers::WithinAbs(2.0, 1e-12));
+
+  const auto dr = gen::relDist(cloud, 1, 0);
+  const double handX = 0.5 * (cloud.pts[0].x + cloud.pts[0].x + dr[0]);
+  const double handY = 0.5 * (cloud.pts[0].y + cloud.pts[0].y + dr[1]);
+  const double handZ = 0.5 * (cloud.pts[0].z + cloud.pts[0].z + dr[2]);
+  REQUIRE_THAT(ions.pts[0].x, Catch::Matchers::WithinAbs(handX, 1e-12));
+  REQUIRE_THAT(ions.pts[0].y, Catch::Matchers::WithinAbs(handY, 1e-12));
+  REQUIRE_THAT(ions.pts[0].z, Catch::Matchers::WithinAbs(handZ, 1e-12));
+}
+
+TEST_CASE("ionCloud monatomic anion is a copy", "[site]") {
+  site::Table table;
+  table.typeToKind[2] = site::Kind::anion;
+
+  auto cloud = makeCloud();
+  addAtom(cloud, 20, 8, 2, 4.0, 5.0, 6.0);
+  cloud.pts[0].inSlice = false;
+
+  const auto ions = site::ionCloud(cloud, table);
+  REQUIRE(ions.nop == 1);
+  REQUIRE(ions.pts[0].type == 2);
+  REQUIRE(ions.pts[0].atomID == 20);
+  REQUIRE(ions.pts[0].molID == 8);
+  REQUIRE_THAT(ions.pts[0].x, Catch::Matchers::WithinAbs(4.0, 1e-12));
+  REQUIRE_THAT(ions.pts[0].y, Catch::Matchers::WithinAbs(5.0, 1e-12));
+  REQUIRE_THAT(ions.pts[0].z, Catch::Matchers::WithinAbs(6.0, 1e-12));
+  REQUIRE(ions.pts[0].inSlice == false);
+  REQUIRE(ions.pts[0].iceType == cloud.pts[0].iceType);
+}
+
+TEST_CASE("parseSiteSpec reads type=kind and optional family", "[site]") {
+  const auto table =
+      site::parseSiteSpec("1=cationHead, 2=anion, 3=tail, family=ionicLiquid");
+  REQUIRE(table.family == site::Family::ionicLiquid);
+  REQUIRE(table.ofType(1) == site::Kind::cationHead);
+  REQUIRE(table.ofType(2) == site::Kind::anion);
+  REQUIRE(table.ofType(3) == site::Kind::tail);
+  REQUIRE(table.ofType(4) == site::Kind::unspecified);
+  REQUIRE(site::lammpsTypeOfKind(table, site::Kind::anion) == 2);
+}
+
+TEST_CASE("parseSiteSpec rejects unknown kind names", "[site]") {
+  REQUIRE_THROWS_AS(site::parseSiteSpec("1=oxygen"), std::invalid_argument);
+}
+
+TEST_CASE("lammpsTypeOfKind errors when the kind is not unique", "[site]") {
+  site::Table table;
+  table.typeToKind[1] = site::Kind::cationHead;
+  table.typeToKind[3] = site::Kind::cationHead;
+  REQUIRE_THROWS_AS(site::lammpsTypeOfKind(table, site::Kind::cationHead),
+                    std::runtime_error);
+  REQUIRE_THROWS_AS(site::lammpsTypeOfKind(table, site::Kind::anion),
+                    std::runtime_error);
+}


### PR DESCRIPTION
# Description

Stacked on #83 (`b9d893c`). Site chemistry is not `atom_state_type`. `site::Table` maps LAMMPS types (and optional atom-ID overrides) onto kinds. `ionCloud` is one COM vertex per ion `molID`, unwrapped with `relDist`. Type 1 is not a chemistry.

Layer 3 of stack #87. Diff against #83: https://github.com/d-SEAMS/seams-core/compare/fix/2026-08-16-tilt-simd-rdf...feat/2026-08-16-site-table

# Changes

- `site.hpp` / `site.cpp`
- `ionCloud` COM (cation type 1, anion type 2)
- Catch2: override, polar union, hand-unwrapped COM, monatomic anion
- `parseSiteSpec`