### PR TITLE
feat: hydrogen bonds from an explicit donor-H set

### DIFF
--- a/docs/newsfragments/hbond-donors.feature
+++ b/docs/newsfragments/hbond-donors.feature
@@ -1,0 +1,6 @@
+Hydrogen bonds accept an explicit donor-H index set
+(``populateHbondsFromDonors``). Water ``populateHbonds*`` still
+use the two-hydrogen ``hAtomMolList`` path. ``seams hbonds
+--donors`` uses every hydrogen as a donor candidate; the water
+cutoffs stay on that command and are not an ionic-liquid
+criterion.

--- a/docs/orgmode/contributing/index.org
+++ b/docs/orgmode/contributing/index.org
@@ -95,7 +95,9 @@ seams-core/
   graphs. ~bondGraphFromName~ accepts ~cutoff~, ~knn~, ~knn-union~.
 
 - ~populateHbonds~ :: Geometric hydrogen bonds. Needs hydrogens
-  (re-read from a dump, or an explicit H cloud).
+  (re-read from a dump, or an explicit H cloud). Water keeps the
+  two-hydrogen ~hAtomMolList~ set. ~populateHbondsFromDonors~
+  takes an explicit ~hCloud~ index list.
 
 - ~getCorrelPlus~ / ~getIceTypePlus~ :: CHILL+. Four-neighbour
   ~c_ij~, then cubic / hexagonal / interfacial / clathrate / water.

--- a/docs/orgmode/reference/cli.org
+++ b/docs/orgmode/reference/cli.org
@@ -13,8 +13,7 @@ seams read FILE
 seams chill FILE
 seams chill-plus FILE
 seams cages FILE
-seams rdf FILE
-seams cn FILE
+seams hbonds FILE
 #+end_src
 
 A positional ~command~ and a positional ~file~ are required. Missing
@@ -23,7 +22,7 @@ either, an unknown command, or a parse error exits 2.
 * Commands
 
 The ~command~ positional help string is ~read | chill | chill-plus |
-cages | rdf | cn~. ~chill_plus~ is an accepted alias of ~chill-plus~
+cages | hbonds~. ~chill_plus~ is an accepted alias of ~chill-plus~
 (not listed in that help string).
 
 | command | action | stdout |
@@ -32,8 +31,7 @@ cages | rdf | cn~. ~chill_plus~ is an accepted alias of ~chill-plus~
 | ~chill~ | CHILL four-neighbour labels | ~nop N~ then ~name count~ for each ice type present |
 | ~chill-plus~ | CHILL+ four-neighbour labels | same as ~chill~ |
 | ~cages~ | ice score on six-membered rings | ~nop N graph KIND hexagonal IH cubic IC water W~ |
-| ~rdf~ | partial site-site \(g_{IJ}(r)\) | ~# r g count~ then ~# types I J rmax R bins N volume V~ then one ~r g count~ row per bin |
-| ~cn~ | site-site coordination number | ~# site-site~ then ~# types I J cutoff R cn X nI N nJ M volume V~ |
+| ~hbonds~ | geometric hydrogen-bond count | ~nop N hbonds E~ |
 
 ~chill~ / ~chill-plus~ call ~nneigh::neighListO~, then
 ~chill::getCorrel~ / ~chill::getIceTypeNoPrint~ or
@@ -55,8 +53,16 @@ is optional. The volume is ~nneigh::dumpVolume~ (det of dump ~H~).
 
 An empty cloud (~nop 0~) still prints. ~chill~ / ~chill-plus~ print
 ~nop 0~. ~cages~ prints ~nop 0 graph KIND hexagonal 0 cubic 0
-water 0~. ~rdf~ prints the comment header and zero-count bins.
-~cn~ prints ~# site-site~ and ~cn 0~.
+water 0~. ~hbonds~ prints ~nop 0 hbonds 0~.
+
+~hbonds~ loads the heavy-atom cloud with ~--type~ and the hydrogen
+cloud with ~--htype~, then builds a cutoff neighbour list. Without
+~--donors~ it uses the water two-hydrogen-per-molecule set
+(~hAtomMolList~). ~--donors~ passes every hydrogen index to
+~populateHbondsFromDonors~. ~--hdist~ and ~--hangle~ are the
+acceptor-H distance and acceptor-donor-H angle cutoffs; the C++
+defaults stay the water values and are not an ionic-liquid
+criterion.
 
 * Options
 
