### PR TITLE
feat: dump-H leftovers and IL site rdf cn domains

### DIFF
--- a/docs/newsfragments/cn-pairs-cli.feature
+++ b/docs/newsfragments/cn-pairs-cli.feature
@@ -1,0 +1,3 @@
+``seams cn FILE --types I,J`` prints the site-site neighbour-list degree.
+``seams cn FILE --ions --site`` prints cage degree on ``site::ionCloud``.
+``seams pairs FILE --site`` prints the mutual-nearest contact-pair count.

--- a/docs/newsfragments/density-z.feature
+++ b/docs/newsfragments/density-z.feature
@@ -1,0 +1,2 @@
+Type-resolved ``rho(z)`` via ``site::densityZ`` and ``seams density-z``.
+Slab volume is ``A_perp * dz`` from dump H (recovered ``lx, ly, lz``).

--- a/docs/newsfragments/family-gate.feature
+++ b/docs/newsfragments/family-gate.feature
@@ -1,0 +1,5 @@
+``--family NAME`` (default ``waterIce``) is an input, not an inference.
+``seams chill``, ``chill-plus``, and ``cages`` exit 2 when the family is
+``ionicLiquid``, ``moltenSalt``, ``des``, ``electrolyte``, ``confinedIL``,
+``confinedWater``, or ``networkFormer``. The refusal names the family.
+Unflagged ``seams chill`` stays the historical water path.

--- a/docs/newsfragments/hbond-donors.feature
+++ b/docs/newsfragments/hbond-donors.feature
@@ -1,0 +1,5 @@
+Hydrogen bonds accept an explicit per-heavy donor-H list
+(``populateHbondsFromDonors``). Water ``populateHbonds*`` keep
+the two-hydrogen ``hAtomMolList`` path and the 2.42 A / 30 deg
+defaults. Callers pass ``(r, theta)`` from that trajectory's
+site-site RDF.

--- a/docs/newsfragments/polar-apolar-domains.feature
+++ b/docs/newsfragments/polar-apolar-domains.feature
@@ -1,0 +1,3 @@
+``seams domains`` reports the largest polar or apolar Stoddard
+cluster and ``P_inf = N_largest / N_subset``. The walk uses a
+``site::indicesOf`` mask; it does not run CHILL or q6.

--- a/docs/newsfragments/rdf-running-cn.feature
+++ b/docs/newsfragments/rdf-running-cn.feature
@@ -1,0 +1,1 @@
+Running 3D site-site CN from `rdf::PartialRdf`: `runningCN`, `firstMinimumBin`, and `coordinationNumber` (`4 pi rho_J int s^2 g ds`, `rho_J = nJ / volume`).

--- a/docs/newsfragments/site-table.feature
+++ b/docs/newsfragments/site-table.feature
@@ -1,0 +1,3 @@
+Site chemistry is a ``site::Table`` of LAMMPS types and optional atom-ID
+overrides, not an extension of ``atom_state_type``. ``site::ionCloud``
+collapses each cation or anion ``molID`` to one unwrapped COM vertex.

--- a/docs/newsfragments/unlike-nearest.feature
+++ b/docs/newsfragments/unlike-nearest.feature
@@ -1,0 +1,3 @@
+Nearest unlike neighbour and mutual-nearest unlike pair on a typed
+ion cloud (``nneigh::nearestUnlike``, ``nneigh::mutualNearestUnlike``).
+The mutual edge is a contact pair, not first-shell membership.

--- a/docs/orgmode/contributing/index.org
+++ b/docs/orgmode/contributing/index.org
@@ -95,7 +95,9 @@ seams-core/
   graphs. ~bondGraphFromName~ accepts ~cutoff~, ~knn~, ~knn-union~.
 
 - ~populateHbonds~ :: Geometric hydrogen bonds. Needs hydrogens
-  (re-read from a dump, or an explicit H cloud).
+  (re-read from a dump, or an explicit H cloud). Water uses the
+  two-hydrogen ~hAtomMolList~ set. ~populateHbondsFromDonors~
+  takes an explicit per-heavy donor-H index list.
 
 - ~getCorrelPlus~ / ~getIceTypePlus~ :: CHILL+. Four-neighbour
   ~c_ij~, then cubic / hexagonal / interfacial / clathrate / water.

--- a/docs/orgmode/howto/classify-cli.org
+++ b/docs/orgmode/howto/classify-cli.org
@@ -23,8 +23,10 @@ seams rdf FILE --type 2 --cutoff 10
 ~--type 0~ (default) guesses type 2 then type 1. Mixed water dumps in
 this tree use type 2 oxygen. Single-site mW dumps use type 1. A
 mixed-type dump that is not that guess needs ~--type I~; see
-[[file:ionic-liquid.org][Ionic-liquid dumps]]. A triclinic dump uses the
-stored tilt; see [[file:sheared-cells.org][Sheared cells]].
+[[file:ionic-liquid.org][Ionic-liquid dumps]]. ~--family~ defaults to
+~waterIce~. ~chill~ / ~chill-plus~ / ~cages~ refuse every other family.
+A triclinic dump uses the stored tilt; see
+[[file:sheared-cells.org][Sheared cells]].
 
 #+begin_src bash
 seams chill-plus FILE --type 2

--- a/docs/orgmode/howto/index.org
+++ b/docs/orgmode/howto/index.org
@@ -8,7 +8,7 @@ A how-to solves a goal you already have. It is not a learning path.
 | [[file:install.org][Install the engine]] | Get a ~seams~ binary |
 | [[file:classify-cli.org][Classify a dump]] | Run ~read~ / ~chill-plus~ / ~cages~ on a file you have |
 | [[file:sheared-cells.org][Sheared cells]] | Triclinic dump: bound spans are not edge lengths; recover H |
-| [[file:ionic-liquid.org][Ionic-liquid dumps]] | Keep one species with ~--type~; unlike-pair ~seams rdf --types I,J~ |
+| [[file:ionic-liquid.org][Ionic-liquid dumps]] | Keep one species with ~--type~; unlike-pair ~seams rdf --types I,J~; confined \(\rho(z)\) |
 | [[file:ase-integration.org][ASE]] | Pointer to the pydseams ASE howto |
 | [[file:solvis.org][View a classified frame]] | solvis via pydseams, not OVITO |
 | [[file:confined-ice.org][Confined ice]] | Nanotube and monolayer classification |

--- a/docs/orgmode/howto/ionic-liquid.org
+++ b/docs/orgmode/howto/ionic-liquid.org
@@ -73,6 +73,23 @@ triclinic (~box.size() >= 6~), the tilt ~xy xz yz~. Bound spans
 are not edge lengths; see [[file:sheared-cells.org][Sheared
 cells]].
 
+* Family gate
+
+~--family~ names the material. The default is ~waterIce~.
+~seams chill~, ~chill-plus~, and ~cages~ refuse (exit 2) when
+~--family~ is ~ionicLiquid~, ~moltenSalt~, ~des~, ~electrolyte~,
+~confinedIL~, ~confinedWater~, or ~networkFormer~. The message
+names the family. Unflagged ~seams chill~ stays the historical
+water path and is not an IL classifier.
+
+#+begin_src bash
+seams rdf FILE --types 1,2 --cutoff 6.0
+seams cn FILE --types 1,2 --cutoff 6.0
+seams cn FILE --ions --site '1=cationHead,2=anion'
+seams pairs FILE --site '1=cationHead,2=anion'
+seams chill FILE --family ionicLiquid   # exits 2
+#+end_src
+
 Flags and the rest of the surface live on
 [[file:../reference/cli.org][seams CLI]]. Formats live on
 [[file:../reference/data-formats.org][data formats]].

--- a/docs/orgmode/howto/ionic-liquid.org
+++ b/docs/orgmode/howto/ionic-liquid.org
@@ -45,6 +45,21 @@ dump carries it.
 ~seams rdf~ is not an ice score. Do not run CHILL or cages on
 the ions.
 
+* Site kinds and ion vertices
+
+LAMMPS ~type~ is not chemistry: type 1 is oxygen in water and a
+cation head in an IL. Hold a ~site::Table~ of type-to-kind (and
+optional atom-ID overrides). ~Table::of~ looks up the override
+first, then the type, else ~unspecified~. ~indicesOf(polar)~ is
+the union of ~cationHead~, ~anion~, and explicit ~polar~;
+~indicesOf(apolar)~ is ~tail~ plus explicit ~apolar~.
+~site::ionCloud~ emits one vertex per ~molID~ that carries a
+cation head or anion: the unweighted COM of those tagged atoms,
+unwrapped with ~gen::relDist~ to the first atom of the group, with
+~Point::type~ 1 (cation) or 2 (anion). A long-chain cation COM
+sits on the polar head, not halfway down the tail. Family is an
+input on the table; it is not inferred from types.
+
 * Read the box
 
 ~seams read FILE~ prints ~box Lx Ly Lz~ and, when the dump is

--- a/docs/orgmode/howto/ionic-liquid.org
+++ b/docs/orgmode/howto/ionic-liquid.org
@@ -69,8 +69,12 @@ not a coordination number.
 
 * Polar and apolar domains
 
-~seams domains FILE --site '1=cationHead,2=anion,3=tail' --subset
-polar~ (~apolar~) builds the mask from ~site::indicesOf~ and walks
+#+begin_src bash
+seams domains FILE --site '1=cationHead,2=anion,3=tail' --subset polar
+seams domains FILE --site '1=cationHead,2=anion,3=tail' --subset apolar
+#+end_src
+
+~seams domains~ builds the mask from ~site::indicesOf~ and walks
 Stoddard's clusters on that subset. It does not run CHILL or
 ~q_6~. Neighbours are the dump-MIC cutoff list (~--cutoff~).
 Stdout is ~subset polar n N largest L P P_inf~ with

--- a/docs/orgmode/howto/ionic-liquid.org
+++ b/docs/orgmode/howto/ionic-liquid.org
@@ -3,7 +3,8 @@
 
 A multi-type dump is not an ice frame. Keep CHILL and cages on
 one species with ~--type I~. Use ~seams rdf~ for a partial
-g_IJ(r) under the dump minimum image.
+g_IJ(r) under the dump minimum image. Use ~seams density-z~
+for a type-resolved \(\rho(z)\) in a slit.
 
 * Pick one type
 
@@ -66,6 +67,47 @@ ion's nearest unlike neighbour and the MIC distance.
 are contact pairs. They are not first-shell membership and
 not a coordination number.
 
+* Polar and apolar domains
+
+~seams domains FILE --site '1=cationHead,2=anion,3=tail' --subset
+polar~ (~apolar~) builds the mask from ~site::indicesOf~ and walks
+Stoddard's clusters on that subset. It does not run CHILL or
+~q_6~. Neighbours are the dump-MIC cutoff list (~--cutoff~).
+Stdout is ~subset polar n N largest L P P_inf~ with
+~P_inf = L / N~. Missing ~--site~ exits 2. ~--family~ still only
+gates ice scores.
+
+* Confined layers
+
+A slit or slab dump needs type-resolved \(\rho(z)\), not bulk CHILL.
+
+#+begin_src bash
+seams density-z FILE
+seams density-z FILE --type 1 --bins 80
+seams density-z FILE --type 2 --axis z
+#+end_src
+
+~--type 0~ (default) histograms every atom. ~--type I~ keeps one
+LAMMPS type. ~--axis~ is the Cartesian coordinate (~x~, ~y~, or
+~z~; default ~z~). ~--bins~ is optional (default the bound span
+over \(0.1\)).
+
+Stdout is ~# z rho~ then one row per bin. The slice volume is
+\(A_\perp \times dz\). \(A_\perp\) comes from dump H (~ly*lz~
+for ~x~, ~lx*lz~ for ~y~, ~lx*ly~ for ~z~) using the recovered
+edge lengths, not bound spans. This is not a 2-periodic MIC.
+The integral of ~rho * A * dz~ is the number of selected atoms.
+
+Confined IL work is this histogram plus the existing in-plane
+~rdf2::rdf2Danalysis_AA~ sampler. Do not run CHILL on
+~--family confinedIL~.
+
+Molten salt is ~seams rdf~ / ~cn~ plus ~ionCloud~ when the melt
+is multi-site. DES adds explicit donor H-bonds. Electrolyte is
+ion--O rdf/cn plus water H-bonds. Silica / BeF2 is rdf/cn plus
+Franzblau on the M--X graph and ~getq6~ on the tetrahedral
+cation (~steinhardtQlVoronoi~ otherwise).
+
 * Read the box
 
 ~seams read FILE~ prints ~box Lx Ly Lz~ and, when the dump is
@@ -87,6 +129,8 @@ seams rdf FILE --types 1,2 --cutoff 6.0
 seams cn FILE --types 1,2 --cutoff 6.0
 seams cn FILE --ions --site '1=cationHead,2=anion'
 seams pairs FILE --site '1=cationHead,2=anion'
+seams domains FILE --site '1=cationHead,2=anion,3=tail' --subset polar
+seams density-z FILE --type 1 --bins 80
 seams chill FILE --family ionicLiquid   # exits 2
 #+end_src
 

--- a/docs/orgmode/howto/ionic-liquid.org
+++ b/docs/orgmode/howto/ionic-liquid.org
@@ -60,6 +60,12 @@ unwrapped with ~gen::relDist~ to the first atom of the group, with
 sits on the polar head, not halfway down the tail. Family is an
 input on the table; it is not inferred from types.
 
+On that ion cloud, ~nneigh::nearestUnlike(cloud, 1, 2)~ is each
+ion's nearest unlike neighbour and the MIC distance.
+~nneigh::mutualNearestUnlike~ keeps the mutual edges. Those
+are contact pairs. They are not first-shell membership and
+not a coordination number.
+
 * Read the box
 
 ~seams read FILE~ prints ~box Lx Ly Lz~ and, when the dump is

--- a/docs/orgmode/howto/sheared-cells.org
+++ b/docs/orgmode/howto/sheared-cells.org
@@ -22,6 +22,8 @@ The ~seams~ CLI has no tilt flag. A sheared dump is enough.
 ~box.size() >= 6~, ~xy xz yz~. ~seams rdf~ histograms
 ~rdf::partialRdf~ with the same dump MIC; the ideal-gas volume is
 ~nneigh::dumpVolume~ (|det H|, not the product of bound spans).
