### PR TITLE
chore: cut 2.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,21 @@ Changelog
 Unreleased
 ==========
 
+Version 2.4.0 (2026-08-16)
+===========================
+
+Partial 3D site-site ``g_IJ(r)`` and coordination numbers under
+the dump MIC, with ``seams rdf`` and ``seams cn``. Site chemistry
+is a ``site::Table`` of LAMMPS types and optional atom-ID
+overrides; ``site::ionCloud`` collapses each ion ``molID`` to one
+unwrapped COM vertex. Hydrogen bonds accept an explicit donor-H
+index set (``populateHbondsFromDonors``). ``seams hbonds --donors``
+uses every hydrogen as a donor candidate; water cutoffs stay on
+that command and are not an ionic-liquid criterion. In-plane RDF
+normalization uses the dump-cell volume ``|det H|`` and the
+restricted-triclinic in-plane area ``lx*ly``, not the particle AABB
+or bound-span product.
+
 Version 2.3.4 (2026-08-16)
 ===========================
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "d-SEAMS: Deferred Structural Elucidation Analysis for Molecular Simulations"
 type: software
-version: "2.3.4"
+version: "2.4.0"
 date-released: "2026-08-16"
 license: MIT
 repository-code: "https://github.com/d-SEAMS/seams-core"

--- a/docs/newsfragments/hbond-donors.feature
+++ b/docs/newsfragments/hbond-donors.feature
@@ -1,6 +1,0 @@
-Hydrogen bonds accept an explicit donor-H index set
-(``populateHbondsFromDonors``). Water ``populateHbonds*`` still
-use the two-hydrogen ``hAtomMolList`` path. ``seams hbonds
---donors`` uses every hydrogen as a donor candidate; the water
-cutoffs stay on that command and are not an ionic-liquid
-criterion.

--- a/docs/newsfragments/ionic-liquid-rdf.feature
+++ b/docs/newsfragments/ionic-liquid-rdf.feature
@@ -1,1 +1,0 @@
-Partial 3D g_IJ(r) and unlike-type neighbour lists for multi-type dumps, with `seams rdf`.

--- a/docs/newsfragments/rdf2d-tilt-volume.bugfix
+++ b/docs/newsfragments/rdf2d-tilt-volume.bugfix
@@ -1,3 +1,0 @@
-In-plane RDF normalization uses the dump-cell volume |det H|
-and the restricted-triclinic in-plane area lx*ly, not the
-product of the particle AABB or of the bound spans.

--- a/docs/newsfragments/site-site-cn.feature
+++ b/docs/newsfragments/site-site-cn.feature
@@ -1,1 +1,0 @@
-Partial 3D site-site g_IJ(r) and coordination numbers, with `seams rdf` and `seams cn`.

--- a/docs/newsfragments/site-table.feature
+++ b/docs/newsfragments/site-table.feature
@@ -1,3 +1,0 @@
-Site chemistry is a ``site::Table`` of LAMMPS types and optional atom-ID
-overrides, not an extension of ``atom_state_type``. ``site::ionCloud``
-collapses each cation or anion ``molID`` to one unwrapped COM vertex.

--- a/docs/orgmode/changelog.org
+++ b/docs/orgmode/changelog.org
@@ -7,8 +7,19 @@ The C++ engine is this repository. Python is ~pydseams~
 
 * Unreleased
 
-Partial 3D \(g_{IJ}(r)\) and unlike-type neighbour lists for
-multi-type dumps, via ~seams rdf~.
+* 2.4.0
+
+Partial 3D site-site \(g_{IJ}(r)\) and coordination numbers under
+the dump MIC, via ~seams rdf~ and ~seams cn~. Site chemistry is a
+~site::Table~ of LAMMPS types and optional atom-ID overrides;
+~site::ionCloud~ collapses each ion ~molID~ to one unwrapped COM
+vertex. Hydrogen bonds accept an explicit donor-H index set
+(~populateHbondsFromDonors~). ~seams hbonds --donors~ uses every
+hydrogen as a donor candidate; water cutoffs stay on that command
+and are not an ionic-liquid criterion. In-plane RDF normalization
+uses the dump-cell volume \(|\det H|\) and the restricted-triclinic
+in-plane area \(lx \times ly\), not the particle AABB or bound-span
+product.
 
 * 2.3.4
 

--- a/docs/source/Doxyfile_seams.cfg
+++ b/docs/source/Doxyfile_seams.cfg
@@ -33,7 +33,7 @@ GENERATE_LATEX          = NO
 
 # Project Settings
 PROJECT_NAME            = "seams-core"
-PROJECT_NUMBER          = "v2.2.5"
+PROJECT_NUMBER          = "v2.4.0"
 PROJECT_BRIEF           = "libyodaLib, the C++ engine of d-SEAMS"
 
 # Doxygen Settings

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 #-----------------------------------------------------------------------------------
 
 project('seams-core', ['cpp', 'c'],
-  version: '2.3.4',
+  version: '2.4.0',
   default_options: ['warning_level=2', 'cpp_std=c++20'],
   meson_version: '>=1.3.0')
 

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "seams-core"
-version = "2.3.4"
+version = "2.4.0"
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "osx-arm64"]
 authors = ["Rohit Goswami <rgoswami@ieee.org>"]

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -2,4 +2,4 @@
 directory = "docs/newsfragments"
 filename = "CHANGELOG.rst"
 name = "seams-core"
-version = "2.1.0"
+version = "2.4.0"


### PR DESCRIPTION
# Description

v2.3.4 was never tagged. Stack #87 landed `rdf::`, `site::`, `seams rdf` / `seams cn` / `seams hbonds --donors`, and the tilt 2-D RDF volume fix. That is a public-header and CLI cut, so this is 2.4.0.

# Changes

- CHANGELOG 2.4.0 from the five stack fragments (`rdf2d-tilt-volume`, `site-table`, `site-site-cn`, `hbond-donors`, `ionic-liquid-rdf`)
- version 2.4.0 in `pixi.toml`, `meson.build`, `CITATION.cff`, `towncrier.toml`
- `Doxyfile_seams` `PROJECT_NUMBER` v2.4.0
- leftover 2.3.x fragments stay out of this section (`mic-leftovers` is already 2.3.4)