@@ -78,6 +84,10 @@ initializers (Argum does not write defaults into the help).
 | ~--bins N~ | ~rmax / 0.1~ | ~RDF histogram bins (default rmax/0.1)~ |
 | ~-k N~ | ~4~ | ~k for knn / seeded cages~ |
 | ~--graph KIND~ | ~seeded~ | ~Bond graph for cages: cutoff \| knn \| knn-union \| seeded~ |
+| ~--htype I~ | ~1~ | ~Hydrogen atom type for hbonds~ |
+| ~--hdist ANGSTROM~ | water C++ default | ~Acceptor-H distance cutoff for hbonds~ |
+| ~--hangle DEG~ | water C++ default | ~Acceptor-donor-H angle cutoff for hbonds~ |
+| ~--donors~ | off | ~Use every hydrogen as a donor candidate~ |
 | ~--config FILE~ | ~SEAMS_CONFIG~ or ~./seams.env~ | Dotenv of ~SEAMS_*~ / ~LINKCELL_*~ knobs. Env wins over the file |
 | ~--print-config~ | | Print the resolved runtime knobs and exit |
 | ~--tpp N~ | ~0~ (occupancy picker) | Threads per particle for the device k-NN (~LINKCELL_TPP~) |

--- a/docs/orgmode/reference/cli.org
+++ b/docs/orgmode/reference/cli.org
@@ -13,6 +13,8 @@ seams read FILE
 seams chill FILE
 seams chill-plus FILE
 seams cages FILE
+seams rdf FILE
+seams cn FILE
 seams hbonds FILE
 #+end_src
 
@@ -22,8 +24,8 @@ either, an unknown command, or a parse error exits 2.
 * Commands
 
 The ~command~ positional help string is ~read | chill | chill-plus |
-cages | hbonds~. ~chill_plus~ is an accepted alias of ~chill-plus~
-(not listed in that help string).
+cages | rdf | cn | hbonds~. ~chill_plus~ is an accepted alias of
+~chill-plus~ (not listed in that help string).
 
 | command | action | stdout |
 |---------+--------+--------|
@@ -31,6 +33,8 @@ cages | hbonds~. ~chill_plus~ is an accepted alias of ~chill-plus~
 | ~chill~ | CHILL four-neighbour labels | ~nop N~ then ~name count~ for each ice type present |
 | ~chill-plus~ | CHILL+ four-neighbour labels | same as ~chill~ |
 | ~cages~ | ice score on six-membered rings | ~nop N graph KIND hexagonal IH cubic IC water W~ |
+| ~rdf~ | partial site-site \(g_{IJ}(r)\) | ~# r g count~ then ~# types I J rmax R bins N volume V~ then one ~r g count~ row per bin |
+| ~cn~ | site-site coordination number | ~# site-site~ then ~# types I J cutoff R cn X nI N nJ M volume V~ |
 | ~hbonds~ | geometric hydrogen-bond count | ~nop N hbonds E~ |
 
 ~chill~ / ~chill-plus~ call ~nneigh::neighListO~, then
@@ -53,15 +57,16 @@ is optional. The volume is ~nneigh::dumpVolume~ (det of dump ~H~).
 
 An empty cloud (~nop 0~) still prints. ~chill~ / ~chill-plus~ print
 ~nop 0~. ~cages~ prints ~nop 0 graph KIND hexagonal 0 cubic 0
-water 0~. ~hbonds~ prints ~nop 0 hbonds 0~.
+water 0~. ~rdf~ / ~cn~ still emit their headers. ~hbonds~ prints
+~nop 0 hbonds 0~.
 
 ~hbonds~ loads the heavy-atom cloud with ~--type~ and the hydrogen
 cloud with ~--htype~, then builds a cutoff neighbour list. Without
 ~--donors~ it uses the water two-hydrogen-per-molecule set
 (~hAtomMolList~). ~--donors~ passes every hydrogen index to
-~populateHbondsFromDonors~. ~--hdist~ and ~--hangle~ are the
-acceptor-H distance and acceptor-donor-H angle cutoffs; the C++
-defaults stay the water values and are not an ionic-liquid
+~populateHbondsFromDonors~. ~--hdist~ and ~--hangle~ are the acceptor-H distance and the
+acceptor-centered O-O-H angle cutoffs (angle between OO and OH);
+the C++ defaults stay the water values and are not an ionic-liquid
 criterion.
 
 * Options