+~seams density-z~ takes \(A_\perp\) from that H (~ly*lz~ for ~x~,
+and so on), not from bound spans.
 Type selection on a mixed dump is ~--type I~; unlike-pair RDF is
 ~--types I,J~. See [[file:ionic-liquid.org][Ionic-liquid dumps]].
 The dump layout is on [[file:../reference/data-formats.org][data

--- a/docs/orgmode/howto/sheared-cells.org
+++ b/docs/orgmode/howto/sheared-cells.org
@@ -74,15 +74,21 @@ distances, cluster unwrap, and the in-plane RDF sampler.
 Catch2: ~steinhardtQl flatten uses dump H not span minImage~,
 ~getHbondDistanceOH uses dump H on a mixed image~,
 ~populateHbondsWithInputClouds accepts a mixed-image dump-H
-bond~, ~recenterClusterCloud unwraps a mixed image on dump H~,
+bond~, ~populateHbondsFromDonors~ on that same sheared OH,
+~recenterClusterCloud unwraps a mixed image on dump H~,
 ~recenterClusterCloud unwraps a three-atom mixed-image chain~,
 ~sampleRDF_AA histograms the tilt a-image pair~.
 
 ~seams rdf FILE --cutoff RMAX~ is the 3D partial \(g_{IJ}(r)\).
 Catch2: ~dumpVolume uses det H not bound spans~, ~partial RDF
 first bin sees the sheared a-image pair~, ~partial RDF like-type
-does not count the unlike neighbour~. The in-plane sampler
-remains ~rdf2::sampleRDF_AA~ on a ~PointCloud~.
+does not count the unlike neighbour~, ~runningCN at rmax is one
+for a single I-J pair~, ~firstMinimumBin finds the valley after
+the first peak~. The in-plane sampler remains
+~rdf2::sampleRDF_AA~ on a ~PointCloud~. ~rdf::runningCN~ and
+~rdf::coordinationNumber~ integrate ~4 pi rho_J s^2 g ds~ with
+~rho_J = nJ / volume~; the cutoff is a caller input, not a
+hard-wired first minimum.
 
 * Empty or ortho clouds
 

--- a/docs/orgmode/reference/api.org
+++ b/docs/orgmode/reference/api.org
@@ -69,6 +69,7 @@ Every file under =src/include/internal=.
 | =order_parameter.hpp= | ~topoparam~ | height% and coverage area |
 | =rdf.hpp= | ~rdf~ | partial 3D ~g_IJ(r)~ |
 | =rdf2d.hpp= | ~rdf2~ | in-plane radial distribution |
+| =density.hpp= | ~site~ | type- or kind-resolved \(\rho\) along one axis |
 | =selection.hpp= | ~gen~, ~ring~ | type and slice selections |
 | =generic.hpp= | ~gen~ | periodic distance, angles, medians |
 | =structure_desc.hpp= | ~chill~ | SOAP, template overlay, linear classifier |

--- a/docs/orgmode/reference/cli.org
+++ b/docs/orgmode/reference/cli.org
@@ -14,6 +14,8 @@ seams chill FILE
 seams chill-plus FILE
 seams cages FILE
 seams rdf FILE
+seams cn FILE
+seams pairs FILE
 #+end_src
 
 A positional ~command~ and a positional ~file~ are required. Missing
@@ -22,7 +24,7 @@ either, an unknown command, or a parse error exits 2.
 * Commands
 
 The ~command~ positional help string is ~read | chill | chill-plus |
-cages | rdf~. ~chill_plus~ is an accepted alias of ~chill-plus~
+cages | rdf | cn | pairs~. ~chill_plus~ is an accepted alias of ~chill-plus~
 (not listed in that help string).
 
 | command | action | stdout |
@@ -32,6 +34,9 @@ cages | rdf~. ~chill_plus~ is an accepted alias of ~chill-plus~
 | ~chill-plus~ | CHILL+ four-neighbour labels | same as ~chill~ |
 | ~cages~ | ice score on six-membered rings | ~nop N graph KIND hexagonal IH cubic IC water W~ |
 | ~rdf~ | partial \(g_{IJ}(r)\) | ~# r g count~ then ~# types I J rmax R bins N volume V~ then one ~r g count~ row per bin |
+| ~cn~ | site-site neighbour-list degree | ~site-site types I J cutoff R degree D nI N~ |
+| ~cn --ions --site~ | cage degree on ~ionCloud~ | ~cage ionCloud types 1 2 cutoff R degree D nCation N nAnion M~ |
+| ~pairs --site~ | mutual-nearest contact pairs | ~contact-pair count N nCation C nAnion A~ |
 
 ~chill~ / ~chill-plus~ call ~nneigh::neighListO~, then
 ~chill::getCorrel~ / ~chill::getIceTypeNoPrint~ or
@@ -48,6 +53,26 @@ are the ~molSys::atom_state_type~ enumerators: ~cubic~, ~hexagonal~,
 ~I = J = --type~). ~--cutoff~ is rmax. ~--bins~ is optional. The
 volume is ~nneigh::dumpVolume~ (det of dump ~H~), including shear.
 This is not an ice score.
+
+~cn~ calls ~nneigh::neighListPair~ on types from ~--types I,J~
+(default ~I = J = --type~) and prints the mean degree of type ~I~
+(row length minus the leading self). The line contains
+~site-site~. This is not an ice score and is not cage CN.
+
+~cn --ions --site SPEC~ builds ~site::ionCloud~ and prints the mean
+unlike degree of type-1 (cation) vertices from
+~nneigh::neighList(cutoff, ions, 1, 2)~. The line contains ~cage~.
+~pairs --site SPEC~ prints the size of
+~nneigh::mutualNearestUnlike(ions, 1, 2)~. That line contains
+~contact-pair~, not ionicity. Both need ~--site~.
+
+~chill~, ~chill-plus~, and ~cages~ call ~site::iceScoreAllowed~.
+When ~--family~ is not ~waterIce~ they print ~site::refuseIceScore~
+(the message names the family) and exit 2. They do not fall through
+to ~atom_state_type::water~. Unflagged ~seams chill~ stays
+~waterIce~. If ~--family~ is absent and the frame has more than two
+LAMMPS types, one stderr line names ~--family~ and the command
+still exits 0.
 
 An empty cloud (~nop 0~) still prints. ~chill~ / ~chill-plus~ print
 ~nop 0~. ~cages~ prints ~nop 0 graph KIND hexagonal 0 cubic 0
@@ -68,7 +93,10 @@ initializers (Argum does not write defaults into the help).
 | ~--last N~ | omitted (~0~) | ~Last frame (inclusive). Omit for a single --frame~ |
 | ~-j~, ~--jobs N~ | ~1~ | ~Parallel frame workers (OpenMP). 1 is serial~ |
 | ~-t~, ~--type I~ | ~0~ | ~Atom type (0 guesses oxygen then type 1)~ |
-| ~--types I,J~ | ~I = J = --type~ | ~Pair types for rdf (default I=J=--type)~ |
+| ~--types I,J~ | ~I = J = --type~ | ~Pair types for rdf/cn (default I=J=--type)~ |
+| ~--family NAME~ | ~waterIce~ | Material family. Ice scores refuse every value except ~waterIce~ |
+| ~--site SPEC~ | | Type-to-kind map for ~ionCloud~ (~1=cationHead,2=anion~) |
+| ~--ions~ | | ~cn~ on ~ionCloud~ cage degree (needs ~--site~) |
 | ~-c~, ~--cutoff ANGSTROM~ | ~3.5~ | ~Neighbour cutoff (rdf rmax)~ |
 | ~--bins N~ | ~rmax / 0.1~ | ~RDF histogram bins (default rmax/0.1)~ |
 | ~-k N~ | ~4~ | ~k for knn / seeded cages~ |
@@ -106,7 +134,7 @@ See [[file:../howto/ionic-liquid.org][Ionic-liquid dumps]].
 
 * ~--types~
 
-Used by ~rdf~. The Argum form is ~I,J~ (one comma). A bad string
+Used by ~rdf~ and ~cn~. The Argum form is ~I,J~ (one comma). A bad string
 exits 2 (~bad --types (want I,J)~). Omit the flag to set both
 sides to ~--type~.
 
@@ -162,6 +190,7 @@ the table.
 | ~SEAMS_CUTOFF~ | ~3.5~ |
 | ~SEAMS_K~ | ~4~ |
 | ~SEAMS_GRAPH~ | ~seeded~ |
+| ~SEAMS_FAMILY~ | ~waterIce~ |
 | ~SEAMS_RESIDENT~ | ~0.80~ |
 | ~SEAMS_CELL~ | ~3.0~ |
 | ~SEAMS_TPP~ / ~LINKCELL_TPP~ | occupancy picker (~0~) |
@@ -249,7 +278,7 @@ Color roles on this binary:
 | code | when |
 |------+------|
 | ~0~ | success, including ~--help~ / ~--version~ / ~--features~ / ~--print-config~ |
-| ~2~ | parse error, missing command or file, unknown command, unknown ~--graph~, bad ~--types~, ~--bins < 0~ |
+| ~2~ | parse error, missing command or file, unknown command, unknown ~--graph~, bad ~--types~, ~--bins < 0~, unknown ~--family~, ice score refused by ~--family~ |
 
 * Examples
 
@@ -263,6 +292,10 @@ seams cages dump.lammpstrj --graph knn-union
 seams chill-plus dump.lammpstrj --frame 1 --last 50 --jobs 8
 seams rdf dump.lammpstrj --type 1 --cutoff 10
 seams rdf dump.lammpstrj --types 1,2 --cutoff 10 --bins 100
+seams cn dump.lammpstrj --types 1,2 --cutoff 6.0
+seams cn dump.lammpstrj --ions --site '1=cationHead,2=anion' --cutoff 6.0
+seams pairs dump.lammpstrj --site '1=cationHead,2=anion'
+seams chill dump.lammpstrj --family ionicLiquid
 #+end_src
 
 Lua and Python are not this binary. See

--- a/docs/orgmode/reference/cli.org
+++ b/docs/orgmode/reference/cli.org
@@ -16,6 +16,7 @@ seams cages FILE
 seams rdf FILE
 seams cn FILE
 seams pairs FILE
+seams density-z FILE
 #+end_src
 
 A positional ~command~ and a positional ~file~ are required. Missing
@@ -24,8 +25,8 @@ either, an unknown command, or a parse error exits 2.
 * Commands
 
 The ~command~ positional help string is ~read | chill | chill-plus |
-cages | rdf | cn | pairs~. ~chill_plus~ is an accepted alias of ~chill-plus~
-(not listed in that help string).
+cages | rdf | cn | pairs | density-z~. ~chill_plus~ is an accepted
+alias of ~chill-plus~ (not listed in that help string).
 
 | command | action | stdout |
 |---------+--------+--------|
@@ -37,6 +38,7 @@ cages | rdf | cn | pairs~. ~chill_plus~ is an accepted alias of ~chill-plus~
 | ~cn~ | site-site neighbour-list degree | ~site-site types I J cutoff R degree D nI N~ |
 | ~cn --ions --site~ | cage degree on ~ionCloud~ | ~cage ionCloud types 1 2 cutoff R degree D nCation N nAnion M~ |
 | ~pairs --site~ | mutual-nearest contact pairs | ~contact-pair count N nCation C nAnion A~ |
+| ~density-z~ | type-resolved \(\rho\) along one axis | ~# z rho~ then one ~z rho~ row per bin |
 
 ~chill~ / ~chill-plus~ call ~nneigh::neighListO~, then
 ~chill::getCorrel~ / ~chill::getIceTypeNoPrint~ or
@@ -66,6 +68,13 @@ unlike degree of type-1 (cation) vertices from
 ~nneigh::mutualNearestUnlike(ions, 1, 2)~. That line contains
 ~contact-pair~, not ionicity. Both need ~--site~.
 
+~density-z~ calls ~site::densityZ~. ~--type 0~ (default) keeps
+every atom; ~--type I~ keeps that LAMMPS type. ~--axis~ is ~x~,
+~y~, or ~z~ (default ~z~). ~--bins~ defaults to the bound span
+over \(0.1\). Each slab volume is \(A_\perp \times dz\), with
+\(A_\perp\) from dump H (recovered ~lx, ly, lz~, not bound
+spans). This is not an ice score.
+
 ~chill~, ~chill-plus~, and ~cages~ call ~site::iceScoreAllowed~.
 When ~--family~ is not ~waterIce~ they print ~site::refuseIceScore~
 (the message names the family) and exit 2. They do not fall through
@@ -77,6 +86,7 @@ still exits 0.
 An empty cloud (~nop 0~) still prints. ~chill~ / ~chill-plus~ print
 ~nop 0~. ~cages~ prints ~nop 0 graph KIND hexagonal 0 cubic 0
 water 0~. ~rdf~ prints the comment header and zero-count bins.
+~density-z~ prints ~# z rho~ and zero-density bins.
 
 * Options
 
@@ -92,13 +102,14 @@ initializers (Argum does not write defaults into the help).
 | ~-f~, ~--frame N~ | ~1~ | ~First frame (1-based)~ |
 | ~--last N~ | omitted (~0~) | ~Last frame (inclusive). Omit for a single --frame~ |
 | ~-j~, ~--jobs N~ | ~1~ | ~Parallel frame workers (OpenMP). 1 is serial~ |
-| ~-t~, ~--type I~ | ~0~ | ~Atom type (0 guesses oxygen then type 1)~ |
+| ~-t~, ~--type I~ | ~0~ | ~Atom type (0 guesses oxygen then type 1; density-z: 0 is every atom)~ |
 | ~--types I,J~ | ~I = J = --type~ | ~Pair types for rdf/cn (default I=J=--type)~ |
 | ~--family NAME~ | ~waterIce~ | Material family. Ice scores refuse every value except ~waterIce~ |
 | ~--site SPEC~ | | Type-to-kind map for ~ionCloud~ (~1=cationHead,2=anion~) |
 | ~--ions~ | | ~cn~ on ~ionCloud~ cage degree (needs ~--site~) |
 | ~-c~, ~--cutoff ANGSTROM~ | ~3.5~ | ~Neighbour cutoff (rdf rmax)~ |
-| ~--bins N~ | ~rmax / 0.1~ | ~RDF histogram bins (default rmax/0.1)~ |
+| ~--bins N~ | ~rmax / 0.1~ or ~L / 0.1~ | ~Histogram bins (rdf: rmax/0.1; density-z: bound span / 0.1)~ |
+| ~--axis XYZ~ | ~z~ | ~Histogram axis for density-z (x, y, or z)~ |
 | ~-k N~ | ~4~ | ~k for knn / seeded cages~ |
 | ~--graph KIND~ | ~seeded~ | ~Bond graph for cages: cutoff \| knn \| knn-union \| seeded~ |
 | ~--config FILE~ | ~SEAMS_CONFIG~ or ~./seams.env~ | Dotenv of ~SEAMS_*~ / ~LINKCELL_*~ knobs. Env wins over the file |
@@ -130,6 +141,7 @@ XYZ always stores type 1. Classification still uses ~--type~ after
 the read (type 0 then becomes 1).
 
 A mixed-type dump that is not the water guess needs ~--type I~.
+~density-z~ treats ~0~ as every atom, not the oxygen guess.
 See [[file:../howto/ionic-liquid.org][Ionic-liquid dumps]].
 
 * ~--types~
@@ -152,7 +164,8 @@ sides to ~--type~.
 ~seams read~ prints ~gen::formatDumpBox~: the three bound spans,
 then ~xy xz yz~ when ~box.size() >= 6~. There is no separate tilt
 flag. ~seams rdf~ uses the same dump H (~gen::periodicDist~ and
-~nneigh::dumpVolume~). The in-plane sampler remains
+~nneigh::dumpVolume~). ~seams density-z~ uses recovered ~lx, ly,
+lz~ for \(A_\perp\), not bound spans. The in-plane sampler remains
 ~rdf2::sampleRDF_AA~; see
 [[file:../howto/sheared-cells.org][Sheared cells]].
 

--- a/meson.build
+++ b/meson.build
@@ -419,6 +419,15 @@ if get_option('with_cli')
     ],
     depends: [seams_exe])
   test(
+    'seams_help_mentions_density_z',
+    python3,
+    args: [
+      '-c',
+      'import subprocess,sys; p=subprocess.run([sys.argv[1],"--help"],capture_output=True,text=True); text=p.stdout+p.stderr; sys.exit(0 if p.returncode==0 and "density-z" in text and "--axis" in text else 1)',
+      seams_exe.full_path(),
+    ],
+    depends: [seams_exe])
+  test(
     'seams_unknown_command_exit_2',
     python3,
     args: [

--- a/meson.build
+++ b/meson.build
@@ -427,4 +427,72 @@ if get_option('with_cli')
       seams_exe.full_path(),
     ],
     depends: [seams_exe])
+  test(
+    'seams_chill_family_ionicLiquid_exit_2',
+    python3,
+    args: [
+      '-c',
+      'import subprocess,sys; p=subprocess.run([sys.argv[1],"chill",sys.argv[2],"--family","ionicLiquid"],capture_output=True,text=True); text=p.stderr+p.stdout; sys.exit(0 if p.returncode==2 and "ionicLiquid" in text else 1)',
+      seams_exe.full_path(),
+      meson.project_source_root() / 'input' / 'traj' / 'exampleTraj.lammpstrj',
+    ],
+    depends: [seams_exe])
+  test(
+    'seams_cages_family_des_exit_2',
+    python3,
+    args: [
+      '-c',
+      'import subprocess,sys; p=subprocess.run([sys.argv[1],"cages",sys.argv[2],"--family","des"],capture_output=True,text=True); text=p.stderr+p.stdout; sys.exit(0 if p.returncode==2 and "des" in text else 1)',
+      seams_exe.full_path(),
+      meson.project_source_root() / 'input' / 'traj' / 'exampleTraj.lammpstrj',
+    ],
+    depends: [seams_exe])
+  test(
+    'seams_chill_exampleTraj',
+    seams_exe,
+    args: ['chill', 'input/traj/exampleTraj.lammpstrj'],
+    workdir: meson.project_source_root(),
+    timeout: 120)
+  test(
+    'seams_help_mentions_family',
+    python3,
+    args: [
+      '-c',
+      'import subprocess,sys; p=subprocess.run([sys.argv[1],"--help"],capture_output=True,text=True); text=p.stdout+p.stderr; sys.exit(0 if p.returncode==0 and "--family" in text and "waterIce" in text else 1)',
+      seams_exe.full_path(),
+    ],
+    depends: [seams_exe])
+  test(
+    'seams_cn_site_site',
+    python3,
+    args: [
+      '-c',
+      'import subprocess,sys; p=subprocess.run([sys.argv[1],"cn",sys.argv[2],"--types","2,2","--cutoff","3.5"],capture_output=True,text=True); text=p.stdout+p.stderr; sys.exit(0 if p.returncode==0 and "site-site" in text else 1)',
+      seams_exe.full_path(),
+      meson.project_source_root() / 'input' / 'traj' / 'exampleTraj.lammpstrj',
+    ],
+    depends: [seams_exe],
+    timeout: 60)
+  test(
+    'seams_cn_ions_cage',
+    python3,
+    args: [
+      '-c',
+      'import subprocess,sys; p=subprocess.run([sys.argv[1],"cn",sys.argv[2],"--ions","--site","1=cationHead,2=anion","--cutoff","3.5"],capture_output=True,text=True); text=p.stdout+p.stderr; sys.exit(0 if p.returncode==0 and "cage" in text else 1)',
+      seams_exe.full_path(),
+      meson.project_source_root() / 'input' / 'traj' / 'exampleTraj.lammpstrj',
+    ],
+    depends: [seams_exe],
+    timeout: 60)
+  test(
+    'seams_pairs_contact',
+    python3,
+    args: [
+      '-c',
+      'import subprocess,sys; p=subprocess.run([sys.argv[1],"pairs",sys.argv[2],"--site","1=cationHead,2=anion"],capture_output=True,text=True); text=p.stdout+p.stderr; sys.exit(0 if p.returncode==0 and "contact-pair" in text else 1)',
+      seams_exe.full_path(),
+      meson.project_source_root() / 'input' / 'traj' / 'exampleTraj.lammpstrj',
+    ],
+    depends: [seams_exe],
+    timeout: 60)
 endif

