### PR TITLE
feat: site-site CN and seams cn

### DIFF
--- a/docs/newsfragments/site-site-cn.feature
+++ b/docs/newsfragments/site-site-cn.feature
@@ -1,0 +1,1 @@
+Partial 3D site-site g_IJ(r) and coordination numbers, with `seams rdf` and `seams cn`.

--- a/docs/orgmode/reference/api.org
+++ b/docs/orgmode/reference/api.org
@@ -67,7 +67,7 @@ Every file under =src/include/internal=.
 | =shapeMatch.hpp= | ~match~ | prism shape-matching |
 | =cluster.hpp= | ~clump~ | Stillinger ice clusters |
 | =order_parameter.hpp= | ~topoparam~ | height% and coverage area |
-| =rdf.hpp= | ~rdf~ | partial 3D ~g_IJ(r)~ |
+| =rdf.hpp= | ~rdf~ | partial 3D ~g_IJ(r)~ and site-site CN |
 | =rdf2d.hpp= | ~rdf2~ | in-plane radial distribution |
 | =selection.hpp= | ~gen~, ~ring~ | type and slice selections |
 | =generic.hpp= | ~gen~ | periodic distance, angles, medians |

--- a/docs/orgmode/reference/cli.org
+++ b/docs/orgmode/reference/cli.org
@@ -14,6 +14,7 @@ seams chill FILE
 seams chill-plus FILE
 seams cages FILE
 seams rdf FILE
+seams cn FILE
 #+end_src
 
 A positional ~command~ and a positional ~file~ are required. Missing
@@ -22,7 +23,7 @@ either, an unknown command, or a parse error exits 2.
 * Commands
 
 The ~command~ positional help string is ~read | chill | chill-plus |
-cages | rdf~. ~chill_plus~ is an accepted alias of ~chill-plus~
+cages | rdf | cn~. ~chill_plus~ is an accepted alias of ~chill-plus~
 (not listed in that help string).
 
 | command | action | stdout |
@@ -31,7 +32,8 @@ cages | rdf~. ~chill_plus~ is an accepted alias of ~chill-plus~
 | ~chill~ | CHILL four-neighbour labels | ~nop N~ then ~name count~ for each ice type present |
 | ~chill-plus~ | CHILL+ four-neighbour labels | same as ~chill~ |
 | ~cages~ | ice score on six-membered rings | ~nop N graph KIND hexagonal IH cubic IC water W~ |
-| ~rdf~ | partial \(g_{IJ}(r)\) | ~# r g count~ then ~# types I J rmax R bins N volume V~ then one ~r g count~ row per bin |
+| ~rdf~ | partial site-site \(g_{IJ}(r)\) | ~# r g count~ then ~# types I J rmax R bins N volume V~ then one ~r g count~ row per bin |
+| ~cn~ | site-site coordination number | ~# site-site~ then ~# types I J cutoff R cn X nI N nJ M volume V~ |
 
 ~chill~ / ~chill-plus~ call ~nneigh::neighListO~, then
 ~chill::getCorrel~ / ~chill::getIceTypeNoPrint~ or
@@ -44,14 +46,17 @@ are the ~molSys::atom_state_type~ enumerators: ~cubic~, ~hexagonal~,
 (Ih), cubic = DDC (Ic), water = neither. The bond graph is
 ~--graph~.
 
-~rdf~ calls ~rdf::partialRdf~ on types from ~--types I,J~ (default
-~I = J = --type~). ~--cutoff~ is rmax. ~--bins~ is optional. The
-volume is ~nneigh::dumpVolume~ (det of dump ~H~), including shear.
-This is not an ice score.
+~rdf~ and ~cn~ call ~rdf::partialRdf~ on LAMMPS type IDs from
+~--types I,J~ (default ~I = J = --type~). ~--cutoff~ is rmax. ~--bins~
+is optional. The volume is ~nneigh::dumpVolume~ (det of dump ~H~).
+~cn~ integrates the site-site RDF to that cutoff
+(~rdf::coordinationNumber~). Help text and the ~cn~ header say
+~site-site~. There is no cage CN and no ~--ions~.
 
 An empty cloud (~nop 0~) still prints. ~chill~ / ~chill-plus~ print
 ~nop 0~. ~cages~ prints ~nop 0 graph KIND hexagonal 0 cubic 0
 water 0~. ~rdf~ prints the comment header and zero-count bins.