@@ -80,13 +85,13 @@ initializers (Argum does not write defaults into the help).
 | ~-j~, ~--jobs N~ | ~1~ | ~Parallel frame workers (OpenMP). 1 is serial~ |
 | ~-t~, ~--type I~ | ~0~ | ~Atom type (0 guesses oxygen then type 1)~ |
 | ~--types I,J~ | ~I = J = --type~ | ~Pair types for site-site rdf/cn (default I=J=--type)~ |
-| ~-c~, ~--cutoff ANGSTROM~ | ~3.5~ | ~Neighbour cutoff (rdf/cn rmax)~ |
+| ~-c~, ~--cutoff ANGSTROM~ | ~3.5~ | ~Neighbour cutoff (rdf/cn rmax; hbonds heavy-atom nList)~ |
 | ~--bins N~ | ~rmax / 0.1~ | ~RDF histogram bins (default rmax/0.1)~ |
 | ~-k N~ | ~4~ | ~k for knn / seeded cages~ |
 | ~--graph KIND~ | ~seeded~ | ~Bond graph for cages: cutoff \| knn \| knn-union \| seeded~ |
 | ~--htype I~ | ~1~ | ~Hydrogen atom type for hbonds~ |
 | ~--hdist ANGSTROM~ | water C++ default | ~Acceptor-H distance cutoff for hbonds~ |
-| ~--hangle DEG~ | water C++ default | ~Acceptor-donor-H angle cutoff for hbonds~ |
+| ~--hangle DEG~ | water C++ default | ~O-O-H angle cutoff for hbonds (acceptor-centered)~ |
 | ~--donors~ | off | ~Use every hydrogen as a donor candidate~ |
 | ~--config FILE~ | ~SEAMS_CONFIG~ or ~./seams.env~ | Dotenv of ~SEAMS_*~ / ~LINKCELL_*~ knobs. Env wins over the file |
 | ~--print-config~ | | Print the resolved runtime knobs and exit |
@@ -267,6 +272,8 @@ seams cages dump.lammpstrj --graph knn-union
 seams chill-plus dump.lammpstrj --frame 1 --last 50 --jobs 8
 seams rdf dump.lammpstrj --types 1,2 --cutoff 10 --bins 100
 seams cn dump.lammpstrj --types 1,2 --cutoff 4.5
+seams hbonds dump.lammpstrj --type 2 --htype 1
+seams hbonds dump.lammpstrj --donors
 #+end_src
 
 Lua and Python are not this binary. See

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -17,51 +17,55 @@
 #include <generic.hpp>
 
 #include <cmath>