--- a/meson.build
+++ b/meson.build
@@ -428,6 +428,16 @@ if get_option('with_cli')
     ],
     depends: [seams_exe])
   test(
+    'seams_density_z',
+    python3,
+    args: [
+      '-c',
+      'import os,subprocess,sys; env=os.environ.copy(); lib=os.path.join(os.path.dirname(sys.argv[1]),"src"); env["LD_LIBRARY_PATH"]=lib+(":"+env["LD_LIBRARY_PATH"] if env.get("LD_LIBRARY_PATH") else ""); p=subprocess.run([sys.argv[1],"density-z",sys.argv[2],"--bins","4","--type","0"],capture_output=True,text=True,env=env); lines=[ln for ln in p.stdout.splitlines() if ln.strip()]; sys.exit(0 if p.returncode==0 and lines and lines[0]=="# z rho" and len(lines)==5 else 1)',
+      seams_exe.full_path(),
+      meson.project_source_root() / 'input' / 'traj' / 'exampleTraj.lammpstrj',
+    ],
+    depends: [seams_exe])
+  test(
     'seams_unknown_command_exit_2',
     python3,
     args: [

--- a/meson.build
+++ b/meson.build
@@ -473,6 +473,25 @@ if get_option('with_cli')
     workdir: meson.project_source_root(),
     timeout: 120)
   test(
+    'seams_help_mentions_domains',
+    python3,
+    args: [
+      '-c',
+      'import subprocess,sys; p=subprocess.run([sys.argv[1],"--help"],capture_output=True,text=True); text=p.stdout+p.stderr; sys.exit(0 if p.returncode==0 and "domains" in text and "--subset" in text else 1)',
+      seams_exe.full_path(),
+    ],
+    depends: [seams_exe])
+  test(
+    'seams_domains_needs_site',
+    python3,
+    args: [
+      '-c',
+      'import subprocess,sys; p=subprocess.run([sys.argv[1],"domains",sys.argv[2]],capture_output=True,text=True); sys.exit(0 if p.returncode==2 else 1)',
+      seams_exe.full_path(),
+      meson.project_source_root() / 'input' / 'traj' / 'exampleTraj.lammpstrj',
+    ],
+    depends: [seams_exe])
+  test(
     'seams_help_mentions_family',
     python3,
     args: [

--- a/src/bond.cpp
+++ b/src/bond.cpp
@@ -20,40 +20,45 @@
 
 namespace {
 
-// Geometric test (O-H cutoff + OO/OH angle) for one donor-acceptor
-// assignment. The H-bond network is undirected, so each unordered pair
-// of oxygens is tried both ways.
-bool donatedHydrogenBond(
-    const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
-    const molSys::PointCloud<molSys::Point<double>, double> &hCloud,
-    const std::vector<std::vector<int>> &molIDlist,
-    const std::unordered_map<int, int> &idMolIDmap, int acceptorIndex,
-    int donorID, double distCutoff, double angleCutoff) {
-  auto molIt = idMolIDmap.find(donorID);
-  if (molIt == idMolIDmap.end()) {
-    return false;
-  }
-  auto donorIt = yCloud.idIndexMap.find(donorID);
-  if (donorIt == yCloud.idIndexMap.end()) {
-    return false;
-  }
-  const int listIndex = molSys::searchMolList(molIDlist, molIt->second);
-  if (listIndex == -1 || molIDlist[listIndex].size() < 3) {
-    return false;
-  }
-  const int donorIndex = donorIt->second;
-  for (int k = 1; k <= 2; k++) {
-    const int hAtomIndex = molIDlist[listIndex][k];
-    if (bond::getHbondDistanceOH(yCloud, hCloud, acceptorIndex, hAtomIndex) >=
-        distCutoff) {
+// Water populateHbonds* keep the two-H-per-molID set from hAtomMolList.
+// Row 0 is molID; rows 1 and 2 are the first two H indices.
+std::vector<std::vector<int>>
+donorHsFromTwoHRows(const std::vector<std::vector<int>> &molIDlist) {
+  std::vector<std::vector<int>> donorHs(molIDlist.size());
+  for (size_t i = 0; i < molIDlist.size(); i++) {
+    if (molIDlist[i].size() < 3) {
       continue;
     }
-    const auto ooArr = gen::relDist(yCloud, acceptorIndex, donorIndex);
-    std::vector<double> oo = {ooArr[0], ooArr[1], ooArr[2]};
+    donorHs[i] = {molIDlist[i][1], molIDlist[i][2]};
+  }
+  return donorHs;
+}
+
+} // namespace
+
+bool bond::donatedHydrogenBond(
+    const molSys::PointCloud<molSys::Point<double>, double> &heavyCloud,
+    const molSys::PointCloud<molSys::Point<double>, double> &hCloud,
+    int acceptorIndex, int donorIndex, const std::vector<int> &donorHs,
+    double distCutoff, double angleCutoff) {
+  if (acceptorIndex < 0 || donorIndex < 0 || acceptorIndex >= heavyCloud.nop ||
+      donorIndex >= heavyCloud.nop) {
+    return false;
+  }
+  const auto ooArr = gen::relDist(heavyCloud, acceptorIndex, donorIndex);
+  const std::vector<double> oo = {ooArr[0], ooArr[1], ooArr[2]};
+  for (int hAtomIndex : donorHs) {
+    if (hAtomIndex < 0 || hAtomIndex >= hCloud.nop) {
+      continue;
+    }
+    if (bond::getHbondDistanceOH(heavyCloud, hCloud, acceptorIndex,
+                                 hAtomIndex) >= distCutoff) {
+      continue;
+    }
     const auto ohArr = gen::relDistFromPoint(
-        yCloud, acceptorIndex, hCloud.pts[hAtomIndex].x,
+        heavyCloud, acceptorIndex, hCloud.pts[hAtomIndex].x,
         hCloud.pts[hAtomIndex].y, hCloud.pts[hAtomIndex].z);
-    std::vector<double> oh = {ohArr[0], ohArr[1], ohArr[2]};
+    const std::vector<double> oh = {ohArr[0], ohArr[1], ohArr[2]};
     if (gen::radDeg(gen::eigenVecAngle(oo, oh)) <= angleCutoff) {
       return true;
     }
@@ -61,17 +66,15 @@ bool donatedHydrogenBond(
   return false;
 }
 
-} // namespace
-
 /**
  * @details Create a vector of vectors containing bond information (outputs
  * bonded atom IDs, not indices!) from the neighbour list vector of vectors
  * (which contains atom INDICES). Moreover, the first element corresponds to the
  * atom whose neighbours have been found.
  */
-std::vector<std::vector<int>>
-bond::populateBonds(const std::vector<std::vector<int>> &nList,
-                    const molSys::PointCloud<molSys::Point<double>, double> &yCloud) {
+std::vector<std::vector<int>> bond::populateBonds(
+    const std::vector<std::vector<int>> &nList,
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud) {
   //
   std::vector<std::vector<int>> bonds; // Output vector of vectors
   std::vector<int> currentBond;        // Vector for the current bond
@@ -136,10 +139,10 @@ bond::populateBonds(const std::vector<std::vector<int>> &nList,
  *  @param[in] yCloud The input molSys::PointCloud
  *  @param[in] atomTypes Contains an atom type for each particle in yCloud
  */
-std::vector<std::vector<int>>
-bond::populateBonds(const std::vector<std::vector<int>> &nList,
-                    const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
-                    const std::vector<cage::iceType> &atomTypes) {
+std::vector<std::vector<int>> bond::populateBonds(
+    const std::vector<std::vector<int>> &nList,
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+    const std::vector<cage::iceType> &atomTypes) {
   //
   std::vector<std::vector<int>> bonds; // Output vector of vectors
   std::vector<int> currentBond;        // Vector for the current bond
@@ -220,8 +223,9 @@ bond::populateBonds(const std::vector<std::vector<int>> &nList,
 std::vector<std::vector<int>>
 bond::populateHbonds(std::string filename,
                      molSys::PointCloud<molSys::Point<double>, double> &yCloud,
-                     const std::vector<std::vector<int>> &nList, int targetFrame,
-                     int Htype, double distCutoff, double angleCutoff) {
+                     const std::vector<std::vector<int>> &nList,
+                     int targetFrame, int Htype, double distCutoff,
+                     double angleCutoff) {
   // Read hydrogen atoms from the trajectory file
   molSys::PointCloud<molSys::Point<double>, double> hCloud;
   hCloud = sinp::readLammpsTrjreduced(filename, targetFrame, hCloud, Htype);
@@ -236,84 +240,76 @@ bond::populateHbonds(std::string filename,
  the particle for which the neighbours are enumerated (the central atom),
  followed by the central atom's neighbour's IDs (not indices). Decides the
  existence of the hydrogen bond depending on the O--O and O--H vectors from the
- neighbour list (by ID) already constructed. The only difference between this function and the
- similar populateHbonds function is that this takes in the H atom PointCloud as input
+ neighbour list (by ID) already constructed. The only difference between this
+ function and the similar populateHbonds function is that this takes in the H
+ atom PointCloud as input
  *  @param[in] yCloud The input molSys::PointCloud for the hydrogen atoms only,
  for the entire system (regardless of whether there is a slice or not)
  *  @param[in] hCloud The input molSys::PointCloud for the oxygen atoms only
  *  @param[in] nList Row-ordered neighbour list by atom ID
  ***********************************************/
-std::vector<std::vector<int>>
-bond::populateHbondsWithInputClouds(molSys::PointCloud<molSys::Point<double>, double> &yCloud,
-                     molSys::PointCloud<molSys::Point<double>, double> &hCloud,
-                     const std::vector<std::vector<int>> &nList,
-                     double distCutoff, double angleCutoff) {
-  //
-  std::vector<std::vector<int>>
-      hBondNet; // Output vector of vectors containing the HBN
-  std::vector<std::vector<int>>
-      molIDlist; // Vector of vectors; first element is the molID, and the next
-                 // two elements are the hydrogen atom indices
-  std::unordered_map<int, int>
-      idMolIDmap; // Unordered map with atom IDs of oxygens as the keys and the
-                  // molecular IDs as the values
-  int nnumNeighbours;
-  int iatomID, jatomID;
-  int iatomIndex, jatomIndex;
+std::vector<std::vector<int>> bond::populateHbondsWithInputClouds(
+    molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+    molSys::PointCloud<molSys::Point<double>, double> &hCloud,
+    const std::vector<std::vector<int>> &nList, double distCutoff,
+    double angleCutoff) {
+  // Two-H hAtomMolList rows: first column is molID, next two are H indices.
+  auto molIDlist = molSys::hAtomMolList(hCloud, yCloud);
+  return bond::populateHbondsFromDonors(yCloud, hCloud, nList,
+                                        donorHsFromTwoHRows(molIDlist),
+                                        distCutoff, angleCutoff);
+}
 
-  // --------------------
-  // Get the unordered map of the oxygen atom IDs (keys) and the molecular IDs
-  // (values)
-  idMolIDmap = molSys::createIDMolIDmap(yCloud);
+std::vector<std::vector<int>> bond::populateHbondsFromDonors(
+    const molSys::PointCloud<molSys::Point<double>, double> &heavyCloud,
+    const molSys::PointCloud<molSys::Point<double>, double> &hCloud,
+    const std::vector<std::vector<int>> &nList,
+    const std::vector<std::vector<int>> &donorHs, double distCutoff,
+    double angleCutoff) {
+  std::vector<std::vector<int>> hBondNet;
+  const std::vector<int> emptyHs;
+  auto hsFor = [&](int donorIndex) -> const std::vector<int> & {
+    if (donorIndex < 0 || static_cast<size_t>(donorIndex) >= donorHs.size()) {
+      return emptyHs;
+    }
+    return donorHs[static_cast<size_t>(donorIndex)];
+  };
 
-  // Get a vector of vectors with the molID in the first column, and the
-  // hydrogen atom indices (not ID) in each row
-  molIDlist = molSys::hAtomMolList(hCloud, yCloud);
+  for (int iatom = 0; iatom < heavyCloud.nop; iatom++) {
+    hBondNet.push_back(std::vector<int>());
+    hBondNet[iatom].push_back(heavyCloud.pts[iatom].atomID);
+  }
 
-  // Initialize the vector of vectors hBondNet
-  for (int iatom = 0; iatom < yCloud.nop; iatom++) {
-    hBondNet.push_back(std::vector<int>()); // Empty vector for the index iatom
-    // Fill the first element with the atom ID of iatom itself
-    hBondNet[iatom].push_back(yCloud.pts[iatom].atomID);
-  } // end of init of hBondNet
-
-  // Loop through the neighbour list
   for (size_t iatom = 0; iatom < nList.size(); iatom++) {
     if (nList[iatom].empty()) {
       continue;
     }
-    iatomID = nList[iatom][0];
-    nnumNeighbours = static_cast<int>(nList[iatom].size()) - 1;
-    iatomIndex = static_cast<int>(iatom);
-    //
-    // Loop through the nearest neighbours
-    // Only process pairs where iatomID < jatomID to avoid adding each
-    // H-bond twice (both directions are added when a bond is found)
+    const int iatomID = nList[iatom][0];
+    const int nnumNeighbours = static_cast<int>(nList[iatom].size()) - 1;
+    const int iatomIndex = static_cast<int>(iatom);
     for (int j = 1; j <= nnumNeighbours; j++) {
-      jatomID = nList[iatom][j]; // Atom ID of the nearest neighbour
+      const int jatomID = nList[iatom][j];
       if (iatomID >= jatomID) {
         continue;
-      } // skip to avoid duplicate H-bond entries
-      auto gotJ = yCloud.idIndexMap.find(jatomID);
-      if (gotJ == yCloud.idIndexMap.end()) {
+      }
+      auto gotJ = heavyCloud.idIndexMap.find(jatomID);
+      if (gotJ == heavyCloud.idIndexMap.end()) {
         continue;
       }
-      jatomIndex = gotJ->second;
-      // Either oxygen may donate. The unordered-pair skip above only
-      // prevents writing the edge twice.
-      if (donatedHydrogenBond(yCloud, hCloud, molIDlist, idMolIDmap,
-                              iatomIndex, jatomID, distCutoff, angleCutoff) ||
-          donatedHydrogenBond(yCloud, hCloud, molIDlist, idMolIDmap,
-                              jatomIndex, iatomID, distCutoff, angleCutoff)) {
+      const int jatomIndex = gotJ->second;
+      // Either heavy atom may donate. The unordered-pair skip above
+      // only prevents writing the edge twice.
+      if (bond::donatedHydrogenBond(heavyCloud, hCloud, iatomIndex, jatomIndex,
+                                    hsFor(jatomIndex), distCutoff,
+                                    angleCutoff) ||
+          bond::donatedHydrogenBond(heavyCloud, hCloud, jatomIndex, iatomIndex,
+                                    hsFor(iatomIndex), distCutoff,
+                                    angleCutoff)) {
         hBondNet[iatomIndex].push_back(jatomID);
         hBondNet[jatomIndex].push_back(iatomID);
       }
-
-    } // end of loop through the nearest neighbours
-
-  } // end of loop through the neighbour list
-
-  // --------------------
+    }
+  }
 
   return hBondNet;
 }
@@ -329,8 +325,8 @@ to each atom.
 */
 double bond::getHbondDistanceOH(
     const molSys::PointCloud<molSys::Point<double>, double> &oCloud,
-    const molSys::PointCloud<molSys::Point<double>, double> &hCloud, int oAtomIndex,
-    int hAtomIndex) {
+    const molSys::PointCloud<molSys::Point<double>, double> &hCloud,
+    int oAtomIndex, int hAtomIndex) {
   const std::vector<double> hpt = {hCloud.pts[hAtomIndex].x,
                                    hCloud.pts[hAtomIndex].y,
                                    hCloud.pts[hAtomIndex].z};
@@ -403,7 +399,7 @@ bond::createBondsFromCages(const std::vector<std::vector<int>> &rings,
       std::sort(currentBond.begin(), currentBond.end());
       bonds.push_back(currentBond);
     } // end of loop through a particular ring
-  }   // end of loop through cages
+  } // end of loop through cages
 
   // This may have duplicates, so the duplicates should be removed
   std::sort(bonds.begin(), bonds.end());

--- a/src/cluster.cpp
+++ b/src/cluster.cpp
@@ -17,6 +17,111 @@
 #include <iostream>
 #include <seams_output.hpp>
 
+namespace {
+
+using Cloud = molSys::PointCloud<molSys::Point<double>, double>;
+
+void buildStoddardList(const Cloud &yCloud,
+                       const std::vector<std::vector<int>> &nList,
+                       const std::vector<bool> &mask,
+                       std::vector<int> &linkedList) {
+  linkedList.assign(yCloud.nop, -1);
+  for (int iatom = 0; iatom < yCloud.nop; iatom++) {
+    if (iatom >= static_cast<int>(mask.size()) ||
+        !mask[static_cast<std::size_t>(iatom)] ||
+        !yCloud.pts[static_cast<std::size_t>(iatom)].inSlice) {
+      continue;
+    }
+    linkedList[static_cast<std::size_t>(iatom)] = iatom;
+  }
+  for (int i = 0; i < yCloud.nop - 1; i++) {
+    if (linkedList[static_cast<std::size_t>(i)] == -1) {
+      continue;
+    }
+    if (linkedList[static_cast<std::size_t>(i)] != i) {
+      continue;
+    }
+    int j = i;
+    do {
+      for (int k = i + 1; k < yCloud.nop; k++) {
+        if (k >= static_cast<int>(mask.size()) ||
+            !mask[static_cast<std::size_t>(k)]) {
+          continue;
+        }
+        if (linkedList[static_cast<std::size_t>(k)] != k) {
+          continue;
+        }
+        const int kAtomID = yCloud.pts[static_cast<std::size_t>(k)].atomID;
+        if (j < 0 || j >= static_cast<int>(nList.size()) ||
+            nList[static_cast<std::size_t>(j)].size() < 2) {
+          continue;
+        }
+        auto it = std::find(nList[static_cast<std::size_t>(j)].begin() + 1,
+                            nList[static_cast<std::size_t>(j)].end(), kAtomID);
+        if (it != nList[static_cast<std::size_t>(j)].end()) {
+          const int temp = linkedList[static_cast<std::size_t>(j)];
+          linkedList[static_cast<std::size_t>(j)] =
+              linkedList[static_cast<std::size_t>(k)];
+          linkedList[static_cast<std::size_t>(k)] = temp;
+        }
+      }
+      j = linkedList[static_cast<std::size_t>(j)];
+    } while (j != i);
+  }
+}
+
+void measureStoddardClusters(const std::vector<int> &linkedList, int nop,
+                             std::vector<int> &startingIndex,
+                             std::vector<int> &nClusters,
+                             bool countSingletons) {
+  std::vector<bool> visited(static_cast<std::size_t>(nop));
+  startingIndex.clear();
+  nClusters.clear();
+  for (int i = 0; i < nop; i++) {
+    if (visited[static_cast<std::size_t>(i)]) {
+      continue;
+    }
+    visited[static_cast<std::size_t>(i)] = true;
+    if (linkedList[static_cast<std::size_t>(i)] == -1) {
+      continue;
+    }
+    if (linkedList[static_cast<std::size_t>(i)] == i) {
+      if (countSingletons) {
+        startingIndex.push_back(i);
+        nClusters.push_back(1);
+      }
+      continue;
+    }
+    int currentIndex = i;
+    int nextElement = linkedList[static_cast<std::size_t>(currentIndex)];
+    int iClusterNumber = 1;
+    const int index = i;
+    while (nextElement != index) {
+      iClusterNumber++;
+      currentIndex = nextElement;
+      visited[static_cast<std::size_t>(currentIndex)] = true;
+      nextElement = linkedList[static_cast<std::size_t>(currentIndex)];
+    }
+    startingIndex.push_back(index);
+    nClusters.push_back(iClusterNumber);
+  }
+}
+
+int subsetCount(const Cloud &cloud, const std::vector<bool> &mask) {
+  int n = 0;
+  const int nop = cloud.nop;
+  for (int i = 0; i < nop; i++) {
+    if (i < static_cast<int>(mask.size()) &&
+        mask[static_cast<std::size_t>(i)] &&
+        cloud.pts[static_cast<std::size_t>(i)].inSlice) {
+      ++n;
+    }
+  }
+  return n;
+}
+
+} // namespace
+
 /**
  * @details Finds the number of particles in the largest ice cluster, for a
  * given frame, using Stoddard's clustering algorithm (Stoddard J. Comp. Phys.,
@@ -43,117 +148,22 @@ int clump::largestIceCluster(
     const std::vector<std::vector<int>> &nList, std::vector<bool> &isIce,
     std::vector<int> &list, std::vector<int> &nClusters,
     std::unordered_map<int, int> &indexNumber, int firstFrame) {
-  //
-  int kAtomID;                    // Atom ID of the nearest neighbour
-  int iClusterNumber;             // Number in the current cluster
   int nLargestCluster;            // Number in the largest cluster
   std::vector<int> linkedList;    // Linked list
-  int j;                          // Index
-  std::vector<int> startingIndex; // Contains the vector index in list
-                                  // corresponding to a particular cluster
-  int temp;                       // For swapping
-  std::vector<bool>
-      visited; // To make sure you don't go through the same atoms again.
-  molSys::Point<double> iPoint; // Current point
-  int currentIndex;             // Current index
+  std::vector<int> startingIndex; // Vector index in list of each cluster
+  molSys::Point<double> iPoint;   // Current point
+  int currentIndex;               // Current index
+
+  (void)list;
+  (void)indexNumber;
 
   iceCloud = molSys::clearPointCloud(iceCloud);
   nClusters.clear();
-  // -----------------------------------------------------------
-  // INITIALIZATION
-  linkedList.assign(yCloud.nop, -1);
-  // Initial values of the list. -1 is a dummy value if the molecule is
-  // water or not in the slice
-  for (int iatom = 0; iatom < yCloud.nop; iatom++) {
-    // Skip if the molecule is water or if it is not in the slice
-    if (!isIce[iatom] || !yCloud.pts[iatom].inSlice) {
-      continue;
-    } // skip for water or not in slice
-    // Otherwise, assign the index as the ID
-    linkedList[iatom] = iatom;
-  } // init of cluster IDs
-  // -----------------------------------------------------------
-  // Get the linked list
-  for (int i = 0; i < yCloud.nop - 1; i++) {
-    //
-    // Skip if the molecule is water or if it is not in the slice
-    if (linkedList[i] == -1) {
-      continue;
-    } // skip for water or not in slice
-    //
-    // If iatom is already in a cluster, skip it
-    if (linkedList[i] != i) {
-      continue;
-    } // Already part of a cluster
-    //
-    j = i; // Init of j
-    // Execute the next part of the loop while j is not equal to i
-    do {
-      //
-      // Go through the rest of the atoms (KLOOP)
-      for (int k = i + 1; k < yCloud.nop; k++) {
-        // Skip if not ice
-        if (!isIce[k]) {
-          continue;
-        } // not ice
-        // Skip if already part of a cluster
-        if (linkedList[k] != k) {
-          continue;
-        } // Already part of a cluster
-        //
-        // Check to see if k is a nearest neighbour of j
-        kAtomID = yCloud.pts[k].atomID; // Atom ID
-        auto it = std::find(nList[j].begin() + 1, nList[j].end(), kAtomID);
-        if (it != nList[j].end()) {
-          // Swap!
-          temp = linkedList[j];
-          linkedList[j] = linkedList[k];
-          linkedList[k] = temp;
-        } // j and k are nearest neighbours
-      }   // end of loop through k (KLOOP)
-      //
-      j = linkedList[j];
-    } while (j != i); // end of control for j!=i
-    //
-
-  } // end of looping through every i
-
-  // -----------------------------------------------------------
-  // Get the starting index (which is the vector index in list) corresponding to
-  // clusters with more than one molecule in them
+  buildStoddardList(yCloud, nList, isIce, linkedList);
+  measureStoddardClusters(linkedList, yCloud.nop, startingIndex, nClusters,
+                          false);
   int nextElement; // value in list
   int index;       // starting index value
-  // init
-  visited.resize(yCloud.nop);
-
-  for (int i = 0; i < yCloud.nop; i++) {
-    //
-    if (visited[i]) {
-      continue;
-    }                  // Already counted
-    visited[i] = true; // Visited
-    if (linkedList[i] == -1) {
-      continue;
-    } // not ice
-    if (linkedList[i] == i) {
-      continue;
-    } // only one element
-    //
-    currentIndex = i;
-    nextElement = linkedList[currentIndex];
-    index = i;
-    iClusterNumber = 1; // at least one value
-    while (nextElement != index) {
-      iClusterNumber++;
-      currentIndex = nextElement;
-      visited[currentIndex] = true;
-      nextElement = linkedList[currentIndex];
-    } // get number
-    // Update startingIndex with index
-    startingIndex.push_back(index);
-    // Update the number of molecules in the cluster
-    nClusters.push_back(iClusterNumber);
-  } // end of loop through
   // -----------------------------------------------------------
   if (nClusters.empty()) {
     iceCloud.currentFrame = yCloud.currentFrame;
@@ -233,6 +243,26 @@ int clump::largestIceCluster(
 
   // -----------------------------------------------------------
   return 0;
+}
+
+clump::Domain
+clump::largestDomain(const Cloud &cloud,
+                     const std::vector<std::vector<int>> &nList,
+                     const std::vector<bool> &mask) {
+  Domain out;
+  out.subset = subsetCount(cloud, mask);
+  std::vector<int> linkedList;
+  std::vector<int> startingIndex;
+  std::vector<int> nClusters;
+  buildStoddardList(cloud, nList, mask, linkedList);
+  measureStoddardClusters(linkedList, cloud.nop, startingIndex, nClusters,
+                          true);
+  if (!nClusters.empty()) {
+    out.largest = *std::max_element(nClusters.begin(), nClusters.end());
+  }
+  out.percolation =
+      out.subset > 0 ? static_cast<double>(out.largest) / out.subset : 0.0;
+  return out;
 }
 
 /**

--- a/src/density.cpp
+++ b/src/density.cpp
@@ -1,0 +1,129 @@
+//-----------------------------------------------------------------------------------
+// d-SEAMS - Deferred Structural Elucidation Analysis for Molecular Simulations
+// SPDX-License-Identifier: MIT
+//-----------------------------------------------------------------------------------
+
+#include <density.hpp>
+
+#include <neighbours.hpp>
+
+#include <cmath>
+
+namespace {
+
+using Cloud = molSys::PointCloud<molSys::Point<double>, double>;
+
+double axisCoord(const molSys::Point<double> &p, int axis) {
+  if (axis == 0) {
+    return p.x;
+  }
+  if (axis == 1) {
+    return p.y;
+  }
+  return p.z;
+}
+
+// Face area conjugate to axis: |det H| / L_axis, i.e. ly*lz for x.
+double faceArea(const Cloud &yCloud, int axis) {
+  double lengths[3] = {0.0, 0.0, 0.0};
+  nneigh::dumpCellLengths(yCloud.box, yCloud.boxLow, lengths);
+  if (axis < 0 || axis > 2 || lengths[axis] == 0.0) {
+    return 0.0;
+  }
+  return nneigh::dumpVolume(yCloud) / lengths[axis];
+}
+
+site::DensityZ fillHistogram(const Cloud &yCloud,
+                             const std::vector<double> &coords, int nbin,
+                             int axis, int type) {
+  site::DensityZ out;
+  out.type = type;
+  if (nbin < 1) {
+    nbin = 1;
+  }
+  if (axis < 0 || axis > 2) {
+    axis = 2;
+  }
+
+  double lo = 0.0;
+  double span = 0.0;
+  if (static_cast<int>(yCloud.boxLow.size()) > axis) {
+    lo = yCloud.boxLow[static_cast<std::size_t>(axis)];
+  }
+  if (static_cast<int>(yCloud.box.size()) > axis) {
+    span = yCloud.box[static_cast<std::size_t>(axis)];
+  }
+  if (span < 0.0) {
+    span = 0.0;
+  }
+  const double dz = span / static_cast<double>(nbin);
+  const double area = faceArea(yCloud, axis);
+  const double slab = area * dz;
+
+  out.z.assign(static_cast<std::size_t>(nbin), 0.0);
+  out.rho.assign(static_cast<std::size_t>(nbin), 0.0);
+  for (int ibin = 0; ibin < nbin; ++ibin) {
+    out.z[static_cast<std::size_t>(ibin)] =
+        lo + dz * (static_cast<double>(ibin) + 0.5);
+  }
+
+  if (dz <= 0.0) {
+    return out;
+  }
+
+  std::vector<int> count(static_cast<std::size_t>(nbin), 0);
+  for (double c : coords) {
+    int ibin = static_cast<int>(std::floor((c - lo) / dz));
+    if (ibin == nbin && c <= lo + span) {
+      ibin = nbin - 1;
+    }
+    if (ibin < 0 || ibin >= nbin) {
+      continue;
+    }
+    count[static_cast<std::size_t>(ibin)] += 1;
+  }
+
+  if (slab <= 0.0) {
+    return out;
+  }
+  for (int ibin = 0; ibin < nbin; ++ibin) {
+    out.rho[static_cast<std::size_t>(ibin)] =
+        static_cast<double>(count[static_cast<std::size_t>(ibin)]) / slab;
+  }
+  return out;
+}
+
+} // namespace
+
+site::DensityZ site::densityZ(const Cloud &yCloud, int typeI, int nbin,
+                              int axis) {
+  if (axis < 0 || axis > 2) {
+    axis = 2;
+  }
+  std::vector<double> coords;
+  coords.reserve(yCloud.pts.size());
+  for (const auto &pt : yCloud.pts) {
+    if (typeI != 0 && pt.type != typeI) {
+      continue;
+    }
+    coords.push_back(axisCoord(pt, axis));
+  }
+  return fillHistogram(yCloud, coords, nbin, axis, typeI);
+}
+
+site::DensityZ site::densityZ(const Cloud &yCloud, const Table &table,
+                              Kind kind, int nbin, int axis) {
+  if (axis < 0 || axis > 2) {
+    axis = 2;
+  }
+  const auto idx = indicesOf(yCloud, table, kind);
+  std::vector<double> coords;
+  coords.reserve(idx.size());
+  for (int i : idx) {
+    if (i < 0 || i >= static_cast<int>(yCloud.pts.size())) {
+      continue;
+    }
+    coords.push_back(axisCoord(yCloud.pts[static_cast<std::size_t>(i)], axis));
+  }
+  return fillHistogram(yCloud, coords, nbin, axis, 0);
+}

--- a/src/include/internal/bond.hpp
+++ b/src/include/internal/bond.hpp
@@ -17,10 +17,10 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <fstream>
 #include <iostream>
 #include <iterator>
-#include <cmath>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -54,10 +54,15 @@
  *
  * A hydrogen bond between two water molecules exists when:
  *
- * 1. The distance between the donor oxygen atom and the acceptor hydrogen atom
+ * 1. The distance between the acceptor heavy atom and the donor hydrogen atom
  is less than 2.42 Angstrom
  * 2. The angle between the O--O vector and the O-H vector should be less than
  30 degrees
+ *
+ * 30 deg O-O-H is 150 deg O-H...O. Those numbers stay the water defaults on
+ * populateHbonds and populateHbondsWithInputClouds. Ionic-liquid callers pass
+ * (r, theta) from the site-site RDF of that trajectory. This header does not
+ * bake a cutoff for any other chemistry.
  *
  * ### Changelog ###
  *
@@ -82,20 +87,45 @@ populateHbonds(std::string filename,
 //! Create a vector of vectors (similar to the neighbour list conventions)
 //! containing the hydrogen bond connectivity information. Decides the
 //! existence of the hydrogen bond depending on the O--O and O--H vectors from
-//! the neighbour list already constructed, taking a PointCloud for the H atoms as input
+//! the neighbour list already constructed, taking a PointCloud for the H atoms
+//! as input
 // ! The H atom PointCloud should be for the entire system
-std::vector<std::vector<int>>
-populateHbondsWithInputClouds(molSys::PointCloud<molSys::Point<double>, double> &yCloud,
-               molSys::PointCloud<molSys::Point<double>, double> &hCloud,
-               const std::vector<std::vector<int>> &nList,
-               double distCutoff = 2.42, double angleCutoff = 30.0);
+std::vector<std::vector<int>> populateHbondsWithInputClouds(
+    molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+    molSys::PointCloud<molSys::Point<double>, double> &hCloud,
+    const std::vector<std::vector<int>> &nList, double distCutoff = 2.42,
+    double angleCutoff = 30.0);
+
+//! Geometric test for one donor-acceptor assignment. donorHs are hCloud
+//! indices attached to the donor. O-O is gen::relDist(heavyCloud,
+//! acceptor, donor). O-H uses gen::relDistFromPoint /
+//! unWrappedDistFromPoint (dump MIC).
+bool donatedHydrogenBond(
+    const molSys::PointCloud<molSys::Point<double>, double> &heavyCloud,
+    const molSys::PointCloud<molSys::Point<double>, double> &hCloud,
+    int acceptorIndex, int donorIndex, const std::vector<int> &donorHs,
+    double distCutoff, double angleCutoff);
+
+//! donorHs[iHeavy] = hCloud indices of donor hydrogens attached to
+//! heavyCloud.pts[iHeavy]. Empty row = this heavy atom does not donate.
+//! nList is the heavy-heavy neighbour list (by atom ID, leading self),
+//! same shape populateHbondsWithInputClouds already consumes. Water
+//! populateHbondsWithInputClouds builds those rows from the two-H
+//! hAtomMolList set. Other chemistries pass (r, theta) from the
+//! site-site RDF of that trajectory; 30 deg O-O-H is 150 deg O-H...O.
+std::vector<std::vector<int>> populateHbondsFromDonors(
+    const molSys::PointCloud<molSys::Point<double>, double> &heavyCloud,
+    const molSys::PointCloud<molSys::Point<double>, double> &hCloud,
+    const std::vector<std::vector<int>> &nList,
+    const std::vector<std::vector<int>> &donorHs, double distCutoff,
+    double angleCutoff);
 
 //! Calculates the distance of the hydrogen bond between O and H (of different
 //! atoms), given the respective pointClouds and the indices to each atom
-double
-getHbondDistanceOH(const molSys::PointCloud<molSys::Point<double>, double> &oCloud,
-                   const molSys::PointCloud<molSys::Point<double>, double> &hCloud,
-                   int oAtomIndex, int hAtomIndex);
+double getHbondDistanceOH(
+    const molSys::PointCloud<molSys::Point<double>, double> &oCloud,
+    const molSys::PointCloud<molSys::Point<double>, double> &hCloud,
+    int oAtomIndex, int hAtomIndex);
 
 //! Create a vector of vectors containing bond connectivity information. May
 //! contain duplicates! Gets the bond information from the vector of vectors

--- a/src/include/internal/cluster.hpp
+++ b/src/include/internal/cluster.hpp
@@ -59,6 +59,19 @@
 
 namespace clump {
 
+//! Largest connected component of a Boolean site mask (Stoddard).
+//! percolation is N_largest / N_subset. Does not classify ice.
+struct Domain {
+  int largest = 0;
+  int subset = 0;
+  double percolation = 0.0; // largest/subset
+};
+
+[[nodiscard]] Domain
+largestDomain(const molSys::PointCloud<molSys::Point<double>, double> &cloud,
+              const std::vector<std::vector<int>> &nList,
+              const std::vector<bool> &mask);
+
 //! Finds the largest ice cluster
 [[nodiscard]] int largestIceCluster(
     std::string path, molSys::PointCloud<molSys::Point<double>, double> &yCloud,

--- a/src/include/internal/density.hpp
+++ b/src/include/internal/density.hpp
@@ -1,0 +1,42 @@
+//-----------------------------------------------------------------------------------
+// d-SEAMS - Deferred Structural Elucidation Analysis for Molecular Simulations
+// SPDX-License-Identifier: MIT
+//-----------------------------------------------------------------------------------
+
+#ifndef SEAMS_DENSITY_H_
+#define SEAMS_DENSITY_H_
+
+#include <mol_sys.hpp>
+#include <site.hpp>
+
+#include <vector>
+
+/** @file density.hpp
+ *  @brief Type- or kind-resolved Cartesian number-density histogram.
+ *
+ *  This is not a 2-periodic MIC. Each slab volume is A_perp * dz,
+ *  with A_perp from dump H (ly*lz for x, lx*lz for y, lx*ly for z)
+ *  using recovered lx, ly, lz, not bound spans.
+ */
+
+namespace site {
+
+struct DensityZ {
+  std::vector<double> z;   //! Bin centres along the chosen axis
+  std::vector<double> rho; //! Number density in each slab
+  int type{0};             //! LAMMPS type; 0 = all atoms
+};
+
+//! Histogram Point::{x,y,z} for typeI (0 = every atom). axis is 0, 1, or 2.
+DensityZ densityZ(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int typeI,
+    int nbin, int axis);
+
+//! Same histogram, restricted to atoms whose Table kind matches.
+DensityZ densityZ(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+    const Table &table, Kind kind, int nbin, int axis);
+
+} // namespace site
+
+#endif // SEAMS_DENSITY_H_

--- a/src/include/internal/neighbours.hpp
+++ b/src/include/internal/neighbours.hpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <array>
 #include <string>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -295,6 +296,23 @@ kNearestNeighbourPair(
 std::pair<double, double> shellSeparation(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int k,
     int typeI);
+
+/** Nearest unlike image of each typeI particle among typeJ particles.
+ *  Returns cloud-index pairs (i, j) and the MIC distance
+ *  (sqrt of gen::periodicDistSq). On an ion cloud, typeI = 1
+ *  (cation vertex) and typeJ = 2 (anion vertex). This is the
+ *  nearest unlike neighbour, not a coordination number.
+ */
+std::vector<std::tuple<int, int, double>> nearestUnlike(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int typeI,
+    int typeJ);
+
+/** Subset of nearestUnlike where j's nearest typeI is i (mutual).
+ *  A contact pair is this mutual edge, not first-shell membership.
+ */
+std::vector<std::pair<int, int>> mutualNearestUnlike(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int typeI,
+    int typeJ);
 
 //! Erases memory for a vector of vectors for the neighbour list
 [[nodiscard]] int clearNeighbourList(std::vector<std::vector<int>> &nList);

--- a/src/include/internal/rdf.hpp
+++ b/src/include/internal/rdf.hpp
@@ -55,6 +55,15 @@ PartialRdf partialRdf(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int typeI,
     int typeJ, double rmax, int nbins);
 
+//! Running CN: 4 pi rho_J int_0^r s^2 g_IJ(s) ds. rho_J = nJ / volume.
+std::vector<double> runningCN(const PartialRdf &h);
+
+//! First minimum of g after the first maximum. Returns the bin index, or -1.
+int firstMinimumBin(const PartialRdf &h);
+
+//! Site-site CN integrated to rMax. Same kernel as runningCN; no default rMax.
+double coordinationNumber(const PartialRdf &h, double rMax);
+
 } // namespace rdf
 
 #endif // SEAMS_RDF_H_

--- a/src/include/internal/seams_config.hpp
+++ b/src/include/internal/seams_config.hpp
@@ -5,6 +5,8 @@
 #include <string>
 #include <string_view>
 
+#include <site.hpp>
+
 /** @file seams_config.hpp
  *  @brief Twelve-factor runtime knobs for the engine and the fronts.
  *
@@ -14,6 +16,13 @@
  *  over the file. CLI flags win over the environment. Compile-time
  *  meson options stay out of this table.
  */
+
+namespace site {
+bool iceScoreAllowed(Family f);
+const char *refuseIceScore(Family f);
+const char *familyName(Family f);
+Family parseFamily(std::string_view name);
+} // namespace site
 
 namespace seams::cfg {
 
@@ -25,6 +34,7 @@ struct Runtime {
   double cutoff = 3.5;
   int k = 4;
   std::string graph = "seeded";
+  site::Family family = site::Family::waterIce;
   double resident = 0.80;
   double cell = 3.0;
   int tpp = 0;

--- a/src/include/internal/site.hpp
+++ b/src/include/internal/site.hpp
@@ -1,0 +1,78 @@
+//-----------------------------------------------------------------------------------
+// d-SEAMS - Deferred Structural Elucidation Analysis for Molecular Simulations
+// SPDX-License-Identifier: MIT
+//-----------------------------------------------------------------------------------
+
+#ifndef SEAMS_SITE_H_
+#define SEAMS_SITE_H_
+
+#include <mol_sys.hpp>
+
+#include <unordered_map>
+#include <vector>
+
+/** @file site.hpp
+ *  @brief Per-atom site chemistry, separate from CHILL ice labels.
+ *
+ *  LAMMPS type IDs are not chemistry. A Table maps type (and optional
+ *  atom-ID override) to Kind. Family is an input, not an inference.
+ *  Table::of does not write polar or apolar back onto the table;
+ *  indicesOf applies those two derived unions.
+ */
+
+namespace site {
+
+enum class Kind {
+  unspecified,
+  cationHead,
+  anion,
+  tail,
+  donorH,
+  acceptor,
+  polar,
+  apolar,
+  waterO,
+  waterH,
+  solvent
+};
+
+enum class Family {
+  waterIce,      // default; CHILL/TUM allowed
+  ionicLiquid,   // CHILL/TUM refused
+  moltenSalt,    // CHILL/TUM refused
+  des,           // CHILL/TUM refused
+  electrolyte,   // CHILL/TUM only if the caller also names a waterIce subset
+  confinedIL,    // CHILL/TUM refused
+  confinedWater, // 2D RDF / monolayer rings; bulk CHILL refused
+  networkFormer  // silica / BeF2; Franzblau yes, CHILL no
+};
+
+struct Table {
+  Family family = Family::waterIce;
+  std::unordered_map<int, Kind> typeToKind;   // LAMMPS type ID
+  std::unordered_map<int, Kind> atomOverride; // atom ID wins over type
+  Kind of(const molSys::Point<double> &p) const;
+  Kind ofType(int typeId) const;
+};
+
+std::vector<int>
+indicesOf(const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+          const Table &table, Kind kind);
+
+int lammpsTypeOfKind(const Table &table, Kind kind); // error if not unique
+
+// One vertex per molID that carries ionKind (cationHead or anion).
+// Coordinates: unweighted geometric COM of atoms of that molID whose
+// kind is ionKind, unwrapped with gen::relDist to the first atom of
+// the group (createMolIDAtomIDMultiMap, mol_sys.hpp:187-190). Copies
+// box / boxLow from src. Point::type is 1 for cationHead molecules
+// and 2 for anion molecules so neighList(merged, 1, 2) is legal.
+// A molecule that is already one tagged site (UA, or one designated
+// type per ion) is a no-op: the COM is that site.
+molSys::PointCloud<molSys::Point<double>, double>
+ionCloud(const molSys::PointCloud<molSys::Point<double>, double> &src,
+         const Table &table);
+
+} // namespace site
+
+#endif // SEAMS_SITE_H_

--- a/src/meson.build
+++ b/src/meson.build
@@ -27,6 +27,7 @@ ydslib_sources = files(
   'seams_output.cpp',
   'selection.cpp',
   'shapeMatch.cpp',
+  'site.cpp',
   'steinhardt_parallel.cpp',
   'topo_bulk.cpp',
   'voronoi_qlm.cpp',

--- a/src/meson.build
+++ b/src/meson.build
@@ -19,6 +19,7 @@ ydslib_sources = files(
   'neighbours.cpp',
   'order_parameter.cpp',
   'pntCorrespondence.cpp',
+  'density.cpp',
   'rdf.cpp',
   'rdf2d.cpp',
   'ring.cpp',

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -15,6 +15,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <limits>
 #include <numeric>
 #include <queue>
 #include <span>
@@ -971,6 +972,84 @@ nneigh::kNearestNeighbourPair(
   std::vector<std::vector<int>> uni;
   fillBothGraphsFromNom(yCloud, nom, k, mutual, uni);
   return {std::move(mutual), std::move(uni)};
+}
+
+/**
+ * @details Nearest unlike neighbour of every typeI index among typeJ
+ *  indices. Each typeI walks every typeJ with gen::periodicDistSq
+ *  (the dump MIC). Ties keep the lowest typeJ index. Particles with
+ *  no unlike partner are omitted. Results are cloud indices and the
+ *  MIC distance, not a coordination number.
+ */
+std::vector<std::tuple<int, int, double>> nneigh::nearestUnlike(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int typeI,
+    int typeJ) {
+  std::vector<std::tuple<int, int, double>> out;
+  if (yCloud.box.size() < 3 || yCloud.nop <= 0) {
+    return out;
+  }
+
+  std::vector<int> jIdx;
+  jIdx.reserve(static_cast<std::size_t>(yCloud.nop));
+  for (int j = 0; j < yCloud.nop; j++) {
+    if (yCloud.pts[static_cast<std::size_t>(j)].type == typeJ) {
+      jIdx.push_back(j);
+    }
+  }
+  if (jIdx.empty()) {
+    return out;
+  }
+
+  for (int i = 0; i < yCloud.nop; i++) {
+    if (yCloud.pts[static_cast<std::size_t>(i)].type != typeI) {
+      continue;
+    }
+    int bestJ = -1;
+    double bestD2 = std::numeric_limits<double>::infinity();
+    for (const int j : jIdx) {
+      if (j == i) {
+        continue;
+      }
+      const double d2 = gen::periodicDistSq(yCloud, i, j);
+      if (d2 < bestD2) {
+        bestD2 = d2;
+        bestJ = j;
+      }
+    }
+    if (bestJ >= 0) {
+      out.emplace_back(i, bestJ, std::sqrt(bestD2));
+    }
+  }
+  return out;
+}
+
+/**
+ * @details Contact pairs: those nearestUnlike edges whose typeJ
+ *  partner also lists the typeI index as its nearest unlike
+ *  neighbour. Not first-shell membership.
+ */
+std::vector<std::pair<int, int>> nneigh::mutualNearestUnlike(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int typeI,
+    int typeJ) {
+  const auto forward = nearestUnlike(yCloud, typeI, typeJ);
+  const auto reverse = nearestUnlike(yCloud, typeJ, typeI);
+  std::vector<int> partnerOfJ(static_cast<std::size_t>(yCloud.nop), -1);
+  for (const auto &row : reverse) {
+    const int j = std::get<0>(row);
+    if (j >= 0 && j < yCloud.nop) {
+      partnerOfJ[static_cast<std::size_t>(j)] = std::get<1>(row);
+    }
+  }
+  std::vector<std::pair<int, int>> out;
+  for (const auto &row : forward) {
+    const int i = std::get<0>(row);
+    const int j = std::get<1>(row);
+    if (j >= 0 && j < yCloud.nop &&
+        partnerOfJ[static_cast<std::size_t>(j)] == i) {
+      out.emplace_back(i, j);
+    }
+  }
+  return out;
 }
 
 /**

--- a/src/rdf.cpp
+++ b/src/rdf.cpp
@@ -127,3 +127,96 @@ rdf::PartialRdf rdf::partialRdf(
   }
   return out;
 }
+
+namespace {
+
+double typeJDensity(const rdf::PartialRdf &h) {
+  if (h.volume <= 0.0) {
+    return 0.0;
+  }
+  return static_cast<double>(h.nJ) / h.volume;
+}
+
+double shellIntegral(double rhoJ, double g, double r0, double r1) {
+  return 4.0 * gen::pi * rhoJ * g * (r1 * r1 * r1 - r0 * r0 * r0) / 3.0;
+}
+
+} // namespace
+
+/**
+ * @details Discrete running integral 4 pi rho_J int_0^r s^2 g(s) ds
+ *  with rho_J = nJ / volume. Each bin is a spherical shell of width
+ *  binwidth, the same shell used to normalize g. The value at bin i
+ *  is the CN at the outer edge of that bin. Unlike I-J with one
+ *  unordered pair therefore integrates to 1 / nI at rmax.
+ */
+std::vector<double> rdf::runningCN(const PartialRdf &h) {
+  std::vector<double> cn(h.g.size(), 0.0);
+  const double rhoJ = typeJDensity(h);
+  if (h.binwidth <= 0.0 || rhoJ == 0.0) {
+    return cn;
+  }
+  double acc = 0.0;
+  for (std::size_t i = 0; i < h.g.size(); ++i) {
+    const double r0 = h.binwidth * static_cast<double>(i);
+    const double r1 = h.binwidth * static_cast<double>(i + 1);
+    acc += shellIntegral(rhoJ, h.g[i], r0, r1);
+    cn[i] = acc;
+  }
+  return cn;
+}
+
+/**
+ * @details First local maximum of g, then the first local minimum after
+ *  that peak. A confirmed minimum needs a descent and a later rise.
+ *  Monotonic or empty histograms return -1. No default radius.
+ */
+int rdf::firstMinimumBin(const PartialRdf &h) {
+  const int n = static_cast<int>(h.g.size());
+  if (n < 3) {
+    return -1;
+  }
+  int i = 0;
+  while (i + 1 < n && h.g[static_cast<std::size_t>(i + 1)] >=
+                           h.g[static_cast<std::size_t>(i)]) {
+    ++i;
+  }
+  const int imax = i;
+  if (imax >= n - 1) {
+    return -1;
+  }
+  i = imax;
+  while (i + 1 < n && h.g[static_cast<std::size_t>(i + 1)] <=
+                           h.g[static_cast<std::size_t>(i)]) {
+    ++i;
+  }
+  if (i == imax || i + 1 >= n) {
+    return -1;
+  }
+  return i;
+}
+
+/**
+ * @details Site-site CN up to rMax. Partial last bins are cut at rMax.
+ *  rMax is a caller input; this function does not pick a first
+ *  minimum.
+ */
+double rdf::coordinationNumber(const PartialRdf &h, double rMax) {
+  const double rhoJ = typeJDensity(h);
+  if (rMax <= 0.0 || h.binwidth <= 0.0 || rhoJ == 0.0 || h.g.empty()) {
+    return 0.0;
+  }
+  double cn = 0.0;
+  for (std::size_t i = 0; i < h.g.size(); ++i) {
+    const double r0 = h.binwidth * static_cast<double>(i);
+    if (r0 >= rMax) {
+      break;
+    }
+    double r1 = h.binwidth * static_cast<double>(i + 1);
+    if (r1 > rMax) {
+      r1 = rMax;
+    }
+    cn += shellIntegral(rhoJ, h.g[i], r0, r1);
+  }
+  return cn;
+}

--- a/src/seams_cli.cpp
+++ b/src/seams_cli.cpp
@@ -10,6 +10,7 @@
 #include <mol_sys.hpp>
 #include <generic.hpp>
 #include <neighbours.hpp>
+#include <cluster.hpp>
 #include <density.hpp>
 #include <rdf.hpp>
 #include <seams_config.hpp>
@@ -400,6 +401,32 @@ int cmdPairs(std::ostream &os, Cloud &cloud, const site::Table &table) {
   return 0;
 }
 
+int cmdDomains(std::ostream &os, Cloud &cloud, double cutoff,
+               const site::Table &table, site::Kind subset) {
+  std::vector<bool> mask(static_cast<std::size_t>(cloud.nop), false);
+  for (const int i : site::indicesOf(cloud, table, subset)) {
+    if (i >= 0 && i < cloud.nop) {
+      mask[static_cast<std::size_t>(i)] = true;
+    }
+  }
+  const auto idxList = nneigh::getNewNeighbourListByIndex(cloud, cutoff);
+  std::vector<std::vector<int>> idList(idxList.size());
+  for (std::size_t i = 0; i < idxList.size(); ++i) {
+    idList[i].reserve(idxList[i].size());
+    for (const int idx : idxList[i]) {
+      if (idx >= 0 && idx < cloud.nop) {
+        idList[i].push_back(cloud.pts[static_cast<std::size_t>(idx)].atomID);
+      }
+    }
+  }
+  const auto d = clump::largestDomain(cloud, idList, mask);
+  const char *name =
+      subset == site::Kind::apolar ? "apolar" : "polar";
+  os << "subset " << name << " n " << d.subset << " largest " << d.largest
+     << " P " << d.percolation << "\n";
+  return 0;
+}
+
 int cmdDensityZ(std::ostream &os, Cloud &cloud, int typeI, int bins, int axis) {
   if (bins <= 0) {
     const int a = (axis >= 0 && axis <= 2) ? axis : 2;
@@ -566,6 +593,7 @@ int main(int argc, char *argv[]) {
   std::string typesFlag;
   std::string siteSpec;
   bool ionsFlag = false;
+  std::string subsetFlag;
   int rdfTypeI = 0;
   int rdfTypeJ = 0;
   bool typesSet = false;
@@ -667,6 +695,13 @@ int main(int argc, char *argv[]) {
                  .help("cn on ionCloud cage degree (needs --site)")
                  .handler([&]() { ionsFlag = true; }));
 
+  parser.add(Option("--subset")
+                 .argName("KIND")
+                 .help("domains subset: polar | apolar")
+                 .handler([&](std::string_view value) {
+                   subsetFlag = std::string(value);
+                 }));
+
   parser.add(Option("--bins")
                  .argName("N")
                  .help("Histogram bins (rdf: rmax/0.1; density-z: L/0.1)")
@@ -736,7 +771,7 @@ int main(int argc, char *argv[]) {
 
   parser.add(Positional("command")
                  .help("read | chill | chill-plus | cages | rdf | cn | pairs | "
-                       "density-z")
+                       "density-z | domains")
                  .occurs(zeroOrOneTime)
                  .handler([&](std::string_view value) { cmd = value; }));
 
@@ -845,6 +880,21 @@ int main(int argc, char *argv[]) {
     std::cerr << colorizer.error("cn --ions needs --site") << "\n";
     return 2;
   }
+  if (cmd == "domains" && siteSpec.empty()) {
+    std::cerr << colorizer.error("domains needs --site") << "\n";
+    return 2;
+  }
+  site::Kind domainKind = site::Kind::polar;
+  if (cmd == "domains") {
+    if (subsetFlag == "apolar" || subsetFlag == "tail") {
+      domainKind = site::Kind::apolar;
+    } else if (subsetFlag.empty() || subsetFlag == "polar") {
+      domainKind = site::Kind::polar;
+    } else {
+      std::cerr << colorizer.error("bad --subset (want polar|apolar)") << "\n";
+      return 2;
+    }
+  }
 
   auto runOne = [&](std::ostream &os, Cloud &cloud) {
     if (!familyFlag && family == site::Family::waterIce &&
@@ -886,6 +936,9 @@ int main(int argc, char *argv[]) {
     if (cmd == "density-z") {
       return cmdDensityZ(os, cloud, typeI, bins, densAxis);
     }
+    if (cmd == "domains") {
+      return cmdDomains(os, cloud, cutoff, siteTable, domainKind);
+    }
     os << colorizer.error("unknown command: ") << cmd << "\n";
     return 2;
   };
@@ -893,7 +946,7 @@ int main(int argc, char *argv[]) {
   const bool loadAll =
       cmd == "pairs" || (cmd == "cn" && ionsFlag) ||
       ((cmd == "rdf" || cmd == "cn") && typesSet && rdfTypeI != rdfTypeJ) ||
-      (cmd == "density-z" && typeI <= 0);
+      (cmd == "density-z" && typeI <= 0) || cmd == "domains";
   const int loadType = loadAll ? -1 : typeI;
 
   if (last <= 0 || last == frame) {

--- a/src/seams_cli.cpp
+++ b/src/seams_cli.cpp
@@ -10,6 +10,7 @@
 #include <mol_sys.hpp>
 #include <generic.hpp>
 #include <neighbours.hpp>
+#include <density.hpp>
 #include <rdf.hpp>
 #include <seams_config.hpp>
 #include <seams_input.hpp>
@@ -399,6 +400,23 @@ int cmdPairs(std::ostream &os, Cloud &cloud, const site::Table &table) {
   return 0;
 }
 
+int cmdDensityZ(std::ostream &os, Cloud &cloud, int typeI, int bins, int axis) {
+  if (bins <= 0) {
+    const int a = (axis >= 0 && axis <= 2) ? axis : 2;
+    const double span =
+        (static_cast<int>(cloud.box.size()) > a)
+            ? cloud.box[static_cast<std::size_t>(a)]
+            : 0.0;
+    bins = std::max(1, static_cast<int>(std::lround(span / 0.1)));
+  }
+  const auto d = site::densityZ(cloud, typeI, bins, axis);
+  os << "# z rho\n";
+  for (std::size_t i = 0; i < d.z.size(); ++i) {
+    os << d.z[i] << " " << d.rho[i] << "\n";
+  }
+  return 0;
+}
+
 int cmdRdf(std::ostream &os, Cloud &cloud, double rmax, int bins, int typeI,
            int typeJ) {
   if (bins <= 0) {
@@ -552,6 +570,8 @@ int main(int argc, char *argv[]) {
   int rdfTypeJ = 0;
   bool typesSet = false;
   int bins = 0;
+  int densAxis = 2;
+  std::string axisFlag;
 
   const char *progname = (argc ? argv[0] : "seams");
   Parser parser;
@@ -606,7 +626,8 @@ int main(int argc, char *argv[]) {
 
   parser.add(Option("--type", "-t")
                  .argName("I")
-                 .help("Atom type (0 guesses oxygen then type 1)")
+                 .help("Atom type (0 guesses oxygen then type 1; "
+                       "density-z: 0 is every atom)")
                  .handler([&](std::string_view value) {
                    typeI = parseIntegral<int>(value);
                  }));
@@ -648,9 +669,16 @@ int main(int argc, char *argv[]) {
 
   parser.add(Option("--bins")
                  .argName("N")
-                 .help("RDF histogram bins (default rmax/0.1)")
+                 .help("Histogram bins (rdf: rmax/0.1; density-z: L/0.1)")
                  .handler([&](std::string_view value) {
                    bins = parseIntegral<int>(value);
+                 }));
+
+  parser.add(Option("--axis")
+                 .argName("XYZ")
+                 .help("Histogram axis for density-z (x|y|z, default z)")
+                 .handler([&](std::string_view value) {
+                   axisFlag = std::string(value);
                  }));
 
   parser.add(Option("-k")
@@ -707,7 +735,8 @@ int main(int argc, char *argv[]) {
                  }));
 
   parser.add(Positional("command")
-                 .help("read | chill | chill-plus | cages | rdf | cn | pairs")
+                 .help("read | chill | chill-plus | cages | rdf | cn | pairs | "
+                       "density-z")
                  .occurs(zeroOrOneTime)
                  .handler([&](std::string_view value) { cmd = value; }));
 
@@ -765,6 +794,21 @@ int main(int argc, char *argv[]) {
   if (bins < 0) {
     std::cerr << colorizer.error("bad --bins (want N > 0)") << "\n";
     return 2;
+  }
+  if (!axisFlag.empty()) {
+    const auto axisView = trimView(axisFlag);
+    if (axisView == "x" || axisView == "X" || axisView == "0") {
+      densAxis = 0;
+    } else if (axisView == "y" || axisView == "Y" || axisView == "1") {
+      densAxis = 1;
+    } else if (axisView == "z" || axisView == "Z" || axisView == "2") {
+      densAxis = 2;
+    } else {
+      std::cerr << colorizer.error("bad --axis (want x|y|z)") << "\n";
+      std::cerr << colorizer.warning(parser.formatUsage(progname, colorizer))
+                << "\n";
+      return 2;
+    }
   }
 
   if (cmd.empty() || file.empty()) {
@@ -839,13 +883,17 @@ int main(int argc, char *argv[]) {
     if (cmd == "pairs") {
       return cmdPairs(os, cloud, siteTable);
     }
+    if (cmd == "density-z") {
+      return cmdDensityZ(os, cloud, typeI, bins, densAxis);
+    }
     os << colorizer.error("unknown command: ") << cmd << "\n";
     return 2;
   };
 
   const bool loadAll =
       cmd == "pairs" || (cmd == "cn" && ionsFlag) ||
-      ((cmd == "rdf" || cmd == "cn") && typesSet && rdfTypeI != rdfTypeJ);
+      ((cmd == "rdf" || cmd == "cn") && typesSet && rdfTypeI != rdfTypeJ) ||
+      (cmd == "density-z" && typeI <= 0);
   const int loadType = loadAll ? -1 : typeI;
 
   if (last <= 0 || last == frame) {

--- a/src/seams_cli.cpp
+++ b/src/seams_cli.cpp
@@ -13,6 +13,7 @@
 #include <rdf.hpp>
 #include <seams_config.hpp>
 #include <seams_input.hpp>
+#include <site.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -20,6 +21,7 @@
 #include <iostream>
 #include <map>
 #include <mutex>
+#include <set>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -230,6 +232,173 @@ int cmdRead(std::ostream &os, Cloud &cloud) {
   return 0;
 }
 
+site::Kind kindFromName(std::string_view name) {
+  if (name == "unspecified") {
+    return site::Kind::unspecified;
+  }
+  if (name == "cationHead") {
+    return site::Kind::cationHead;
+  }
+  if (name == "anion") {
+    return site::Kind::anion;
+  }
+  if (name == "tail") {
+    return site::Kind::tail;
+  }
+  if (name == "donorH") {
+    return site::Kind::donorH;
+  }
+  if (name == "acceptor") {
+    return site::Kind::acceptor;
+  }
+  if (name == "polar") {
+    return site::Kind::polar;
+  }
+  if (name == "apolar") {
+    return site::Kind::apolar;
+  }
+  if (name == "waterO") {
+    return site::Kind::waterO;
+  }
+  if (name == "waterH") {
+    return site::Kind::waterH;
+  }
+  if (name == "solvent") {
+    return site::Kind::solvent;
+  }
+  throw std::invalid_argument("unknown site kind '" + std::string(name) + "'");
+}
+
+site::Table parseSiteSpec(std::string_view spec, site::Family family) {
+  site::Table table;
+  table.family = family;
+  std::size_t start = 0;
+  while (start <= spec.size()) {
+    const std::size_t comma = spec.find(',', start);
+    const auto raw =
+        spec.substr(start, comma == std::string_view::npos
+                               ? std::string_view::npos
+                               : comma - start);
+    start = (comma == std::string_view::npos) ? spec.size() + 1 : comma + 1;
+    const auto token = trimView(raw);
+    if (token.empty()) {
+      continue;
+    }
+    const auto eq = token.find('=');
+    if (eq == std::string_view::npos) {
+      throw std::invalid_argument("site spec token '" + std::string(token) +
+                                  "' is not key=value");
+    }
+    const auto key = trimView(token.substr(0, eq));
+    const auto val = trimView(token.substr(eq + 1));
+    if (key.empty() || val.empty()) {
+      throw std::invalid_argument("site spec token '" + std::string(token) +
+                                  "' is not key=value");
+    }
+    if (key == "family") {
+      table.family = site::parseFamily(val);
+      continue;
+    }
+    int typeId = 0;
+    try {
+      typeId = parseIntegral<int>(key);
+    } catch (const ParsingException &) {
+      throw std::invalid_argument("site spec type '" + std::string(key) +
+                                  "' is not an integer");
+    }
+    table.typeToKind[typeId] = kindFromName(val);
+  }
+  return table;
+}
+
+void countIonTypes(const Cloud &ions, int &nCation, int &nAnion) {
+  nCation = 0;
+  nAnion = 0;
+  for (const auto &pt : ions.pts) {
+    if (pt.type == 1) {
+      ++nCation;
+    } else if (pt.type == 2) {
+      ++nAnion;
+    }
+  }
+}
+
+double meanCageDegree(const Cloud &ions, double cutoff) {
+  if (ions.nop == 0) {
+    return 0.0;
+  }
+  const auto nList = nneigh::neighList(cutoff, ions, 1, 2);
+  double sum = 0.0;
+  int nI = 0;
+  const int nRows = static_cast<int>(nList.size());
+  for (int i = 0; i < ions.nop; ++i) {
+    if (ions.pts[static_cast<std::size_t>(i)].type != 1) {
+      continue;
+    }
+    ++nI;
+    if (i >= nRows || nList[static_cast<std::size_t>(i)].empty()) {
+      continue;
+    }
+    sum += static_cast<double>(nList[static_cast<std::size_t>(i)].size() - 1);
+  }
+  return nI > 0 ? sum / static_cast<double>(nI) : 0.0;
+}
+
+int uniqueTypeCount(const Cloud &cloud) {
+  std::set<int> types;
+  for (const auto &pt : cloud.pts) {
+    types.insert(pt.type);
+  }
+  return static_cast<int>(types.size());
+}
+
+int cmdCn(std::ostream &os, Cloud &cloud, double cutoff, int typeI,
+          int typeJ) {
+  const int typI = typeOf(cloud, typeI);
+  const int typJ = typeJ > 0 ? typeJ : typI;
+  const auto nList = nneigh::neighListPair(cutoff, cloud, typI, typJ);
+  double sum = 0.0;
+  int nI = 0;
+  const int nRows = static_cast<int>(nList.size());
+  for (int i = 0; i < cloud.nop; ++i) {
+    if (cloud.pts[static_cast<std::size_t>(i)].type != typI) {
+      continue;
+    }
+    ++nI;
+    if (i >= nRows || nList[static_cast<std::size_t>(i)].empty()) {
+      continue;
+    }
+    sum += static_cast<double>(nList[static_cast<std::size_t>(i)].size() - 1);
+  }
+  const double degree = nI > 0 ? sum / static_cast<double>(nI) : 0.0;
+  os << "site-site types " << typI << " " << typJ << " cutoff " << cutoff
+     << " degree " << degree << " nI " << nI << "\n";
+  return 0;
+}
+
+int cmdCnIons(std::ostream &os, Cloud &cloud, double cutoff,
+              const site::Table &table) {
+  const auto ions = site::ionCloud(cloud, table);
+  int nCation = 0;
+  int nAnion = 0;
+  countIonTypes(ions, nCation, nAnion);
+  const double degree = meanCageDegree(ions, cutoff);
+  os << "cage ionCloud types 1 2 cutoff " << cutoff << " degree " << degree
+     << " nCation " << nCation << " nAnion " << nAnion << "\n";
+  return 0;
+}
+
+int cmdPairs(std::ostream &os, Cloud &cloud, const site::Table &table) {
+  const auto ions = site::ionCloud(cloud, table);
+  const auto pairs = nneigh::mutualNearestUnlike(ions, 1, 2);
+  int nCation = 0;
+  int nAnion = 0;
+  countIonTypes(ions, nCation, nAnion);
+  os << "contact-pair count " << pairs.size() << " nCation " << nCation
+     << " nAnion " << nAnion << "\n";
+  return 0;
+}
+
 int cmdRdf(std::ostream &os, Cloud &cloud, double rmax, int bins, int typeI,
            int typeJ) {
   if (bins <= 0) {
@@ -370,10 +539,15 @@ int main(int argc, char *argv[]) {
   double cutoff = cfg.cutoff;
   int k = cfg.k;
   std::string graph = cfg.graph;
+  site::Family family = cfg.family;
+  bool familyFlag = false;
+  std::string familyNameFlag;
   bool printConfig = false;
   std::string cmd;
   std::string file;
   std::string typesFlag;
+  std::string siteSpec;
+  bool ionsFlag = false;
   int rdfTypeI = 0;
   int rdfTypeJ = 0;
   bool typesSet = false;
@@ -446,10 +620,31 @@ int main(int argc, char *argv[]) {
 
   parser.add(Option("--types")
                  .argName("I,J")
-                 .help("Pair types for rdf (default I=J=--type)")
+                 .help("Pair types for rdf/cn (default I=J=--type)")
                  .handler([&](std::string_view value) {
                    typesFlag = std::string(value);
                  }));
+
+  parser.add(Option("--family")
+                 .argName("NAME")
+                 .help("Material family (default waterIce): waterIce, "
+                       "ionicLiquid, moltenSalt, des, electrolyte, "
+                       "confinedIL, confinedWater, networkFormer")
+                 .handler([&](std::string_view value) {
+                   familyNameFlag = std::string(value);
+                   familyFlag = true;
+                 }));
+
+  parser.add(Option("--site")
+                 .argName("SPEC")
+                 .help("Type-to-kind map for ionCloud (1=cationHead,2=anion)")
+                 .handler([&](std::string_view value) {
+                   siteSpec = std::string(value);
+                 }));
+
+  parser.add(Option("--ions")
+                 .help("cn on ionCloud cage degree (needs --site)")
+                 .handler([&]() { ionsFlag = true; }));
 
   parser.add(Option("--bins")
                  .argName("N")
@@ -512,7 +707,7 @@ int main(int argc, char *argv[]) {
                  }));
 
   parser.add(Positional("command")
-                 .help("read | chill | chill-plus | cages | rdf")
+                 .help("read | chill | chill-plus | cages | rdf | cn | pairs")
                  .occurs(zeroOrOneTime)
                  .handler([&](std::string_view value) { cmd = value; }));
 
@@ -537,6 +732,17 @@ int main(int argc, char *argv[]) {
   cfg.cutoff = cutoff;
   cfg.k = k;
   cfg.graph = graph;
+  if (familyFlag) {
+    try {
+      family = site::parseFamily(familyNameFlag);
+    } catch (const std::invalid_argument &e) {
+      std::cerr << colorizer.error(e.what()) << "\n";
+      std::cerr << colorizer.warning(parser.formatUsage(progname, colorizer))
+                << "\n";
+      return 2;
+    }
+  }
+  cfg.family = family;
   seams::cfg::exportEnviron(cfg);
 
   if (printConfig) {
@@ -570,7 +776,40 @@ int main(int argc, char *argv[]) {
     return 2;
   }
 
+  const bool iceCmd = cmd == "chill" || cmd == "chill-plus" ||
+                      cmd == "chill_plus" || cmd == "cages";
+  if (iceCmd && !site::iceScoreAllowed(family)) {
+    std::cerr << colorizer.error(site::refuseIceScore(family)) << "\n";
+    return 2;
+  }
+
+  site::Table siteTable;
+  siteTable.family = family;
+  if (!siteSpec.empty()) {
+    try {
+      siteTable = parseSiteSpec(siteSpec, family);
+    } catch (const std::exception &e) {
+      std::cerr << colorizer.error(e.what()) << "\n";
+      return 2;
+    }
+  }
+  if (cmd == "pairs" && siteSpec.empty()) {
+    std::cerr << colorizer.error("pairs needs --site") << "\n";
+    return 2;
+  }
+  if (cmd == "cn" && ionsFlag && siteSpec.empty()) {
+    std::cerr << colorizer.error("cn --ions needs --site") << "\n";
+    return 2;
+  }
+
   auto runOne = [&](std::ostream &os, Cloud &cloud) {
+    if (!familyFlag && family == site::Family::waterIce &&
+        uniqueTypeCount(cloud) > 2) {
+      std::cerr << colorizer.warning(
+                       "hint: more than two LAMMPS types; set --family "
+                       "(default waterIce)")
+                << "\n";
+    }
     if (cmd == "read") {
       return cmdRead(os, cloud);
     }
@@ -591,12 +830,23 @@ int main(int argc, char *argv[]) {
     if (cmd == "rdf") {
       return cmdRdf(os, cloud, cutoff, bins, rdfTypeI, rdfTypeJ);
     }
+    if (cmd == "cn") {
+      if (ionsFlag) {
+        return cmdCnIons(os, cloud, cutoff, siteTable);
+      }
+      return cmdCn(os, cloud, cutoff, rdfTypeI, rdfTypeJ);
+    }
+    if (cmd == "pairs") {
+      return cmdPairs(os, cloud, siteTable);
+    }
     os << colorizer.error("unknown command: ") << cmd << "\n";
     return 2;
   };
 
-  const int loadType =
-      (cmd == "rdf" && (typesSet ? rdfTypeI != rdfTypeJ : false)) ? -1 : typeI;
+  const bool loadAll =
+      cmd == "pairs" || (cmd == "cn" && ionsFlag) ||
+      ((cmd == "rdf" || cmd == "cn") && typesSet && rdfTypeI != rdfTypeJ);
+  const int loadType = loadAll ? -1 : typeI;
 
   if (last <= 0 || last == frame) {
     Cloud cloud = load(file, frame, loadType);
@@ -605,9 +855,7 @@ int main(int argc, char *argv[]) {
 
   std::mutex outMu;
   int rc = 0;
-  const int typeFilter = (cmd == "rdf" && typesSet && rdfTypeI != rdfTypeJ)
-                             ? 0
-                             : (typeI > 0 ? typeI : 0);
+  const int typeFilter = loadAll ? 0 : (typeI > 0 ? typeI : 0);
   sinp::forEachLammpsFrame(
       file, frame, last, typeFilter,
       [&](int /*fr*/, Cloud &cloud) {

--- a/src/seams_config.cpp
+++ b/src/seams_config.cpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <fstream>
 #include <stdexcept>
+#include <string>
 
 namespace seams::cfg {
 namespace {
@@ -101,6 +102,97 @@ int firstPositive(int a, int b) {
 
 } // namespace
 
+} // namespace seams::cfg
+
+namespace site {
+
+const char *familyName(Family f) {
+  switch (f) {
+  case Family::waterIce:
+    return "waterIce";
+  case Family::ionicLiquid:
+    return "ionicLiquid";
+  case Family::moltenSalt:
+    return "moltenSalt";
+  case Family::des:
+    return "des";
+  case Family::electrolyte:
+    return "electrolyte";
+  case Family::confinedIL:
+    return "confinedIL";
+  case Family::confinedWater:
+    return "confinedWater";
+  case Family::networkFormer:
+    return "networkFormer";
+  }
+  return "waterIce";
+}
+
+Family parseFamily(std::string_view name) {
+  if (name == "waterIce" || name == "water-ice" || name == "water_ice") {
+    return Family::waterIce;
+  }
+  if (name == "ionicLiquid" || name == "ionic-liquid" ||
+      name == "ionic_liquid" || name == "il") {
+    return Family::ionicLiquid;
+  }
+  if (name == "moltenSalt" || name == "molten-salt" ||
+      name == "molten_salt") {
+    return Family::moltenSalt;
+  }
+  if (name == "des") {
+    return Family::des;
+  }
+  if (name == "electrolyte") {
+    return Family::electrolyte;
+  }
+  if (name == "confinedIL" || name == "confined-il" ||
+      name == "confined_il") {
+    return Family::confinedIL;
+  }
+  if (name == "confinedWater" || name == "confined-water" ||
+      name == "confined_water") {
+    return Family::confinedWater;
+  }
+  if (name == "networkFormer" || name == "network-former" ||
+      name == "network_former" || name == "network") {
+    return Family::networkFormer;
+  }
+  throw std::invalid_argument("unknown family '" + std::string(name) +
+                              "' (want waterIce, ionicLiquid, moltenSalt, "
+                              "des, electrolyte, confinedIL, confinedWater, "
+                              "networkFormer)");
+}
+
+bool iceScoreAllowed(Family f) { return f == Family::waterIce; }
+
+const char *refuseIceScore(Family f) {
+  switch (f) {
+  case Family::waterIce:
+    return "";
+  case Family::ionicLiquid:
+    return "CHILL/TUM refused for family ionicLiquid";
+  case Family::moltenSalt:
+    return "CHILL/TUM refused for family moltenSalt";
+  case Family::des:
+    return "CHILL/TUM refused for family des";
+  case Family::electrolyte:
+    return "CHILL/TUM refused for family electrolyte "
+           "(name a waterIce subset)";
+  case Family::confinedIL:
+    return "CHILL/TUM refused for family confinedIL";
+  case Family::confinedWater:
+    return "CHILL/TUM refused for family confinedWater";
+  case Family::networkFormer:
+    return "CHILL/TUM refused for family networkFormer";
+  }
+  return "CHILL/TUM refused";
+}
+
+} // namespace site
+
+namespace seams::cfg {
+
 std::string pathFromArgv(int argc, char **argv) {
   for (int i = 1; i < argc; ++i) {
     const std::string_view a(argv[i]);
@@ -181,6 +273,9 @@ Runtime load(std::string_view explicitFile) {
   if (const char *g = env("SEAMS_GRAPH")) {
     r.graph = g;
   }
+  if (const char *fam = env("SEAMS_FAMILY")) {
+    r.family = site::parseFamily(fam);
+  }
   r.resident = envDouble("SEAMS_RESIDENT", r.resident);
   r.cell = envDouble("SEAMS_CELL", r.cell);
   r.tpp = firstPositive(envInt("LINKCELL_TPP", 0), envInt("SEAMS_TPP", 0));
@@ -201,6 +296,7 @@ void exportEnviron(const Runtime &cfg) {
   putEnv("SEAMS_CUTOFF", std::to_string(cfg.cutoff), true);
   putEnv("SEAMS_K", std::to_string(cfg.k), true);
   putEnv("SEAMS_GRAPH", cfg.graph, true);
+  putEnv("SEAMS_FAMILY", site::familyName(cfg.family), true);
   putEnv("SEAMS_RESIDENT", std::to_string(cfg.resident), true);
   putEnv("SEAMS_CELL", std::to_string(cfg.cell), true);
   if (cfg.tpp > 0) {
@@ -228,6 +324,7 @@ void dump(const Runtime &cfg, std::ostream &os) {
   os << "SEAMS_CUTOFF=" << cfg.cutoff << "\n";
   os << "SEAMS_K=" << cfg.k << "\n";
   os << "SEAMS_GRAPH=" << cfg.graph << "\n";
+  os << "SEAMS_FAMILY=" << site::familyName(cfg.family) << "\n";
   os << "SEAMS_RESIDENT=" << cfg.resident << "\n";
   os << "SEAMS_CELL=" << cfg.cell << "\n";
   if (cfg.tpp > 0) {

--- a/src/site.cpp
+++ b/src/site.cpp
@@ -1,0 +1,169 @@
+//-----------------------------------------------------------------------------------
+// d-SEAMS - Deferred Structural Elucidation Analysis for Molecular Simulations
+// SPDX-License-Identifier: MIT
+//-----------------------------------------------------------------------------------
+
+#include <site.hpp>
+
+#include <generic.hpp>
+#include <mol_sys.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+#include <unordered_set>
+#include <utility>
+
+namespace site {
+
+namespace {
+
+using Cloud = molSys::PointCloud<molSys::Point<double>, double>;
+
+bool isIonKind(Kind k) {
+  return k == Kind::cationHead || k == Kind::anion;
+}
+
+bool matchesKind(Kind have, Kind want) {
+  if (want == Kind::polar) {
+    return have == Kind::cationHead || have == Kind::anion ||
+           have == Kind::polar;
+  }
+  if (want == Kind::apolar) {
+    return have == Kind::tail || have == Kind::apolar;
+  }
+  return have == want;
+}
+
+int indexOfAtom(const Cloud &src, int atomID) {
+  const auto it = src.idIndexMap.find(atomID);
+  if (it != src.idIndexMap.end()) {
+    return it->second;
+  }
+  const int n = static_cast<int>(src.pts.size());
+  for (int i = 0; i < n; ++i) {
+    if (src.pts[static_cast<std::size_t>(i)].atomID == atomID) {
+      return i;
+    }
+  }
+  return -1;
+}
+
+} // namespace
+
+Kind Table::of(const molSys::Point<double> &p) const {
+  if (const auto it = atomOverride.find(p.atomID); it != atomOverride.end()) {
+    return it->second;
+  }
+  return ofType(p.type);
+}
+
+Kind Table::ofType(int typeId) const {
+  if (const auto it = typeToKind.find(typeId); it != typeToKind.end()) {
+    return it->second;
+  }
+  return Kind::unspecified;
+}
+
+std::vector<int> indicesOf(const Cloud &yCloud, const Table &table,
+                           Kind kind) {
+  std::vector<int> out;
+  const int n = static_cast<int>(yCloud.pts.size());
+  out.reserve(static_cast<std::size_t>(n));
+  for (int i = 0; i < n; ++i) {
+    if (matchesKind(table.of(yCloud.pts[static_cast<std::size_t>(i)]), kind)) {
+      out.push_back(i);
+    }
+  }
+  return out;
+}
+
+int lammpsTypeOfKind(const Table &table, Kind kind) {
+  int found = 0;
+  int typeId = -1;
+  for (const auto &[id, mapped] : table.typeToKind) {
+    if (mapped == kind) {
+      ++found;
+      typeId = id;
+    }
+  }
+  if (found != 1) {
+    throw std::runtime_error("site kind does not map to a unique LAMMPS type");
+  }
+  return typeId;
+}
+
+Cloud ionCloud(const Cloud &src, const Table &table) {
+  Cloud out;
+  out.box = src.box;
+  out.boxLow = src.boxLow;
+  out.currentFrame = src.currentFrame;
+
+  auto &mutableSrc = const_cast<Cloud &>(src);
+  const auto molMap = molSys::createMolIDAtomIDMultiMap(mutableSrc);
+
+  std::vector<int> molOrder;
+  std::unordered_set<int> seenMol;
+  molOrder.reserve(src.pts.size());
+  for (const auto &pt : src.pts) {
+    if (seenMol.insert(pt.molID).second) {
+      molOrder.push_back(pt.molID);
+    }
+  }
+
+  for (const int molID : molOrder) {
+    std::vector<int> ions;
+    const auto range = molMap.equal_range(molID);
+    for (auto it = range.first; it != range.second; ++it) {
+      const int idx = indexOfAtom(src, it->second);
+      if (idx < 0) {
+        continue;
+      }
+      if (isIonKind(table.of(src.pts[static_cast<std::size_t>(idx)]))) {
+        ions.push_back(idx);
+      }
+    }
+    if (ions.empty()) {
+      continue;
+    }
+    std::sort(ions.begin(), ions.end());
+    const Kind ionKind = table.of(src.pts[static_cast<std::size_t>(ions.front())]);
+    ions.erase(std::remove_if(ions.begin(), ions.end(),
+                              [&](int idx) {
+                                return table.of(src.pts[static_cast<std::size_t>(
+                                           idx)]) != ionKind;
+                              }),
+               ions.end());
+    if (ions.empty()) {
+      continue;
+    }
+
+    molSys::Point<double> vertex = src.pts[static_cast<std::size_t>(ions.front())];
+    vertex.type = (ionKind == Kind::cationHead) ? 1 : 2;
+    vertex.molID = molID;
+    if (ions.size() > 1) {
+      const int ref = ions.front();
+      double sx = src.pts[static_cast<std::size_t>(ref)].x;
+      double sy = src.pts[static_cast<std::size_t>(ref)].y;
+      double sz = src.pts[static_cast<std::size_t>(ref)].z;
+      for (std::size_t k = 1; k < ions.size(); ++k) {
+        const auto dr = gen::relDist(src, ions[k], ref);
+        sx += src.pts[static_cast<std::size_t>(ref)].x + dr[0];
+        sy += src.pts[static_cast<std::size_t>(ref)].y + dr[1];
+        sz += src.pts[static_cast<std::size_t>(ref)].z + dr[2];
+      }
+      const double inv = 1.0 / static_cast<double>(ions.size());
+      vertex.x = sx * inv;
+      vertex.y = sy * inv;
+      vertex.z = sz * inv;
+    }
+
+    const int outIdx = static_cast<int>(out.pts.size());
+    out.idIndexMap[vertex.atomID] = outIdx;
+    out.pts.push_back(std::move(vertex));
+  }
+
+  out.nop = static_cast<int>(out.pts.size());
+  return out;
+}
+
+} // namespace site

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -16,6 +16,7 @@ test_sources = {
   'order_parameter': 'test_order_parameter.cpp',
   'rdf': 'test_rdf.cpp',
   'rdf2d': 'test_rdf2d.cpp',
+  'density': 'test_density.cpp',
   'selection': 'test_selection.cpp',
   'shapeMatch': 'test_shapeMatch.cpp',
   'topo_two_dim': 'test_topo_two_dim.cpp',

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -32,6 +32,7 @@ test_sources = {
   'cage_affiliation': 'test_cage_affiliation.cpp',
   'gpu_residency': 'test_gpu_residency.cpp',
   'config': 'test_config.cpp',
+  'site': 'test_site.cpp',
 }
 
 if readcon_dep.found()

--- a/tests/test_bond.cpp
+++ b/tests/test_bond.cpp
@@ -63,7 +63,8 @@ TEST_CASE("trimBonds on empty input returns empty", "[bond]") {
 
 TEST_CASE("populateBonds generates bonds from neighbour list", "[bond]") {
   auto cloud = makeSquareCloud();
-  // Build a neighbour list by index (not ID, since populateBonds expects index-based)
+  // Build a neighbour list by index (not ID, since populateBonds expects
+  // index-based)
   auto nList = nneigh::getNewNeighbourListByIndex(cloud, 1.5);
 
   auto bonds = bond::populateBonds(nList, cloud);
@@ -143,12 +144,13 @@ TEST_CASE("getHbondDistanceOH uses dump H on a mixed image", "[bond]") {
   hPoint.z = 1.0;
   hCloud.pts.push_back(hPoint);
   const double dist = bond::getHbondDistanceOH(oCloud, hCloud, 0, 0);
-  const double expect = std::sqrt(4.5 * 4.5 + 1.160254037844386 * 1.160254037844386);
+  const double expect =
+      std::sqrt(4.5 * 4.5 + 1.160254037844386 * 1.160254037844386);
   REQUIRE_THAT(dist, Catch::Matchers::WithinAbs(expect, 1e-10));
 }
 
-static molSys::Point<double> makeAtom(int atomID, int molID, double x,
-                                      double y, double z) {
+static molSys::Point<double> makeAtom(int atomID, int molID, double x, double y,
+                                      double z) {
   molSys::Point<double> p;
   p.atomID = atomID;
   p.molID = molID;
@@ -193,6 +195,10 @@ TEST_CASE("populateHbondsWithInputClouds accepts acceptor-first angle",
   REQUIRE(net[1].size() == 2);
   REQUIRE(net[0][1] == 2);
   REQUIRE(net[1][1] == 1);
+  const std::vector<std::vector<int>> donorHs = {{0, 1}, {2, 3}};
+  const auto donorNet = bond::populateHbondsFromDonors(oCloud, hCloud, nList,
+                                                       donorHs, 2.42, 30.0);
+  REQUIRE(donorNet == net);
 }
 
 TEST_CASE("populateHbondsWithInputClouds accepts a mixed-image dump-H bond",
@@ -235,6 +241,14 @@ TEST_CASE("populateHbondsWithInputClouds accepts a mixed-image dump-H bond",
   REQUIRE(net[1].size() == 2);
   REQUIRE(net[0][1] == 2);
   REQUIRE(net[1][1] == 1);
+  const std::vector<std::vector<int>> donorHs = {{0, 1}, {2, 3}};
+  const auto donorNet = bond::populateHbondsFromDonors(oCloud, hCloud, nList,
+                                                       donorHs, 2.42, 30.0);
+  REQUIRE(donorNet == net);
+  REQUIRE(
+      bond::donatedHydrogenBond(oCloud, hCloud, 1, 0, donorHs[0], 2.42, 30.0));
+  REQUIRE_THAT(gen::periodicDist(oCloud, 0, 1),
+               Catch::Matchers::WithinAbs(2.8, 1e-10));
 }
 
 TEST_CASE("populateBonds with cage iceType filters dummy atoms", "[bond]") {
@@ -245,8 +259,8 @@ TEST_CASE("populateBonds with cage iceType filters dummy atoms", "[bond]") {
   std::vector<cage::iceType> atomTypes(4, cage::iceType::dummy);
   auto bonds = bond::populateBonds(nList, cloud, atomTypes);
 
-  // With bondsBetweenDummy=false (default), bonds between dummy atoms are excluded
-  // So no bonds should be created
+  // With bondsBetweenDummy=false (default), bonds between dummy atoms are
+  // excluded So no bonds should be created
   REQUIRE(bonds.empty());
 }
 
@@ -267,7 +281,7 @@ TEST_CASE("populateBonds with non-dummy iceType creates bonds", "[bond]") {
 TEST_CASE("createBondsFromCages extracts bonds from cage rings", "[bond]") {
   // Minimal cage setup: a single HC cage has rings
   std::vector<std::vector<int>> rings = {{1, 2, 3, 4, 5, 6},
-                                          {7, 8, 9, 10, 11, 12}};
+                                         {7, 8, 9, 10, 11, 12}};
   cage::Cage cage1;
   cage1.type = cage::cageType::HexC;
   cage1.rings = {0, 1}; // Indices into rings
@@ -275,8 +289,8 @@ TEST_CASE("createBondsFromCages extracts bonds from cage rings", "[bond]") {
   std::vector<cage::Cage> cageList = {cage1};
   int nRings = 0;
 
-  auto bonds = bond::createBondsFromCages(rings, cageList,
-                                           cage::cageType::HexC, nRings);
+  auto bonds =
+      bond::createBondsFromCages(rings, cageList, cage::cageType::HexC, nRings);
 
   REQUIRE(nRings == 2);
   REQUIRE(bonds.size() > 0);
@@ -290,8 +304,8 @@ TEST_CASE("populateHbonds detects hydrogen bonds from trajectory", "[bond]") {
 
   auto nList = nneigh::neighListO(3.5, yCloud, 2);
 
-  auto hBonds = bond::populateHbonds("traj/exampleTraj.lammpstrj", yCloud,
-                                      nList, 1, 1);
+  auto hBonds =
+      bond::populateHbonds("traj/exampleTraj.lammpstrj", yCloud, nList, 1, 1);
 
   REQUIRE(hBonds.size() == static_cast<size_t>(yCloud.nop));
   int bonded = 0;
@@ -370,6 +384,76 @@ TEST_CASE("H-bond thresholds are configurable", "[bond]") {
   REQUIRE(countEdges(looseNet) >= countEdges(waterNet));
 }
 
+TEST_CASE("populateHbondsFromDonors two-H rows match water fixture bonds",
+          "[bond]") {
+  molSys::PointCloud<molSys::Point<double>, double> oCloud;
+  oCloud = sinp::readLammpsTrjO("traj/exampleTraj.lammpstrj", 1, oCloud, 2);
+  REQUIRE(oCloud.nop > 0);
+
+  molSys::PointCloud<molSys::Point<double>, double> hCloud;
+  hCloud = sinp::readLammpsTrjO("traj/exampleTraj.lammpstrj", 1, hCloud, 1);
+  REQUIRE(hCloud.nop == 2 * oCloud.nop);
+
+  auto nList = nneigh::neighListO(3.5, oCloud, 2);
+  auto molList = molSys::hAtomMolList(hCloud, oCloud);
+  std::vector<std::vector<int>> donorHs(molList.size());
+  for (size_t i = 0; i < molList.size(); i++) {
+    if (molList[i].size() < 3) {
+      continue;
+    }
+    donorHs[i] = {molList[i][1], molList[i][2]};
+  }
+  REQUIRE_FALSE(donorHs.empty());
+
+  auto waterNet = bond::populateHbondsWithInputClouds(oCloud, hCloud, nList);
+  auto donorNet = bond::populateHbondsFromDonors(oCloud, hCloud, nList, donorHs,
+                                                 2.42, 30.0);
+  REQUIRE(donorNet == waterNet);
+  int bonded = 0;
+  for (const auto &row : waterNet) {
+    if (row.size() > 1) {
+      bonded++;
+    }
+  }
+  REQUIRE(bonded > 0);
+}
+
+TEST_CASE("populateHbondsFromDonors ignores a far third donor H", "[bond]") {
+  molSys::PointCloud<molSys::Point<double>, double> oCloud, hCloud;
+  oCloud.box = {10.0, 10.0, 10.0};
+  oCloud.boxLow = {0.0, 0.0, 0.0};
+  hCloud.box = oCloud.box;
+  hCloud.boxLow = oCloud.boxLow;
+  oCloud.pts.push_back(makeAtom(1, 1, 0.0, 0.0, 0.0));
+  oCloud.pts.push_back(makeAtom(2, 2, 2.8, 0.0, 0.0));
+  oCloud.nop = 2;
+  oCloud.idIndexMap[1] = 0;
+  oCloud.idIndexMap[2] = 1;
+  hCloud.pts.push_back(makeAtom(11, 1, 1.0, 0.0, 0.0));
+  hCloud.pts.push_back(makeAtom(12, 1, -0.96, 0.76, 0.0));
+  hCloud.pts.push_back(makeAtom(21, 2, 3.8, 0.0, 0.0));
+  hCloud.pts.push_back(makeAtom(22, 2, 2.8, 0.96, 0.0));
+  hCloud.pts.push_back(makeAtom(13, 1, 8.0, 8.0, 8.0));
+  hCloud.nop = 5;
+  const std::vector<std::vector<int>> nList = {{1, 2}, {2, 1}};
+  const auto waterNet =
+      bond::populateHbondsWithInputClouds(oCloud, hCloud, nList, 2.42, 30.0);
+  REQUIRE(waterNet[0].size() == 2);
+  REQUIRE(waterNet[1].size() == 2);
+  REQUIRE(waterNet[0][1] == 2);
+  REQUIRE(waterNet[1][1] == 1);
+  const std::vector<std::vector<int>> twoH = {{0, 1}, {2, 3}};
+  const auto twoHNet =
+      bond::populateHbondsFromDonors(oCloud, hCloud, nList, twoH, 2.42, 30.0);
+  REQUIRE(twoHNet == waterNet);
+  const std::vector<std::vector<int>> threeH = {{0, 1, 4}, {2, 3}};
+  const auto threeHNet =
+      bond::populateHbondsFromDonors(oCloud, hCloud, nList, threeH, 2.42, 30.0);
+  REQUIRE(threeHNet == waterNet);
+  REQUIRE_FALSE(bond::donatedHydrogenBond(oCloud, hCloud, 1, 0,
+                                          std::vector<int>{4}, 2.42, 30.0));
+}
+
 TEST_CASE("createBondsFromCages with no matching cage type returns empty",
           "[bond]") {
   std::vector<std::vector<int>> rings = {{1, 2, 3, 4, 5, 6}};
@@ -380,8 +464,8 @@ TEST_CASE("createBondsFromCages with no matching cage type returns empty",
   std::vector<cage::Cage> cageList = {cage1};
   int nRings = 0;
 
-  auto bonds = bond::createBondsFromCages(rings, cageList,
-                                           cage::cageType::HexC, nRings);
+  auto bonds =
+      bond::createBondsFromCages(rings, cageList, cage::cageType::HexC, nRings);
 
   REQUIRE(nRings == 0);
 }

--- a/tests/test_cluster.cpp
+++ b/tests/test_cluster.cpp
@@ -7,6 +7,7 @@
 #include <mol_sys.hpp>
 #include <neighbours.hpp>
 #include <seams_input.hpp>
+#include <site.hpp>
 
 #include <cmath>
 #include <filesystem>
@@ -293,4 +294,112 @@ TEST_CASE("clusterAnalysis with Q6 on mW cubic trajectory", "[cluster]") {
   REQUIRE(iceCloud.nop > 0);
 
   std::error_code _ec_; std::filesystem::remove_all(tmpPath, _ec_);
+}
+
+namespace {
+
+using Cloud = molSys::PointCloud<molSys::Point<double>, double>;
+
+void addAtom(Cloud &cloud, int atomID, int molID, int type, double x, double y,
+             double z) {
+  molSys::Point<double> pt;
+  pt.atomID = atomID;
+  pt.molID = molID;
+  pt.type = type;
+  pt.x = x;
+  pt.y = y;
+  pt.z = z;
+  cloud.idIndexMap[atomID] = static_cast<int>(cloud.pts.size());
+  cloud.pts.push_back(pt);
+  cloud.nop = static_cast<int>(cloud.pts.size());
+}
+
+std::vector<bool> maskOf(const Cloud &cloud, const site::Table &table,
+                         site::Kind kind) {
+  std::vector<bool> mask(static_cast<std::size_t>(cloud.nop), false);
+  for (const int i : site::indicesOf(cloud, table, kind)) {
+    if (i >= 0 && i < cloud.nop) {
+      mask[static_cast<std::size_t>(i)] = true;
+    }
+  }
+  return mask;
+}
+
+} // namespace
+
+TEST_CASE("largestDomain polar star plus isolated polar", "[cluster]") {
+  site::Table table;
+  table.typeToKind[1] = site::Kind::cationHead;
+  table.typeToKind[2] = site::Kind::anion;
+  table.typeToKind[3] = site::Kind::tail;
+
+  Cloud cloud;
+  cloud.box = {100.0, 100.0, 100.0};
+  cloud.boxLow = {0.0, 0.0, 0.0};
+  cloud.currentFrame = 1;
+  addAtom(cloud, 1, 1, 1, 0.0, 0.0, 0.0);
+  addAtom(cloud, 2, 2, 1, 1.0, 0.0, 0.0);
+  addAtom(cloud, 3, 3, 2, 0.0, 1.0, 0.0);
+  addAtom(cloud, 4, 4, 2, 0.0, 0.0, 1.0);
+  addAtom(cloud, 5, 5, 1, 50.0, 50.0, 50.0);
+  addAtom(cloud, 6, 6, 3, 0.5, 0.5, 0.5);
+
+  const auto nList = nneigh::getNewNeighbourListByIndex(cloud, 1.5);
+  std::vector<std::vector<int>> idList(nList.size());
+  for (std::size_t i = 0; i < nList.size(); ++i) {
+    idList[i].reserve(nList[i].size());
+    for (const int idx : nList[i]) {
+      idList[i].push_back(cloud.pts[static_cast<std::size_t>(idx)].atomID);
+    }
+  }
+
+  const auto polar = clump::largestDomain(cloud, idList,
+                                          maskOf(cloud, table, site::Kind::polar));
+  REQUIRE(polar.subset == 5);
+  REQUIRE(polar.largest == 4);
+  REQUIRE_THAT(polar.percolation,
+               Catch::Matchers::WithinAbs(4.0 / 5.0, 1e-12));
+
+  const auto apolar = clump::largestDomain(
+      cloud, idList, maskOf(cloud, table, site::Kind::apolar));
+  REQUIRE(apolar.subset == 1);
+  REQUIRE(apolar.largest == 1);
+  REQUIRE_THAT(apolar.percolation, Catch::Matchers::WithinAbs(1.0, 1e-12));
+}
+
+TEST_CASE("largestDomain sheared MIC polar star", "[cluster]") {
+  site::Table table;
+  table.typeToKind[1] = site::Kind::cationHead;
+  table.typeToKind[2] = site::Kind::anion;
+  table.typeToKind[3] = site::Kind::tail;
+
+  Cloud cloud;
+  cloud.box = {15.0, 8.660254037844386, 10.0, 5.0, 0.0, 0.0};
+  cloud.boxLow = {0.0, 0.0, 0.0};
+  cloud.currentFrame = 1;
+  addAtom(cloud, 1, 1, 1, 0.2, 0.1, 1.0);
+  addAtom(cloud, 2, 2, 1, 9.7, 0.1, 1.0);
+  addAtom(cloud, 3, 3, 2, 0.2, 1.1, 1.0);
+  addAtom(cloud, 4, 4, 2, 0.2, 0.1, 2.0);
+  addAtom(cloud, 5, 5, 1, 5.0, 4.0, 5.0);
+  addAtom(cloud, 6, 6, 3, 7.0, 3.0, 4.0);
+
+  REQUIRE_THAT(gen::periodicDistSq(cloud, 0, 1),
+               Catch::Matchers::WithinAbs(0.25, 1e-9));
+
+  const auto nList = nneigh::getNewNeighbourListByIndex(cloud, 1.2);
+  std::vector<std::vector<int>> idList(nList.size());
+  for (std::size_t i = 0; i < nList.size(); ++i) {
+    idList[i].reserve(nList[i].size());
+    for (const int idx : nList[i]) {
+      idList[i].push_back(cloud.pts[static_cast<std::size_t>(idx)].atomID);
+    }
+  }
+
+  const auto polar = clump::largestDomain(
+      cloud, idList, maskOf(cloud, table, site::Kind::polar));
+  REQUIRE(polar.subset == 5);
+  REQUIRE(polar.largest == 4);
+  REQUIRE_THAT(polar.percolation,
+               Catch::Matchers::WithinAbs(4.0 / 5.0, 1e-12));
 }

--- a/tests/test_config.cpp
+++ b/tests/test_config.cpp
@@ -15,9 +15,9 @@ namespace {
 const char *kKeys[] = {
     "SEAMS_CONFIG",  "SEAMS_FRAME",    "SEAMS_LAST",     "SEAMS_JOBS",
     "SEAMS_TYPE",    "SEAMS_CUTOFF",   "SEAMS_K",        "SEAMS_GRAPH",
-    "SEAMS_RESIDENT", "SEAMS_CELL",    "SEAMS_TPP",      "SEAMS_BLOCK",
-    "SEAMS_OFFLOAD", "LINKCELL_TPP",   "LINKCELL_BLOCK", "YODA_FENNEL_PATH",
-    "YODA_LUA_PATH"};
+    "SEAMS_FAMILY",  "SEAMS_RESIDENT", "SEAMS_CELL",    "SEAMS_TPP",
+    "SEAMS_BLOCK",   "SEAMS_OFFLOAD", "LINKCELL_TPP",   "LINKCELL_BLOCK",
+    "YODA_FENNEL_PATH", "YODA_LUA_PATH"};
 
 struct EnvGuard {
   std::vector<std::pair<std::string, std::string>> saved;
@@ -62,6 +62,7 @@ TEST_CASE("defaults when the environment is empty") {
   REQUIRE(cfg.cutoff == 3.5);
   REQUIRE(cfg.k == 4);
   REQUIRE(cfg.graph == "seeded");
+  REQUIRE(cfg.family == site::Family::waterIce);
   REQUIRE(cfg.resident == 0.80);
   REQUIRE(cfg.cell == 3.0);
   REQUIRE(cfg.tpp == 0);
@@ -121,6 +122,49 @@ TEST_CASE("dump lists resolved keys") {
   const auto text = os.str();
   REQUIRE(text.find("SEAMS_JOBS=4") != std::string::npos);
   REQUIRE(text.find("SEAMS_GRAPH=seeded") != std::string::npos);
+}
+
+TEST_CASE("SEAMS_FAMILY fills the runtime table") {
+  EnvGuard g;
+  setenv("SEAMS_FAMILY", "ionicLiquid", 1);
+  const auto cfg = seams::cfg::load();
+  REQUIRE(cfg.family == site::Family::ionicLiquid);
+  REQUIRE_FALSE(site::iceScoreAllowed(cfg.family));
+}
+
+TEST_CASE("parseFamily accepts camelCase and kebab aliases") {
+  REQUIRE(site::parseFamily("waterIce") == site::Family::waterIce);
+  REQUIRE(site::parseFamily("water-ice") == site::Family::waterIce);
+  REQUIRE(site::parseFamily("ionicLiquid") == site::Family::ionicLiquid);
+  REQUIRE(site::parseFamily("il") == site::Family::ionicLiquid);
+  REQUIRE(site::parseFamily("moltenSalt") == site::Family::moltenSalt);
+  REQUIRE(site::parseFamily("des") == site::Family::des);
+  REQUIRE(site::parseFamily("electrolyte") == site::Family::electrolyte);
+  REQUIRE(site::parseFamily("confinedIL") == site::Family::confinedIL);
+  REQUIRE(site::parseFamily("confinedWater") == site::Family::confinedWater);
+  REQUIRE(site::parseFamily("networkFormer") == site::Family::networkFormer);
+  REQUIRE_THROWS_AS(site::parseFamily("not-a-family"), std::invalid_argument);
+}
+
+TEST_CASE("iceScoreAllowed is true only for waterIce") {
+  REQUIRE(site::iceScoreAllowed(site::Family::waterIce));
+  REQUIRE_FALSE(site::iceScoreAllowed(site::Family::ionicLiquid));
+  REQUIRE_FALSE(site::iceScoreAllowed(site::Family::moltenSalt));
+  REQUIRE_FALSE(site::iceScoreAllowed(site::Family::des));
+  REQUIRE_FALSE(site::iceScoreAllowed(site::Family::electrolyte));
+  REQUIRE_FALSE(site::iceScoreAllowed(site::Family::confinedIL));
+  REQUIRE_FALSE(site::iceScoreAllowed(site::Family::confinedWater));
+  REQUIRE_FALSE(site::iceScoreAllowed(site::Family::networkFormer));
+}
+
+TEST_CASE("refuseIceScore names the family") {
+  const std::string il = site::refuseIceScore(site::Family::ionicLiquid);
+  REQUIRE(il.find("ionicLiquid") != std::string::npos);
+  const std::string salt = site::refuseIceScore(site::Family::moltenSalt);
+  REQUIRE(salt.find("moltenSalt") != std::string::npos);
+  const std::string el = site::refuseIceScore(site::Family::electrolyte);
+  REQUIRE(el.find("electrolyte") != std::string::npos);
+  REQUIRE(std::string(site::familyName(site::Family::waterIce)) == "waterIce");
 }
 
 TEST_CASE("pathFromArgv reads --config") {

--- a/tests/test_density.cpp
+++ b/tests/test_density.cpp
@@ -76,7 +76,8 @@ TEST_CASE("tilted box uses det H face area not bound spans", "[density]") {
   const auto d = site::densityZ(cloud, 0, nbin, 2);
   const double dz = 10.0 / static_cast<double>(nbin);
   REQUIRE_THAT(integrateRho(d, area, dz), Catch::Matchers::WithinAbs(10.0, 1e-9));
-  REQUIRE(integrateRho(d, boundArea, dz) < 9.0);
+  REQUIRE_THAT(integrateRho(d, boundArea, dz),
+               Catch::Matchers::WithinAbs(10.0 * boundArea / area, 1e-9));
 }
 
 TEST_CASE("type 0 is every atom and type I filters", "[density]") {

--- a/tests/test_density.cpp
+++ b/tests/test_density.cpp
@@ -1,0 +1,115 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <density.hpp>
+#include <mol_sys.hpp>
+#include <neighbours.hpp>
+#include <site.hpp>
+
+#include <vector>
+
+namespace {
+
+using Cloud = molSys::PointCloud<molSys::Point<double>, double>;
+
+void addAtom(Cloud &cloud, int atomID, int type, double x, double y, double z) {
+  molSys::Point<double> pt;
+  pt.atomID = atomID;
+  pt.molID = atomID;
+  pt.type = type;
+  pt.x = x;
+  pt.y = y;
+  pt.z = z;
+  cloud.idIndexMap[atomID] = static_cast<int>(cloud.pts.size());
+  cloud.pts.push_back(pt);
+  cloud.nop = static_cast<int>(cloud.pts.size());
+}
+
+Cloud uniformZCloud(const std::vector<double> &box, int n, int type) {
+  Cloud cloud;
+  cloud.box = box;
+  cloud.boxLow = {0.0, 0.0, 0.0};
+  cloud.currentFrame = 1;
+  const double lz = box.size() > 2 ? box[2] : 0.0;
+  for (int i = 0; i < n; ++i) {
+    const double z = (static_cast<double>(i) + 0.5) * lz / static_cast<double>(n);
+    addAtom(cloud, i + 1, type, 1.0, 1.0, z);
+  }
+  return cloud;
+}
+
+double integrateRho(const site::DensityZ &d, double area, double dz) {
+  double acc = 0.0;
+  for (double rho : d.rho) {
+    acc += rho * area * dz;
+  }
+  return acc;
+}
+
+} // namespace
+
+TEST_CASE("uniform z histogram integrates to N on an ortho box", "[density]") {
+  auto cloud = uniformZCloud({10.0, 8.0, 20.0}, 10, 1);
+  const int nbin = 20;
+  const auto d = site::densityZ(cloud, 0, nbin, 2);
+  REQUIRE(d.z.size() == static_cast<std::size_t>(nbin));
+  REQUIRE(d.rho.size() == static_cast<std::size_t>(nbin));
+  REQUIRE(d.type == 0);
+  const double area = 10.0 * 8.0;
+  const double dz = 20.0 / static_cast<double>(nbin);
+  REQUIRE_THAT(integrateRho(d, area, dz), Catch::Matchers::WithinAbs(10.0, 1e-9));
+  REQUIRE_THAT(d.z.front(), Catch::Matchers::WithinAbs(0.5 * dz, 1e-12));
+}
+
+TEST_CASE("tilted box uses det H face area not bound spans", "[density]") {
+  auto cloud =
+      uniformZCloud({15.0, 8.660254037844386, 10.0, 5.0, 0.0, 0.0}, 10, 1);
+  const double vol = nneigh::dumpVolume(cloud);
+  double lengths[3] = {0.0, 0.0, 0.0};
+  nneigh::dumpCellLengths(cloud.box, cloud.boxLow, lengths);
+  const double area = vol / lengths[2];
+  const double boundArea = 15.0 * 8.660254037844386;
+  REQUIRE(area < boundArea - 1.0);
+  REQUIRE_THAT(area, Catch::Matchers::WithinAbs(lengths[0] * lengths[1], 1e-9));
+
+  const int nbin = 10;
+  const auto d = site::densityZ(cloud, 0, nbin, 2);
+  const double dz = 10.0 / static_cast<double>(nbin);
+  REQUIRE_THAT(integrateRho(d, area, dz), Catch::Matchers::WithinAbs(10.0, 1e-9));
+  REQUIRE(integrateRho(d, boundArea, dz) < 9.0);
+}
+
+TEST_CASE("type 0 is every atom and type I filters", "[density]") {
+  Cloud cloud;
+  cloud.box = {10.0, 10.0, 10.0};
+  cloud.boxLow = {0.0, 0.0, 0.0};
+  addAtom(cloud, 1, 1, 1.0, 1.0, 1.0);
+  addAtom(cloud, 2, 1, 1.0, 1.0, 3.0);
+  addAtom(cloud, 3, 2, 1.0, 1.0, 7.0);
+
+  const auto all = site::densityZ(cloud, 0, 10, 2);
+  REQUIRE_THAT(integrateRho(all, 100.0, 1.0), Catch::Matchers::WithinAbs(3.0, 1e-9));
+
+  const auto t1 = site::densityZ(cloud, 1, 10, 2);
+  REQUIRE(t1.type == 1);
+  REQUIRE_THAT(integrateRho(t1, 100.0, 1.0), Catch::Matchers::WithinAbs(2.0, 1e-9));
+
+  const auto t2 = site::densityZ(cloud, 2, 10, 2);
+  REQUIRE(t2.type == 2);
+  REQUIRE_THAT(integrateRho(t2, 100.0, 1.0), Catch::Matchers::WithinAbs(1.0, 1e-9));
+}
+
+TEST_CASE("kind histogram uses indicesOf", "[density]") {
+  Cloud cloud;
+  cloud.box = {10.0, 10.0, 10.0};
+  cloud.boxLow = {0.0, 0.0, 0.0};
+  addAtom(cloud, 1, 1, 1.0, 1.0, 2.0);
+  addAtom(cloud, 2, 2, 1.0, 1.0, 8.0);
+  site::Table table;
+  table.typeToKind[1] = site::Kind::cationHead;
+  table.typeToKind[2] = site::Kind::anion;
+
+  const auto heads = site::densityZ(cloud, table, site::Kind::cationHead, 10, 2);
+  REQUIRE_THAT(integrateRho(heads, 100.0, 1.0),
+               Catch::Matchers::WithinAbs(1.0, 1e-9));
+}

--- a/tests/test_neighbours.cpp
+++ b/tests/test_neighbours.cpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <stdexcept>
 #include <string>
+#include <tuple>
 #include <vector>
 
 // Helper: build a 4-atom system in a 10x10x10 box
@@ -707,6 +708,95 @@ TEST_CASE("tilt dump cutoff list finds the a-image pair", "[neighbours]") {
   cloud.box[3] = 4.0;
   skin.update(cloud);
   REQUIRE(skin.lastRebuilt());
+}
+
+// Type 1 / type 2 ion vertices (cation, anion). Not a cutoff shell.
+static molSys::PointCloud<molSys::Point<double>, double>
+makeFourIonCloud() {
+  molSys::PointCloud<molSys::Point<double>, double> cloud;
+  cloud.box = {20.0, 20.0, 20.0};
+  cloud.boxLow = {0.0, 0.0, 0.0};
+  cloud.nop = 4;
+  cloud.currentFrame = 1;
+  // 0 --1.0-- 1 --2.0-- 2 --3.0-- 3
+  // type 1    2         1         2
+  // Mutual nearest unlike: (0, 1). Ion 2's nearest unlike is 1,
+  // whose nearest type-1 is 0, so (2, 1) is not mutual.
+  const int types[4] = {1, 2, 1, 2};
+  const double x[4] = {0.0, 1.0, 3.0, 6.0};
+  const int atomIDs[4] = {10, 20, 30, 40};
+  for (int i = 0; i < 4; i++) {
+    molSys::Point<double> pt;
+    pt.type = types[i];
+    pt.atomID = atomIDs[i];
+    pt.molID = atomIDs[i];
+    pt.x = x[i];
+    pt.y = 0.0;
+    pt.z = 0.0;
+    cloud.pts.push_back(pt);
+    cloud.idIndexMap[pt.atomID] = i;
+  }
+  return cloud;
+}
+
+TEST_CASE("nearestUnlike on 2+2 ions has one mutual pair",
+          "[neighbours]") {
+  auto cloud = makeFourIonCloud();
+  const auto nearest = nneigh::nearestUnlike(cloud, 1, 2);
+  REQUIRE(nearest.size() == 2);
+  REQUIRE(std::get<0>(nearest[0]) == 0);
+  REQUIRE(std::get<1>(nearest[0]) == 1);
+  REQUIRE_THAT(std::get<2>(nearest[0]),
+               Catch::Matchers::WithinAbs(1.0, 1e-12));
+  REQUIRE(std::get<0>(nearest[1]) == 2);
+  REQUIRE(std::get<1>(nearest[1]) == 1);
+  REQUIRE_THAT(std::get<2>(nearest[1]),
+               Catch::Matchers::WithinAbs(2.0, 1e-12));
+
+  const auto pairs = nneigh::mutualNearestUnlike(cloud, 1, 2);
+  REQUIRE(pairs.size() == 1);
+  REQUIRE(pairs[0].first == 0);
+  REQUIRE(pairs[0].second == 1);
+}
+
+TEST_CASE("nearestUnlike picks the sheared a-image unlike ion",
+          "[neighbours]") {
+  molSys::PointCloud<molSys::Point<double>, double> cloud;
+  cloud.box = {15.0, 8.660254037844386, 10.0, 5.0, 0.0, 0.0};
+  cloud.boxLow = {0.0, 0.0, 0.0};
+  cloud.nop = 3;
+  // Type-1 at the origin side. Type-2 at 9.7 is the a-image partner
+  // (MIC 0.5). The decoy type-2 at 1.0 is closer in the unwrapped
+  // cell (0.8) and must not win.
+  const double coords[3][3] = {
+      {0.2, 0.1, 1.0}, {9.7, 0.1, 1.0}, {1.0, 0.1, 1.0}};
+  const int types[3] = {1, 2, 2};
+  for (int i = 0; i < 3; i++) {
+    molSys::Point<double> pt;
+    pt.type = types[i];
+    pt.atomID = i + 1;
+    pt.molID = i + 1;
+    pt.x = coords[i][0];
+    pt.y = coords[i][1];
+    pt.z = coords[i][2];
+    cloud.pts.push_back(pt);
+    cloud.idIndexMap[i + 1] = i;
+  }
+  REQUIRE_THAT(gen::periodicDistSq(cloud, 0, 1),
+               Catch::Matchers::WithinAbs(0.25, 1e-9));
+  REQUIRE(gen::periodicDistSq(cloud, 0, 2) > 0.25);
+
+  const auto nearest = nneigh::nearestUnlike(cloud, 1, 2);
+  REQUIRE(nearest.size() == 1);
+  REQUIRE(std::get<0>(nearest[0]) == 0);
+  REQUIRE(std::get<1>(nearest[0]) == 1);
+  REQUIRE_THAT(std::get<2>(nearest[0]),
+               Catch::Matchers::WithinAbs(0.5, 1e-9));
+
+  const auto pairs = nneigh::mutualNearestUnlike(cloud, 1, 2);
+  REQUIRE(pairs.size() == 1);
+  REQUIRE(pairs[0].first == 0);
+  REQUIRE(pairs[0].second == 1);
 }
 
 #ifdef SEAMS_HAS_LINKCELL

--- a/tests/test_rdf.cpp
+++ b/tests/test_rdf.cpp
@@ -73,3 +73,34 @@ TEST_CASE("partial RDF like-type does not count the unlike neighbour",
   const auto unlike = rdf::partialRdf(cloud, 1, 2, 6.0, 6);
   REQUIRE(unlike.count[5] == 1);
 }
+
+TEST_CASE("runningCN at rmax is one for a single I-J pair", "[rdf]") {
+  const double coords[2][3] = {{1.0, 1.0, 1.0}, {3.0, 1.0, 1.0}};
+  auto cloud = twoTypeCloud({10.0, 10.0, 10.0}, coords);
+  const auto gr = rdf::partialRdf(cloud, 1, 2, 5.0, 10);
+  REQUIRE(gr.nI == 1);
+  REQUIRE(gr.nJ == 1);
+  REQUIRE(gr.binwidth == 0.5);
+  REQUIRE(gr.count[4] == 1);
+  const auto cn = rdf::runningCN(gr);
+  REQUIRE(cn.size() == gr.g.size());
+  REQUIRE_THAT(cn[3], Catch::Matchers::WithinAbs(0.0, 1e-12));
+  REQUIRE_THAT(cn.back(), Catch::Matchers::WithinAbs(1.0, 1e-12));
+  REQUIRE_THAT(rdf::coordinationNumber(gr, 5.0),
+               Catch::Matchers::WithinAbs(1.0, 1e-12));
+  REQUIRE_THAT(rdf::coordinationNumber(gr, 1.5),
+               Catch::Matchers::WithinAbs(0.0, 1e-12));
+}
+
+TEST_CASE("firstMinimumBin finds the valley after the first peak", "[rdf]") {
+  rdf::PartialRdf h;
+  h.g = {0.1, 0.4, 2.0, 1.1, 0.3, 0.5, 1.6, 0.8};
+  REQUIRE(rdf::firstMinimumBin(h) == 4);
+
+  rdf::PartialRdf empty;
+  REQUIRE(rdf::firstMinimumBin(empty) == -1);
+
+  rdf::PartialRdf rising;
+  rising.g = {0.1, 0.2, 0.4, 0.8, 1.2};
+  REQUIRE(rdf::firstMinimumBin(rising) == -1);
+}

--- a/tests/test_site.cpp
+++ b/tests/test_site.cpp
@@ -1,0 +1,231 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <generic.hpp>
+#include <mol_sys.hpp>
+#include <site.hpp>
+
+#include <array>
+#include <cmath>
+#include <stdexcept>
+
+namespace {
+
+using Cloud = molSys::PointCloud<molSys::Point<double>, double>;
+
+Cloud makeCloud() {
+  Cloud cloud;
+  cloud.box = {10.0, 10.0, 10.0};
+  cloud.boxLow = {0.0, 0.0, 0.0};
+  cloud.currentFrame = 1;
+  return cloud;
+}
+
+void addAtom(Cloud &cloud, int atomID, int molID, int type, double x, double y,
+             double z) {
+  molSys::Point<double> pt;
+  pt.atomID = atomID;
+  pt.molID = molID;
+  pt.type = type;
+  pt.x = x;
+  pt.y = y;
+  pt.z = z;
+  cloud.idIndexMap[atomID] = static_cast<int>(cloud.pts.size());
+  cloud.pts.push_back(pt);
+  cloud.nop = static_cast<int>(cloud.pts.size());
+}
+
+} // namespace
+
+TEST_CASE("of override wins over type", "[site]") {
+  site::Table table;
+  table.typeToKind[1] = site::Kind::cationHead;
+  table.typeToKind[2] = site::Kind::anion;
+  table.atomOverride[17] = site::Kind::tail;
+
+  molSys::Point<double> head;
+  head.type = 1;
+  head.atomID = 3;
+  REQUIRE(table.of(head) == site::Kind::cationHead);
+  REQUIRE(table.ofType(1) == site::Kind::cationHead);
+
+  molSys::Point<double> overridden;
+  overridden.type = 1;
+  overridden.atomID = 17;
+  REQUIRE(table.of(overridden) == site::Kind::tail);
+  REQUIRE(table.ofType(1) == site::Kind::cationHead);
+
+  molSys::Point<double> unknown;
+  unknown.type = 9;
+  unknown.atomID = 99;
+  REQUIRE(table.of(unknown) == site::Kind::unspecified);
+  REQUIRE(table.ofType(9) == site::Kind::unspecified);
+}
+
+TEST_CASE("type 1 is not chemistry", "[site]") {
+  site::Table table;
+  REQUIRE(table.family == site::Family::waterIce);
+  REQUIRE(table.ofType(1) == site::Kind::unspecified);
+
+  molSys::Point<double> pt;
+  pt.type = 1;
+  pt.atomID = 1;
+  REQUIRE(table.of(pt) == site::Kind::unspecified);
+
+  table.family = site::Family::ionicLiquid;
+  REQUIRE(table.of(pt) == site::Kind::unspecified);
+
+  table.typeToKind[1] = site::Kind::waterO;
+  REQUIRE(table.of(pt) == site::Kind::waterO);
+
+  table.typeToKind[1] = site::Kind::cationHead;
+  REQUIRE(table.of(pt) == site::Kind::cationHead);
+}
+
+TEST_CASE("indicesOf polar is the cationHead anion polar union", "[site]") {
+  site::Table table;
+  table.typeToKind[1] = site::Kind::cationHead;
+  table.typeToKind[2] = site::Kind::anion;
+  table.typeToKind[3] = site::Kind::tail;
+  table.typeToKind[4] = site::Kind::polar;
+  table.typeToKind[5] = site::Kind::apolar;
+
+  auto cloud = makeCloud();
+  addAtom(cloud, 1, 1, 1, 1.0, 0.0, 0.0);
+  addAtom(cloud, 2, 2, 2, 2.0, 0.0, 0.0);
+  addAtom(cloud, 3, 1, 3, 3.0, 0.0, 0.0);
+  addAtom(cloud, 4, 1, 3, 4.0, 0.0, 0.0);
+  addAtom(cloud, 5, 3, 4, 5.0, 0.0, 0.0);
+  addAtom(cloud, 6, 4, 5, 6.0, 0.0, 0.0);
+
+  const auto polar = site::indicesOf(cloud, table, site::Kind::polar);
+  REQUIRE(polar.size() == 3);
+  REQUIRE(polar[0] == 0);
+  REQUIRE(polar[1] == 1);
+  REQUIRE(polar[2] == 4);
+
+  const auto apolar = site::indicesOf(cloud, table, site::Kind::apolar);
+  REQUIRE(apolar.size() == 3);
+  REQUIRE(apolar[0] == 2);
+  REQUIRE(apolar[1] == 3);
+  REQUIRE(apolar[2] == 5);
+
+  REQUIRE(site::indicesOf(cloud, table, site::Kind::cationHead).size() == 1);
+  REQUIRE(site::indicesOf(cloud, table, site::Kind::tail).size() == 2);
+}
+
+TEST_CASE("ionCloud two mols cation 3 atoms plus anion 1", "[site]") {
+  site::Table table;
+  table.typeToKind[1] = site::Kind::cationHead;
+  table.typeToKind[2] = site::Kind::anion;
+  table.typeToKind[3] = site::Kind::tail;
+  table.typeToKind[4] = site::Kind::donorH;
+
+  auto cloud = makeCloud();
+  // Cation mol: two heads split across the seam, plus a tail that must
+  // not enter the COM. Anion mol: one site.
+  addAtom(cloud, 10, 7, 1, 0.5, 1.0, 2.0);
+  addAtom(cloud, 11, 7, 1, 9.5, 1.0, 2.0);
+  addAtom(cloud, 12, 7, 3, 5.0, 4.0, 5.0);
+  addAtom(cloud, 20, 8, 2, 4.0, 5.0, 6.0);
+
+  const auto ions = site::ionCloud(cloud, table);
+  REQUIRE(ions.nop == 2);
+  REQUIRE(ions.box == cloud.box);
+  REQUIRE(ions.boxLow == cloud.boxLow);
+  REQUIRE(ions.currentFrame == cloud.currentFrame);
+
+  REQUIRE(ions.pts[0].type == 1);
+  REQUIRE(ions.pts[0].molID == 7);
+  REQUIRE(ions.pts[1].type == 2);
+  REQUIRE(ions.pts[1].molID == 8);
+  REQUIRE_THAT(ions.pts[1].x, Catch::Matchers::WithinAbs(4.0, 1e-12));
+  REQUIRE_THAT(ions.pts[1].y, Catch::Matchers::WithinAbs(5.0, 1e-12));
+  REQUIRE_THAT(ions.pts[1].z, Catch::Matchers::WithinAbs(6.0, 1e-12));
+
+  // First head at 0.5; second unwraps across L=10 to -0.5; COM x = 0.
+  // Tail at 5 is not averaged in.
+  REQUIRE_THAT(ions.pts[0].x, Catch::Matchers::WithinAbs(0.0, 1e-12));
+  REQUIRE_THAT(ions.pts[0].y, Catch::Matchers::WithinAbs(1.0, 1e-12));
+  REQUIRE_THAT(ions.pts[0].z, Catch::Matchers::WithinAbs(2.0, 1e-12));
+
+  const auto dr = gen::relDist(cloud, 1, 0);
+  const double handX = 0.5 * (cloud.pts[0].x + cloud.pts[0].x + dr[0]);
+  const double handY = 0.5 * (cloud.pts[0].y + cloud.pts[0].y + dr[1]);
+  const double handZ = 0.5 * (cloud.pts[0].z + cloud.pts[0].z + dr[2]);
+  REQUIRE_THAT(ions.pts[0].x, Catch::Matchers::WithinAbs(handX, 1e-12));
+  REQUIRE_THAT(ions.pts[0].y, Catch::Matchers::WithinAbs(handY, 1e-12));
+  REQUIRE_THAT(ions.pts[0].z, Catch::Matchers::WithinAbs(handZ, 1e-12));
+}
+
+TEST_CASE("ionCloud sheared box COM uses relDist not bound-span wrap",
+          "[site]") {
+  site::Table table;
+  table.typeToKind[1] = site::Kind::cationHead;
+
+  Cloud cloud;
+  cloud.box = {15.0, 8.660254037844386, 10.0, 5.0, 0.0, 0.0};
+  cloud.boxLow = {0.0, 0.0, 0.0};
+  cloud.currentFrame = 1;
+  addAtom(cloud, 1, 1, 1, 0.5, 0.5, 1.0);
+  addAtom(cloud, 2, 1, 1, 1.0, 8.0, 1.0);
+
+  const auto ions = site::ionCloud(cloud, table);
+  REQUIRE(ions.nop == 1);
+  REQUIRE(ions.pts[0].type == 1);
+  REQUIRE(ions.box == cloud.box);
+  REQUIRE(ions.boxLow == cloud.boxLow);
+
+  const auto dr = gen::relDist(cloud, 1, 0);
+  const double expectX = 0.5 * (cloud.pts[0].x + cloud.pts[0].x + dr[0]);
+  const double expectY = 0.5 * (cloud.pts[0].y + cloud.pts[0].y + dr[1]);
+  const double expectZ = 0.5 * (cloud.pts[0].z + cloud.pts[0].z + dr[2]);
+  REQUIRE_THAT(ions.pts[0].x, Catch::Matchers::WithinAbs(expectX, 1e-10));
+  REQUIRE_THAT(ions.pts[0].y, Catch::Matchers::WithinAbs(expectY, 1e-10));
+  REQUIRE_THAT(ions.pts[0].z, Catch::Matchers::WithinAbs(expectZ, 1e-12));
+
+  std::array<double, 3> span = {cloud.pts[1].x - cloud.pts[0].x,
+                                cloud.pts[1].y - cloud.pts[0].y,
+                                cloud.pts[1].z - cloud.pts[0].z};
+  for (int k = 0; k < 3; k++) {
+    span[k] -= cloud.box[static_cast<std::size_t>(k)] *
+               std::round(span[k] / cloud.box[static_cast<std::size_t>(k)]);
+  }
+  const double spanX = 0.5 * (cloud.pts[0].x + cloud.pts[0].x + span[0]);
+  const double spanY = 0.5 * (cloud.pts[0].y + cloud.pts[0].y + span[1]);
+  REQUIRE(std::abs(ions.pts[0].x - spanX) > 1.0);
+  REQUIRE(std::abs(expectX - spanX) > 1.0);
+  (void)spanY;
+}
+
+TEST_CASE("ionCloud monatomic anion is a copy", "[site]") {
+  site::Table table;
+  table.typeToKind[2] = site::Kind::anion;
+
+  auto cloud = makeCloud();
+  addAtom(cloud, 20, 8, 2, 4.0, 5.0, 6.0);
+  cloud.pts[0].inSlice = false;
+
+  const auto ions = site::ionCloud(cloud, table);
+  REQUIRE(ions.nop == 1);
+  REQUIRE(ions.pts[0].type == 2);
+  REQUIRE(ions.pts[0].atomID == 20);
+  REQUIRE(ions.pts[0].molID == 8);
+  REQUIRE_THAT(ions.pts[0].x, Catch::Matchers::WithinAbs(4.0, 1e-12));
+  REQUIRE_THAT(ions.pts[0].y, Catch::Matchers::WithinAbs(5.0, 1e-12));
+  REQUIRE_THAT(ions.pts[0].z, Catch::Matchers::WithinAbs(6.0, 1e-12));
+  REQUIRE(ions.pts[0].inSlice == false);
+  REQUIRE(ions.pts[0].iceType == cloud.pts[0].iceType);
+}
+
+TEST_CASE("lammpsTypeOfKind errors when the kind is not unique", "[site]") {
+  site::Table table;
+  table.typeToKind[1] = site::Kind::cationHead;
+  table.typeToKind[2] = site::Kind::anion;
+  table.typeToKind[3] = site::Kind::cationHead;
+  REQUIRE(site::lammpsTypeOfKind(table, site::Kind::anion) == 2);
+  REQUIRE_THROWS_AS(site::lammpsTypeOfKind(table, site::Kind::cationHead),
+                    std::runtime_error);
+  REQUIRE_THROWS_AS(site::lammpsTypeOfKind(table, site::Kind::tail),
+                    std::runtime_error);
+}


### PR DESCRIPTION
# Description

v2.4.0 already recovers dump H for cutoff and k-NN lists. This branch finishes the leftover writers and unwraps, then adds the first IL/network-liquid surface that does not invent an ice score.

Dump and LAMMPS data writers emit xy xz yz from recovered lx,ly,lz, not bound spans. Nanotube axial wrap, prism height, and cluster recenter invert dump H. The leftover qlmOneAtom path packs into the Dr kernel and does not wrap. The Highway batch stays orthorhombic; tilted callers skip it.

IL support is species-restricted graphs on that same MIC. site::Table maps LAMMPS types to kinds. ionCloud is one COM vertex per ion molID. rdf::partialRdf / runningCN / firstMinimumBin are site-site g_IJ and the integral CN. populateHbondsFromDonors takes an explicit H list; water 2.42 A / 30 deg is unchanged. nearestUnlike / mutualNearestUnlike are contact pairs on an ion cloud, not cage CN. largestDomain is Stoddard on a polar or apolar mask. densityZ is type-resolved rho(z).

CLI: --family (default waterIce). chill / chill-plus / cages exit 2 on ionicLiquid, moltenSalt, des, confinedIL, confinedWater, networkFormer, and electrolyte. seams rdf, cn, pairs, density-z, and domains. Unflagged seams chill on a water dump is unchanged.

# Changes

- dump/data tilt headers; axial wrap; cluster recenter; qlmOneAtom Dr pack
- site::Table, ionCloud, densityZ
- rdf runningCN / firstMinimumBin / coordinationNumber
- populateHbondsFromDonors
- nearestUnlike / mutualNearestUnlike
- largestDomain; seams domains --subset polar|apolar
- --family ice-score gate; seams rdf / cn / pairs / density-z
- howtos: sheared-cells, ionic-liquid

# Test plan

- meson test cluster neighbours rdf density site bond (dump-H and IL fixtures)
- seams chill --family ionicLiquid exits 2
- seams chill exampleTraj still labels the mixed TIP4P frame
- seams domains without --site exits 2