+~cn~ prints ~# site-site~ and ~cn 0~.
 
 * Options
 
@@ -68,8 +73,8 @@ initializers (Argum does not write defaults into the help).
 | ~--last N~ | omitted (~0~) | ~Last frame (inclusive). Omit for a single --frame~ |
 | ~-j~, ~--jobs N~ | ~1~ | ~Parallel frame workers (OpenMP). 1 is serial~ |
 | ~-t~, ~--type I~ | ~0~ | ~Atom type (0 guesses oxygen then type 1)~ |
-| ~--types I,J~ | ~I = J = --type~ | ~Pair types for rdf (default I=J=--type)~ |
-| ~-c~, ~--cutoff ANGSTROM~ | ~3.5~ | ~Neighbour cutoff (rdf rmax)~ |
+| ~--types I,J~ | ~I = J = --type~ | ~Pair types for site-site rdf/cn (default I=J=--type)~ |
+| ~-c~, ~--cutoff ANGSTROM~ | ~3.5~ | ~Neighbour cutoff (rdf/cn rmax)~ |
 | ~--bins N~ | ~rmax / 0.1~ | ~RDF histogram bins (default rmax/0.1)~ |
 | ~-k N~ | ~4~ | ~k for knn / seeded cages~ |
 | ~--graph KIND~ | ~seeded~ | ~Bond graph for cages: cutoff \| knn \| knn-union \| seeded~ |
@@ -101,14 +106,12 @@ only by ~cages~.
 XYZ always stores type 1. Classification still uses ~--type~ after
 the read (type 0 then becomes 1).
 
-A mixed-type dump that is not the water guess needs ~--type I~.
-See [[file:../howto/ionic-liquid.org][Ionic-liquid dumps]].
-
 * ~--types~
 
-Used by ~rdf~. The Argum form is ~I,J~ (one comma). A bad string
-exits 2 (~bad --types (want I,J)~). Omit the flag to set both
-sides to ~--type~.
+Used by ~rdf~ and ~cn~. The Argum form is ~I,J~ (one comma). A bad
+string exits 2 (~bad --types (want I,J)~). Omit the flag to set both
+sides to ~--type~. These are LAMMPS type IDs on the original cloud
+(site-site). There is no ~--ions~.
 
 | ~--types~ | single-frame load | ~--last~ range |
 |-----------+-------------------+----------------|
@@ -116,17 +119,8 @@ sides to ~--type~.
 | ~I,I~ (like) | keep type ~I~ | keep type ~I~ |
 | ~I,J~ with ~I != J~ | every atom (~readLammpsTrj~ / chemfiles unfiltered) | every atom (~typeFilter 0~) |
 
-~cmdRdf~ then histograms ~rdf::partialRdf~ on those two integers.
+~cmdRdf~ / ~cmdCn~ then call ~rdf::partialRdf~ on those two integers.
 ~typeOf~ still resolves a zero to the first atom (or 1).
-
-* ~seams read~ and the box
-
-~seams read~ prints ~gen::formatDumpBox~: the three bound spans,
-then ~xy xz yz~ when ~box.size() >= 6~. There is no separate tilt
-flag. ~seams rdf~ uses the same dump H (~gen::periodicDist~ and
-~nneigh::dumpVolume~). The in-plane sampler remains
-~rdf2::sampleRDF_AA~; see
-[[file:../howto/sheared-cells.org][Sheared cells]].
 
 * ~--graph~
 
@@ -261,8 +255,8 @@ seams cages dump.lammpstrj --graph cutoff
 seams cages dump.lammpstrj --graph knn
 seams cages dump.lammpstrj --graph knn-union
 seams chill-plus dump.lammpstrj --frame 1 --last 50 --jobs 8
-seams rdf dump.lammpstrj --type 1 --cutoff 10
 seams rdf dump.lammpstrj --types 1,2 --cutoff 10 --bins 100
+seams cn dump.lammpstrj --types 1,2 --cutoff 4.5
 #+end_src
 
 Lua and Python are not this binary. See