+#include <unordered_map>
 
 namespace {
 
-// Geometric test (O-H cutoff + OO/OH angle) for one donor-acceptor
-// assignment. The H-bond network is undirected, so each unordered pair
-// of oxygens is tried both ways.
-bool donatedHydrogenBond(
-    const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
-    const molSys::PointCloud<molSys::Point<double>, double> &hCloud,
-    const std::vector<std::vector<int>> &molIDlist,
-    const std::unordered_map<int, int> &idMolIDmap, int acceptorIndex,
-    int donorID, double distCutoff, double angleCutoff) {
-  auto molIt = idMolIDmap.find(donorID);
-  if (molIt == idMolIDmap.end()) {
-    return false;
-  }
-  auto donorIt = yCloud.idIndexMap.find(donorID);
-  if (donorIt == yCloud.idIndexMap.end()) {
-    return false;
-  }
-  const int listIndex = molSys::searchMolList(molIDlist, molIt->second);
-  if (listIndex == -1 || molIDlist[listIndex].size() < 3) {
-    return false;
-  }
-  const int donorIndex = donorIt->second;
-  for (int k = 1; k <= 2; k++) {
-    const int hAtomIndex = molIDlist[listIndex][k];
-    if (bond::getHbondDistanceOH(yCloud, hCloud, acceptorIndex, hAtomIndex) >=
-        distCutoff) {
+// Water populateHbonds* keep the two-H-per-molID set from hAtomMolList.
+std::vector<int> donorHsFromMolList(const std::vector<std::vector<int>> &molIDlist) {
+  std::vector<int> donorHs;
+  for (const auto &row : molIDlist) {
+    if (row.size() < 3) {
       continue;
     }
-    const auto ooArr = gen::relDist(yCloud, acceptorIndex, donorIndex);
-    std::vector<double> oo = {ooArr[0], ooArr[1], ooArr[2]};
-    const auto ohArr = gen::relDistFromPoint(
+    donorHs.push_back(row[1]);
+    donorHs.push_back(row[2]);
+  }
+  return donorHs;
+}
+
+} // namespace
+
+bool bond::donatedHydrogenBond(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+    const molSys::PointCloud<molSys::Point<double>, double> &hCloud,
+    int acceptorIndex, int donorIndex, const std::vector<int> &donorHs,
+    double distCutoff, double angleCutoff) {
+  if (acceptorIndex < 0 || donorIndex < 0 ||
+      acceptorIndex >= yCloud.nop || donorIndex >= yCloud.nop) {
+    return false;
+  }
+  const auto oo = gen::relDist(yCloud, acceptorIndex, donorIndex);
+  const std::vector<double> ooVec{oo[0], oo[1], oo[2]};
+  const double dist2 = distCutoff * distCutoff;
+  for (int hAtomIndex : donorHs) {
+    if (hAtomIndex < 0 || hAtomIndex >= hCloud.nop) {
+      continue;
+    }
+    const auto oh = gen::relDistFromPoint(
         yCloud, acceptorIndex, hCloud.pts[hAtomIndex].x,
         hCloud.pts[hAtomIndex].y, hCloud.pts[hAtomIndex].z);
-    std::vector<double> oh = {ohArr[0], ohArr[1], ohArr[2]};
-    if (gen::radDeg(gen::eigenVecAngle(oo, oh)) <= angleCutoff) {
+    const double oh2 = oh[0] * oh[0] + oh[1] * oh[1] + oh[2] * oh[2];
+    if (oh2 >= dist2) {
+      continue;
+    }
+    const std::vector<double> ohVec{oh[0], oh[1], oh[2]};
+    if (gen::radDeg(gen::eigenVecAngle(ooVec, ohVec)) <= angleCutoff) {
       return true;
     }
   }
   return false;
 }
-
-} // namespace
 
 /**
  * @details Create a vector of vectors containing bond information (outputs
@@ -248,72 +252,68 @@ bond::populateHbondsWithInputClouds(molSys::PointCloud<molSys::Point<double>, do
                      molSys::PointCloud<molSys::Point<double>, double> &hCloud,
                      const std::vector<std::vector<int>> &nList,
                      double distCutoff, double angleCutoff) {
-  //
-  std::vector<std::vector<int>>
-      hBondNet; // Output vector of vectors containing the HBN
-  std::vector<std::vector<int>>
-      molIDlist; // Vector of vectors; first element is the molID, and the next
-                 // two elements are the hydrogen atom indices
-  std::unordered_map<int, int>
-      idMolIDmap; // Unordered map with atom IDs of oxygens as the keys and the
-                  // molecular IDs as the values
-  int nnumNeighbours;
-  int iatomID, jatomID;
-  int iatomIndex, jatomIndex;
+  auto molIDlist = molSys::hAtomMolList(hCloud, yCloud);
+  return bond::populateHbondsFromDonors(yCloud, hCloud, nList,
+                                        donorHsFromMolList(molIDlist),
+                                        distCutoff, angleCutoff);
+}
 
-  // --------------------
-  // Get the unordered map of the oxygen atom IDs (keys) and the molecular IDs
-  // (values)
-  idMolIDmap = molSys::createIDMolIDmap(yCloud);
+std::vector<std::vector<int>> bond::populateHbondsFromDonors(
+    molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+    molSys::PointCloud<molSys::Point<double>, double> &hCloud,
+    const std::vector<std::vector<int>> &nList,
+    const std::vector<int> &donorHs, double distCutoff, double angleCutoff) {
+  std::vector<std::vector<int>> hBondNet;
+  std::unordered_map<int, std::vector<int>> donorHsByMol;
+  for (int hAtomIndex : donorHs) {
+    if (hAtomIndex < 0 || hAtomIndex >= hCloud.nop) {
+      continue;
+    }
+    donorHsByMol[hCloud.pts[hAtomIndex].molID].push_back(hAtomIndex);
+  }
 
-  // Get a vector of vectors with the molID in the first column, and the
-  // hydrogen atom indices (not ID) in each row
-  molIDlist = molSys::hAtomMolList(hCloud, yCloud);
-
-  // Initialize the vector of vectors hBondNet
   for (int iatom = 0; iatom < yCloud.nop; iatom++) {
-    hBondNet.push_back(std::vector<int>()); // Empty vector for the index iatom
-    // Fill the first element with the atom ID of iatom itself
+    hBondNet.push_back(std::vector<int>());
     hBondNet[iatom].push_back(yCloud.pts[iatom].atomID);
-  } // end of init of hBondNet
+  }
 
-  // Loop through the neighbour list
+  const std::vector<int> emptyHs;
+  auto hsFor = [&](int donorIndex) -> const std::vector<int> & {
+    auto it = donorHsByMol.find(yCloud.pts[donorIndex].molID);
+    if (it == donorHsByMol.end()) {
+      return emptyHs;
+    }
+    return it->second;
+  };
+
   for (size_t iatom = 0; iatom < nList.size(); iatom++) {
     if (nList[iatom].empty()) {
       continue;
     }
-    iatomID = nList[iatom][0];
-    nnumNeighbours = static_cast<int>(nList[iatom].size()) - 1;
-    iatomIndex = static_cast<int>(iatom);
-    //
-    // Loop through the nearest neighbours
-    // Only process pairs where iatomID < jatomID to avoid adding each
-    // H-bond twice (both directions are added when a bond is found)
+    const int iatomID = nList[iatom][0];
+    const int nnumNeighbours = static_cast<int>(nList[iatom].size()) - 1;
+    const int iatomIndex = static_cast<int>(iatom);
     for (int j = 1; j <= nnumNeighbours; j++) {
-      jatomID = nList[iatom][j]; // Atom ID of the nearest neighbour
+      const int jatomID = nList[iatom][j];
       if (iatomID >= jatomID) {
         continue;
-      } // skip to avoid duplicate H-bond entries
+      }
       auto gotJ = yCloud.idIndexMap.find(jatomID);
       if (gotJ == yCloud.idIndexMap.end()) {
         continue;
       }
-      jatomIndex = gotJ->second;
-      // Either oxygen may donate. The unordered-pair skip above only
-      // prevents writing the edge twice.
-      if (donatedHydrogenBond(yCloud, hCloud, molIDlist, idMolIDmap,
-                              iatomIndex, jatomID, distCutoff, angleCutoff) ||
-          donatedHydrogenBond(yCloud, hCloud, molIDlist, idMolIDmap,
-                              jatomIndex, iatomID, distCutoff, angleCutoff)) {
+      const int jatomIndex = gotJ->second;
+      if (bond::donatedHydrogenBond(yCloud, hCloud, iatomIndex, jatomIndex,
+                                    hsFor(jatomIndex), distCutoff,
+                                    angleCutoff) ||
+          bond::donatedHydrogenBond(yCloud, hCloud, jatomIndex, iatomIndex,
+                                    hsFor(iatomIndex), distCutoff,
+                                    angleCutoff)) {
         hBondNet[iatomIndex].push_back(jatomID);
         hBondNet[jatomIndex].push_back(iatomID);
       }
-
-    } // end of loop through the nearest neighbours
-
-  } // end of loop through the neighbour list
-
-  // --------------------
+    }
+  }
 
   return hBondNet;
 }

--- a/src/include/internal/bond.hpp
+++ b/src/include/internal/bond.hpp
@@ -54,10 +54,15 @@
  *
  * A hydrogen bond between two water molecules exists when:
  *
- * 1. The distance between the donor oxygen atom and the acceptor hydrogen atom
+ * 1. The distance between the acceptor oxygen atom and the donor hydrogen atom
  is less than 2.42 Angstrom
- * 2. The angle between the O--O vector and the O-H vector should be less than
+ * 2. The angle between the O-O vector and the O-H vector should be less than
  30 degrees
+ *
+ * Those numbers are the water defaults on populateHbonds and
+ * populateHbondsWithInputClouds. populateHbondsFromDonors takes the same
+ * defaults so a water donor-H set stays comparable; other chemistries pass
+ * their own cutoffs. They are not an ionic-liquid default.
  *
  * ### Changelog ###
  *
@@ -89,6 +94,25 @@ populateHbondsWithInputClouds(molSys::PointCloud<molSys::Point<double>, double> 
                molSys::PointCloud<molSys::Point<double>, double> &hCloud,
                const std::vector<std::vector<int>> &nList,
                double distCutoff = 2.42, double angleCutoff = 30.0);
+
+//! Geometric test for one donor-acceptor assignment. donorHs are hCloud
+//! indices on the donor. O-O is gen::relDist(yCloud, acceptor, donor).
+//! O-H uses gen::relDistFromPoint (dump MIC).
+bool donatedHydrogenBond(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+    const molSys::PointCloud<molSys::Point<double>, double> &hCloud,
+    int acceptorIndex, int donorIndex, const std::vector<int> &donorHs,
+    double distCutoff = 2.42, double angleCutoff = 30.0);
+
+//! Hydrogen-bond network from an explicit donor-H set. donorHs are hCloud
+//! indices; each is paired with the heavy atom that shares its molID.
+//! Water callers build donorHs from hAtomMolList (two H per molecule).
+std::vector<std::vector<int>> populateHbondsFromDonors(
+    molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+    molSys::PointCloud<molSys::Point<double>, double> &hCloud,
+    const std::vector<std::vector<int>> &nList,
+    const std::vector<int> &donorHs, double distCutoff = 2.42,
+    double angleCutoff = 30.0);
 
 //! Calculates the distance of the hydrogen bond between O and H (of different
 //! atoms), given the respective pointClouds and the indices to each atom

--- a/src/seams_cli.cpp
+++ b/src/seams_cli.cpp
@@ -496,7 +496,7 @@ int main(int argc, char *argv[]) {
 
   parser.add(Option("--cutoff", "-c")
                  .argName("ANGSTROM")
-                 .help("Neighbour cutoff (rdf/cn rmax)")
+                 .help("Neighbour cutoff (rdf/cn rmax; hbonds heavy-atom nList)")
                  .handler([&](std::string_view value) {
                    cutoff = parseFloatingPoint<double>(value);
                  }));
@@ -543,7 +543,7 @@ int main(int argc, char *argv[]) {
 
   parser.add(Option("--hangle")
                  .argName("DEG")
-                 .help("Acceptor-donor-H angle cutoff for hbonds")
+                 .help("O-O-H angle cutoff for hbonds (acceptor-centered)")
                  .handler([&](std::string_view value) {
                    hangle = parseFloatingPoint<double>(value);
                  }));

--- a/src/seams_cli.cpp
+++ b/src/seams_cli.cpp
@@ -4,6 +4,7 @@
 //-----------------------------------------------------------------------------------
 
 #include <argum.h>
+#include <bond.hpp>
 #include <bop.hpp>
 #include <cage_affiliation.hpp>
 #include <franzblau.hpp>
@@ -375,6 +376,40 @@ int cmdCages(std::ostream &os, Cloud &cloud, double cutoff, int typeI, int k,
   return 0;
 }
 
+int cmdHbonds(std::ostream &os, Cloud &yCloud, Cloud &hCloud, double cutoff,
+              int typeI, double distCutoff, double angleCutoff,
+              bool allDonors) {
+  if (yCloud.nop == 0) {
+    os << colorizer.heading("nop") << " 0 "
+       << colorizer.longOption("hbonds") << " 0\n";
+    return 0;
+  }
+  const int typ = typeOf(yCloud, typeI);
+  auto nList = nneigh::neighListO(cutoff, yCloud, typ);
+  std::vector<std::vector<int>> net;
+  if (allDonors) {
+    std::vector<int> donorHs;
+    donorHs.reserve(static_cast<std::size_t>(hCloud.nop));
+    for (int i = 0; i < hCloud.nop; ++i) {
+      donorHs.push_back(i);
+    }
+    net = bond::populateHbondsFromDonors(yCloud, hCloud, nList, donorHs,
+                                         distCutoff, angleCutoff);
+  } else {
+    net = bond::populateHbondsWithInputClouds(yCloud, hCloud, nList, distCutoff,
+                                              angleCutoff);
+  }
+  int edges = 0;
+  for (const auto &row : net) {
+    if (row.size() > 1) {
+      edges += static_cast<int>(row.size()) - 1;
+    }
+  }
+  os << colorizer.heading("nop") << " " << yCloud.nop << " "
+     << colorizer.longOption("hbonds") << " " << (edges / 2) << "\n";
+  return 0;
+}
+
 } // namespace
 
 int main(int argc, char *argv[]) {
@@ -389,6 +424,10 @@ int main(int argc, char *argv[]) {
   int k = cfg.k;
   std::string graph = cfg.graph;
   bool printConfig = false;
+  int htype = 1;
+  double hdist = 2.42;
+  double hangle = 30.0;
+  bool allDonors = false;
   std::string cmd;
   std::string file;
   std::string typesFlag;
@@ -488,6 +527,31 @@ int main(int argc, char *argv[]) {
                  .help("Bond graph for cages: cutoff | knn | knn-union | seeded")
                  .handler([&](std::string_view value) { graph = value; }));
 
+  parser.add(Option("--htype")
+                 .argName("I")
+                 .help("Hydrogen atom type for hbonds")
+                 .handler([&](std::string_view value) {
+                   htype = parseIntegral<int>(value);
+                 }));
+
+  parser.add(Option("--hdist")
+                 .argName("ANGSTROM")
+                 .help("Acceptor-H distance cutoff for hbonds")
+                 .handler([&](std::string_view value) {
+                   hdist = parseFloatingPoint<double>(value);
+                 }));
+
+  parser.add(Option("--hangle")
+                 .argName("DEG")
+                 .help("Acceptor-donor-H angle cutoff for hbonds")
+                 .handler([&](std::string_view value) {
+                   hangle = parseFloatingPoint<double>(value);
+                 }));
+
+  parser.add(Option("--donors")
+                 .help("Use every hydrogen as a donor candidate")
+                 .handler([&]() { allDonors = true; }));
+
   parser.add(Option("--config")
                  .argName("FILE")
                  .help("Dotenv file of SEAMS_* / LINKCELL_* knobs "
@@ -530,7 +594,7 @@ int main(int argc, char *argv[]) {
                  }));
 
   parser.add(Positional("command")
-                 .help("read | chill | chill-plus | cages | rdf | cn")
+                 .help("read | chill | chill-plus | cages | rdf | cn | hbonds")
                  .occurs(zeroOrOneTime)
                  .handler([&](std::string_view value) { cmd = value; }));
 
@@ -611,6 +675,11 @@ int main(int argc, char *argv[]) {
     }
     if (cmd == "cn") {
       return cmdCn(os, cloud, cutoff, bins, rdfTypeI, rdfTypeJ);
+    }
+    if (cmd == "hbonds") {
+      Cloud hCloud = load(file, cloud.currentFrame, htype);
+      return cmdHbonds(os, cloud, hCloud, cutoff, typeI, hdist, hangle,
+                       allDonors);
     }
     os << colorizer.error("unknown command: ") << cmd << "\n";
     return 2;

--- a/tests/test_bond.cpp
+++ b/tests/test_bond.cpp
@@ -370,6 +370,106 @@ TEST_CASE("H-bond thresholds are configurable", "[bond]") {
   REQUIRE(countEdges(looseNet) >= countEdges(waterNet));
 }
 
+TEST_CASE("three-H imidazolium-like donor set forms a bond that two-H water "
+          "list drops",
+          "[bond]") {
+  molSys::PointCloud<molSys::Point<double>, double> yCloud;
+  yCloud.box = {20.0, 20.0, 20.0};
+  yCloud.boxLow = {0.0, 0.0, 0.0};
+  yCloud.currentFrame = 1;
+
+  molSys::Point<double> donor;
+  donor.type = 2;
+  donor.atomID = 1;
+  donor.molID = 1;
+  donor.x = 0.0;
+  donor.y = 0.0;
+  donor.z = 0.0;
+
+  molSys::Point<double> acceptor;
+  acceptor.type = 2;
+  acceptor.atomID = 2;
+  acceptor.molID = 2;
+  acceptor.x = 2.8;
+  acceptor.y = 0.0;
+  acceptor.z = 0.0;
+
+  yCloud.pts.push_back(donor);
+  yCloud.pts.push_back(acceptor);
+  yCloud.nop = 2;
+  yCloud.idIndexMap[1] = 0;
+  yCloud.idIndexMap[2] = 1;
+
+  molSys::PointCloud<molSys::Point<double>, double> hCloud;
+  hCloud.box = yCloud.box;
+  hCloud.boxLow = yCloud.boxLow;
+  hCloud.currentFrame = 1;
+
+  // First two H (hAtomMolList) point away from the acceptor. The third is
+  // the imidazolium-like ring hydrogen that actually donates.
+  const double hxyz[3][3] = {{-0.96, 0.0, 0.0}, {0.0, 0.96, 0.0}, {0.96, 0.0, 0.0}};
+  for (int i = 0; i < 3; i++) {
+    molSys::Point<double> h;
+    h.type = 1;
+    h.atomID = 10 + i;
+    h.molID = 1;
+    h.x = hxyz[i][0];
+    h.y = hxyz[i][1];
+    h.z = hxyz[i][2];
+    hCloud.pts.push_back(h);
+    hCloud.idIndexMap[h.atomID] = i;
+  }
+  hCloud.nop = 3;
+
+  const std::vector<std::vector<int>> nList = {{1, 2}, {2, 1}};
+
+  auto waterNet = bond::populateHbondsWithInputClouds(yCloud, hCloud, nList);
+  REQUIRE(waterNet.size() == 2);
+  REQUIRE(waterNet[0].size() == 1);
+  REQUIRE(waterNet[1].size() == 1);
+
+  const std::vector<int> twoH = {0, 1};
+  auto twoHNet =
+      bond::populateHbondsFromDonors(yCloud, hCloud, nList, twoH);
+  REQUIRE(twoHNet == waterNet);
+
+  const std::vector<int> threeH = {0, 1, 2};
+  auto threeHNet =
+      bond::populateHbondsFromDonors(yCloud, hCloud, nList, threeH);
+  REQUIRE(threeHNet[0].size() == 2);
+  REQUIRE(threeHNet[0][1] == 2);
+  REQUIRE(threeHNet[1].size() == 2);
+  REQUIRE(threeHNet[1][1] == 1);
+  REQUIRE(bond::donatedHydrogenBond(yCloud, hCloud, 1, 0, threeH));
+  REQUIRE_FALSE(bond::donatedHydrogenBond(yCloud, hCloud, 1, 0, twoH));
+}
+
+TEST_CASE("water donorHs from hAtomMolList matches populateHbondsWithInputClouds",
+          "[bond]") {
+  molSys::PointCloud<molSys::Point<double>, double> oCloud;
+  oCloud = sinp::readLammpsTrjO("traj/exampleTraj.lammpstrj", 1, oCloud, 2);
+  REQUIRE(oCloud.nop > 0);
+
+  molSys::PointCloud<molSys::Point<double>, double> hCloud;
+  hCloud = sinp::readLammpsTrjO("traj/exampleTraj.lammpstrj", 1, hCloud, 1);
+  REQUIRE(hCloud.nop == 2 * oCloud.nop);
+
+  auto nList = nneigh::neighListO(3.5, oCloud, 2);
+  auto molList = molSys::hAtomMolList(hCloud, oCloud);
+  std::vector<int> donorHs;
+  for (const auto &row : molList) {
+    for (size_t k = 1; k < row.size(); k++) {
+      donorHs.push_back(row[k]);
+    }
+  }
+  REQUIRE_FALSE(donorHs.empty());
+
+  auto waterNet = bond::populateHbondsWithInputClouds(oCloud, hCloud, nList);
+  auto donorNet =
+      bond::populateHbondsFromDonors(oCloud, hCloud, nList, donorHs);
+  REQUIRE(donorNet == waterNet);
+}
+
 TEST_CASE("createBondsFromCages with no matching cage type returns empty",
           "[bond]") {
   std::vector<std::vector<int>> rings = {{1, 2, 3, 4, 5, 6}};


### PR DESCRIPTION
# Description

Stacked on #85 (`113f72f`). Water still uses two hydrogens per `molID` at 2.42 A / 30 deg. `populateHbondsFromDonors` takes an explicit H-index list so a three-H donor set is legal. O--O is `relDist(acceptor, donor)`. O--H is `relDistFromPoint`.

Top of stack #87. Diff against #85: https://github.com/d-SEAMS/seams-core/compare/feat/2026-08-16-rdf-cn...feat/2026-08-16-hbond-donors

# Changes

- `bond::donatedHydrogenBond` / `populateHbondsFromDonors`
- `seams hbonds --donors`
- tests: three-H set vs `hAtomMolList`; water path matches