--- a/src/include/internal/rdf.hpp
+++ b/src/include/internal/rdf.hpp
@@ -55,6 +55,15 @@ PartialRdf partialRdf(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int typeI,
     int typeJ, double rmax, int nbins);
 
+//! Running site-site CN: 4 pi rho_J integral_0^{r} s^2 g_IJ(s) ds per bin.
+std::vector<double> runningCN(const PartialRdf &h, double rhoJ);
+
+//! First minimum of g after the first maximum. Returns the bin index, or -1.
+int firstMinimumBin(const PartialRdf &h);
+
+//! Site-site CN integrated to rMax. rhoJ is the number density of type J.
+double coordinationNumber(const PartialRdf &h, double rMax, double rhoJ);
+
 } // namespace rdf
 
 #endif // SEAMS_RDF_H_

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -237,14 +237,6 @@ nneigh::neighList(double rcutoff,
   return neighListPair(rcutoff, yCloud, typeI, typeJ);
 }
 
-std::vector<std::vector<int>>
-nneigh::neighListPair(
-    double rcutoff,
-    const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int typeI,
-    int typeJ) {
-  return neighList(rcutoff, yCloud, typeI, typeJ);
-}
-
 /**
  * @details Function for building neighbour lists for each
  *  particle of only one type. Inefficient brute-force \f$ O(n^2) \f$

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -237,6 +237,14 @@ nneigh::neighList(double rcutoff,
   return neighListPair(rcutoff, yCloud, typeI, typeJ);
 }
 
+std::vector<std::vector<int>>
+nneigh::neighListPair(
+    double rcutoff,
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int typeI,
+    int typeJ) {
+  return neighList(rcutoff, yCloud, typeI, typeJ);
+}
+
 /**
  * @details Function for building neighbour lists for each
  *  particle of only one type. Inefficient brute-force \f$ O(n^2) \f$

--- a/src/rdf.cpp
+++ b/src/rdf.cpp
@@ -127,3 +127,77 @@ rdf::PartialRdf rdf::partialRdf(
   }
   return out;
 }
+
+/**
+ * @details Discrete running integral 4 pi rho_J int_0^r s^2 g(s) ds.
+ *  Each bin contributes a spherical shell of width binwidth. The
+ *  value at bin i is the CN at the outer edge of that bin.
+ */
+std::vector<double> rdf::runningCN(const PartialRdf &h, double rhoJ) {
+  std::vector<double> cn(h.g.size(), 0.0);
+  if (h.binwidth <= 0.0 || rhoJ == 0.0) {
+    return cn;
+  }
+  double acc = 0.0;
+  for (std::size_t i = 0; i < h.g.size(); ++i) {
+    const double r0 = h.binwidth * static_cast<double>(i);
+    const double r1 = h.binwidth * static_cast<double>(i + 1);
+    acc += 4.0 * gen::pi * rhoJ * h.g[i] * (r1 * r1 * r1 - r0 * r0 * r0) /
+           3.0;
+    cn[i] = acc;
+  }
+  return cn;
+}
+
+/**
+ * @details First local maximum of g, then the first local minimum after
+ *  that peak. A confirmed minimum needs a descent and a later rise.
+ *  Monotonic or empty histograms return -1.
+ */
+int rdf::firstMinimumBin(const PartialRdf &h) {
+  const int n = static_cast<int>(h.g.size());
+  if (n < 3) {
+    return -1;
+  }
+  int i = 0;
+  while (i + 1 < n && h.g[static_cast<std::size_t>(i + 1)] >=
+                           h.g[static_cast<std::size_t>(i)]) {
+    ++i;
+  }
+  const int imax = i;
+  if (imax >= n - 1) {
+    return -1;
+  }
+  i = imax;
+  while (i + 1 < n && h.g[static_cast<std::size_t>(i + 1)] <=
+                           h.g[static_cast<std::size_t>(i)]) {
+    ++i;
+  }
+  if (i == imax || i + 1 >= n) {
+    return -1;
+  }
+  return i;
+}
+
+/**
+ * @details Site-site CN up to rMax. Partial last bins are cut at rMax.
+ */
+double rdf::coordinationNumber(const PartialRdf &h, double rMax,
+                               double rhoJ) {
+  if (rMax <= 0.0 || h.binwidth <= 0.0 || rhoJ == 0.0 || h.g.empty()) {
+    return 0.0;
+  }
+  double cn = 0.0;
+  for (std::size_t i = 0; i < h.g.size(); ++i) {
+    const double r0 = h.binwidth * static_cast<double>(i);
+    if (r0 >= rMax) {
+      break;
+    }
+    double r1 = h.binwidth * static_cast<double>(i + 1);
+    if (r1 > rMax) {
+      r1 = rMax;
+    }
+    cn += 4.0 * gen::pi * rhoJ * h.g[i] * (r1 * r1 * r1 - r0 * r0 * r0) / 3.0;
+  }
+  return cn;
+}

--- a/src/seams_cli.cpp
+++ b/src/seams_cli.cpp
@@ -130,6 +130,37 @@ int typeOf(const Cloud &cloud, int requested) {
   return cloud.pts[0].type;
 }
 
+std::string_view trimView(std::string_view s) {
+  const auto first = s.find_first_not_of(" \t");
+  if (first == std::string_view::npos) {
+    return {};
+  }
+  const auto last = s.find_last_not_of(" \t");
+  return s.substr(first, last - first + 1);
+}
+
+bool parseTypePair(std::string_view value, int &typeI, int &typeJ) {
+  const auto comma = value.find(',');
+  if (comma == std::string_view::npos) {
+    return false;
+  }
+  if (value.find(',', comma + 1) != std::string_view::npos) {
+    return false;
+  }
+  const auto left = trimView(value.substr(0, comma));
+  const auto right = trimView(value.substr(comma + 1));
+  if (left.empty() || right.empty()) {
+    return false;
+  }
+  try {
+    typeI = parseIntegral<int>(left);
+    typeJ = parseIntegral<int>(right);
+  } catch (const ParsingException &) {
+    return false;
+  }
+  return true;
+}
+
 std::string iceColor(std::string_view name) {
   if (name == "cubic" || name == "reCubic") {
     return colorizer.longOption(name);
@@ -244,6 +275,24 @@ int cmdRdf(std::ostream &os, Cloud &cloud, double rmax, int bins, int typeI,
   for (std::size_t i = 0; i < gr.r.size(); ++i) {
     os << gr.r[i] << " " << gr.g[i] << " " << gr.count[i] << "\n";
   }
+  return 0;
+}
+
+int cmdCn(std::ostream &os, Cloud &cloud, double rmax, int bins, int typeI,
+          int typeJ) {
+  if (bins <= 0) {
+    bins = std::max(1, static_cast<int>(std::lround(rmax / 0.1)));
+  }
+  const int typI = typeOf(cloud, typeI);
+  const int typJ = typeJ > 0 ? typeJ : typI;
+  const auto gr = rdf::partialRdf(cloud, typI, typJ, rmax, bins);
+  const double rhoJ =
+      (gr.volume > 0.0) ? static_cast<double>(gr.nJ) / gr.volume : 0.0;
+  const double cn = rdf::coordinationNumber(gr, rmax, rhoJ);
+  os << "# site-site\n";
+  os << "# types " << typI << " " << typJ << " cutoff " << rmax << " cn "
+     << cn << " nI " << gr.nI << " nJ " << gr.nJ << " volume " << gr.volume
+     << "\n";
   return 0;
 }
 
@@ -439,14 +488,14 @@ int main(int argc, char *argv[]) {
 
   parser.add(Option("--cutoff", "-c")
                  .argName("ANGSTROM")
-                 .help("Neighbour cutoff (rdf rmax)")
+                 .help("Neighbour cutoff (rdf/cn rmax)")
                  .handler([&](std::string_view value) {
                    cutoff = parseFloatingPoint<double>(value);
                  }));
 
   parser.add(Option("--types")
                  .argName("I,J")
-                 .help("Pair types for rdf (default I=J=--type)")
+                 .help("Pair types for site-site rdf/cn (default I=J=--type)")
                  .handler([&](std::string_view value) {
                    typesFlag = std::string(value);
                  }));
@@ -512,7 +561,7 @@ int main(int argc, char *argv[]) {
                  }));
 
   parser.add(Positional("command")
-                 .help("read | chill | chill-plus | cages | rdf")
+                 .help("read | chill | chill-plus | cages | rdf | cn")
                  .occurs(zeroOrOneTime)
                  .handler([&](std::string_view value) { cmd = value; }));
 
@@ -591,12 +640,16 @@ int main(int argc, char *argv[]) {
     if (cmd == "rdf") {
       return cmdRdf(os, cloud, cutoff, bins, rdfTypeI, rdfTypeJ);
     }
+    if (cmd == "cn") {
+      return cmdCn(os, cloud, cutoff, bins, rdfTypeI, rdfTypeJ);
+    }
     os << colorizer.error("unknown command: ") << cmd << "\n";
     return 2;
   };
 
+  const bool pairCmd = (cmd == "rdf" || cmd == "cn");
   const int loadType =
-      (cmd == "rdf" && (typesSet ? rdfTypeI != rdfTypeJ : false)) ? -1 : typeI;
+      (pairCmd && (typesSet ? rdfTypeI != rdfTypeJ : false)) ? -1 : typeI;
 
   if (last <= 0 || last == frame) {
     Cloud cloud = load(file, frame, loadType);
@@ -605,7 +658,7 @@ int main(int argc, char *argv[]) {
 
   std::mutex outMu;
   int rc = 0;
-  const int typeFilter = (cmd == "rdf" && typesSet && rdfTypeI != rdfTypeJ)
+  const int typeFilter = (pairCmd && typesSet && rdfTypeI != rdfTypeJ)
                              ? 0
                              : (typeI > 0 ? typeI : 0);
   sinp::forEachLammpsFrame(

--- a/src/seams_cli.cpp
+++ b/src/seams_cli.cpp
@@ -130,37 +130,6 @@ int typeOf(const Cloud &cloud, int requested) {
   return cloud.pts[0].type;
 }
 
-std::string_view trimView(std::string_view s) {
-  const auto first = s.find_first_not_of(" \t");
-  if (first == std::string_view::npos) {
-    return {};
-  }
-  const auto last = s.find_last_not_of(" \t");
-  return s.substr(first, last - first + 1);
-}
-
-bool parseTypePair(std::string_view value, int &typeI, int &typeJ) {
-  const auto comma = value.find(',');
-  if (comma == std::string_view::npos) {
-    return false;
-  }
-  if (value.find(',', comma + 1) != std::string_view::npos) {
-    return false;
-  }
-  const auto left = trimView(value.substr(0, comma));
-  const auto right = trimView(value.substr(comma + 1));
-  if (left.empty() || right.empty()) {
-    return false;
-  }
-  try {
-    typeI = parseIntegral<int>(left);
-    typeJ = parseIntegral<int>(right);
-  } catch (const ParsingException &) {
-    return false;
-  }
-  return true;
-}
-
 std::string iceColor(std::string_view name) {
   if (name == "cubic" || name == "reCubic") {
     return colorizer.longOption(name);

--- a/tests/test_rdf.cpp
+++ b/tests/test_rdf.cpp
@@ -6,6 +6,7 @@
 #include <neighbours.hpp>
 #include <rdf.hpp>
 
+#include <array>
 #include <vector>
 
 namespace {
@@ -31,6 +32,46 @@ twoTypeCloud(const std::vector<double> &box,
     cloud.idIndexMap[i + 1] = i;
   }
   return cloud;
+}
+
+molSys::PointCloud<molSys::Point<double>, double>
+typedCloud(const std::vector<double> &box,
+           const std::vector<int> &types,
+           const std::vector<std::array<double, 3>> &coords) {
+  molSys::PointCloud<molSys::Point<double>, double> cloud;
+  cloud.box = box;
+  cloud.boxLow = {0.0, 0.0, 0.0};
+  cloud.nop = static_cast<int>(coords.size());
+  cloud.currentFrame = 1;
+  for (int i = 0; i < cloud.nop; ++i) {
+    molSys::Point<double> pt;
+    pt.type = types[static_cast<std::size_t>(i)];
+    pt.atomID = i + 1;
+    pt.molID = i + 1;
+    pt.x = coords[static_cast<std::size_t>(i)][0];
+    pt.y = coords[static_cast<std::size_t>(i)][1];
+    pt.z = coords[static_cast<std::size_t>(i)][2];
+    cloud.pts.push_back(pt);
+    cloud.idIndexMap[i + 1] = i;
+  }
+  return cloud;
+}
+
+double meanTypeIDegree(const std::vector<std::vector<int>> &nList,
+                       const molSys::PointCloud<molSys::Point<double>, double> &cloud,
+                       int typeI) {
+  int nI = 0;
+  int deg = 0;
+  for (int i = 0; i < cloud.nop; ++i) {
+    if (cloud.pts[static_cast<std::size_t>(i)].type != typeI) {
+      continue;
+    }
+    ++nI;
+    if (i < static_cast<int>(nList.size()) && nList[static_cast<std::size_t>(i)].size() > 1) {
+      deg += static_cast<int>(nList[static_cast<std::size_t>(i)].size()) - 1;
+    }
+  }
+  return nI > 0 ? static_cast<double>(deg) / static_cast<double>(nI) : 0.0;
 }
 
 } // namespace
@@ -72,4 +113,40 @@ TEST_CASE("partial RDF like-type does not count the unlike neighbour",
   REQUIRE(total == 0);
   const auto unlike = rdf::partialRdf(cloud, 1, 2, 6.0, 6);
   REQUIRE(unlike.count[5] == 1);
+}
+
+TEST_CASE("neighList degree matches site-site CN past every pair and before none",
+          "[rdf]") {
+  auto cloud = typedCloud(
+      {20.0, 20.0, 20.0}, {1, 1, 2, 2},
+      {{{0.0, 0.0, 0.0}, {10.0, 10.0, 10.0}, {2.0, 0.0, 0.0}, {10.0, 12.0, 10.0}}});
+  const auto gr = rdf::partialRdf(cloud, 1, 2, 10.0, 10);
+  const double rhoJ = static_cast<double>(gr.nJ) / gr.volume;
+
+  const auto past = nneigh::neighList(3.0, cloud, 1, 2);
+  const double degPast = meanTypeIDegree(past, cloud, 1);
+  REQUIRE_THAT(degPast, Catch::Matchers::WithinAbs(1.0, 1e-12));
+  REQUIRE_THAT(rdf::coordinationNumber(gr, 3.0, rhoJ),
+               Catch::Matchers::WithinAbs(degPast, 1e-9));
+
+  const auto none = nneigh::neighList(1.0, cloud, 1, 2);
+  const double degNone = meanTypeIDegree(none, cloud, 1);
+  REQUIRE_THAT(degNone, Catch::Matchers::WithinAbs(0.0, 1e-12));
+  REQUIRE_THAT(rdf::coordinationNumber(gr, 1.0, rhoJ),
+               Catch::Matchers::WithinAbs(degNone, 1e-9));
+}
+
+TEST_CASE("firstMinimumBin finds the valley after the first of two peaks",
+          "[rdf]") {
+  rdf::PartialRdf h;
+  h.binwidth = 0.5;
+  h.g = {0.1, 0.4, 2.0, 1.1, 0.3, 0.5, 1.6, 0.8};
+  REQUIRE(rdf::firstMinimumBin(h) == 4);
+
+  rdf::PartialRdf empty;
+  REQUIRE(rdf::firstMinimumBin(empty) == -1);
+
+  rdf::PartialRdf rising;
+  rising.g = {0.1, 0.2, 0.4, 0.8, 1.2};
+  REQUIRE(rdf::firstMinimumBin(rising) == -1);
 }


### PR DESCRIPTION
# Description

Stacked on #84 (`1943959`). `rdf::partialRdf` already bins I-J under dump H. This adds the running integral, the first minimum after the first peak, and `seams cn`. Help and the `cn` header say `site-site`. There is no cage CN and no `--ions`.

Layer 4 of stack #87. Diff against #84: https://github.com/d-SEAMS/seams-core/compare/feat/2026-08-16-site-table...feat/2026-08-16-rdf-cn

# Changes

- `rdf::runningCN` / `firstMinimumBin` / `coordinationNumber`
- `seams cn --types I,J`
- tests: `neighList` degree vs CN; two-peak first min