### PR TITLE
chore: cut 2.5.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,19 @@ Changelog
 Unreleased
 ==========
 
+Version 2.5.0 (2026-08-16)
+===========================
+
+``--family`` (default ``waterIce``) is an input. Ice scores refuse
+non-water families and name the family. ``seams cn --ions`` is cage
+degree on ``site::ionCloud``; ``seams pairs`` is the mutual-nearest
+contact-pair count, not ionicity. ``seams domains`` is the largest
+polar or apolar Stoddard component. ``seams density-z`` is type-resolved
+``rho(z)`` with slab volume from dump H. Running CN and the first
+minimum of ``g_IJ`` come from ``rdf::runningCN`` /
+``firstMinimumBin``. Dump writers emit ``xy, xz, yz`` when the cloud
+carries tilt.
+
 Version 2.4.0 (2026-08-16)
 ===========================
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "d-SEAMS: Deferred Structural Elucidation Analysis for Molecular Simulations"
 type: software
-version: "2.4.0"
+version: "2.5.0"
 date-released: "2026-08-16"
 license: MIT
 repository-code: "https://github.com/d-SEAMS/seams-core"

--- a/docs/newsfragments/cn-pairs-cli.feature
+++ b/docs/newsfragments/cn-pairs-cli.feature
@@ -1,3 +1,0 @@
-``seams cn FILE --types I,J`` prints the site-site neighbour-list degree.
-``seams cn FILE --ions --site`` prints cage degree on ``site::ionCloud``.
-``seams pairs FILE --site`` prints the mutual-nearest contact-pair count.

--- a/docs/newsfragments/density-z.feature
+++ b/docs/newsfragments/density-z.feature
@@ -1,2 +1,0 @@
-Type-resolved ``rho(z)`` via ``site::densityZ`` and ``seams density-z``.
-Slab volume is ``A_perp * dz`` from dump H (recovered ``lx, ly, lz``).

--- a/docs/newsfragments/family-gate.feature
+++ b/docs/newsfragments/family-gate.feature
@@ -1,5 +1,0 @@
-``--family NAME`` (default ``waterIce``) is an input, not an inference.
-``seams chill``, ``chill-plus``, and ``cages`` exit 2 when the family is
-``ionicLiquid``, ``moltenSalt``, ``des``, ``electrolyte``, ``confinedIL``,
-``confinedWater``, or ``networkFormer``. The refusal names the family.
-Unflagged ``seams chill`` stays the historical water path.

--- a/docs/newsfragments/gpu-resident-ice.feature
+++ b/docs/newsfragments/gpu-resident-ice.feature
@@ -1,5 +1,0 @@
-The optional gpulite path keeps a batch of frames on the device and
-runs the TUM ice score there: the cell list, mutual four-nearest
-graph, primitive six-rings and the HC/DDC affiliation predicates.
-CHILL and :math:`q_{lm}` stay on the host. Only the cage labels come
-back.

--- a/docs/newsfragments/hbond-donors.feature
+++ b/docs/newsfragments/hbond-donors.feature
@@ -1,5 +1,0 @@
-Hydrogen bonds accept an explicit per-heavy donor-H list
-(``populateHbondsFromDonors``). Water ``populateHbonds*`` keep
-the two-hydrogen ``hAtomMolList`` path and the 2.42 A / 30 deg
-defaults. Callers pass ``(r, theta)`` from that trajectory's
-site-site RDF.

--- a/docs/newsfragments/ira-sofi.feature
+++ b/docs/newsfragments/ira-sofi.feature
@@ -1,1 +1,0 @@
-Optional IRA/SOFI backend for permutation-aware cage and prism matching (Gunde et al.). Horn remains the fallback when libira is not linked.

--- a/docs/newsfragments/linkcell-knn.feature
+++ b/docs/newsfragments/linkcell-knn.feature
@@ -1,1 +1,0 @@
-k-nearest graphs use the linkcell library (periodic linked-cell walk, Meson wrap).

--- a/docs/newsfragments/mic-leftovers.bugfix
+++ b/docs/newsfragments/mic-leftovers.bugfix
@@ -1,3 +1,0 @@
-Pair distances and leftover wraps use the dump minimum image,
-not an independent-axis wrap on bound spans. Dump writers emit
-xy, xz, yz when the cloud carries tilt.

--- a/docs/newsfragments/polar-apolar-domains.feature
+++ b/docs/newsfragments/polar-apolar-domains.feature
@@ -1,3 +1,0 @@
-``seams domains`` reports the largest polar or apolar Stoddard
-cluster and ``P_inf = N_largest / N_subset``. The walk uses a
-``site::indicesOf`` mask; it does not run CHILL or q6.

--- a/docs/newsfragments/rdf-running-cn.feature
+++ b/docs/newsfragments/rdf-running-cn.feature
@@ -1,1 +1,0 @@
-Running 3D site-site CN from `rdf::PartialRdf`: `runningCN`, `firstMinimumBin`, and `coordinationNumber` (`4 pi rho_J int s^2 g ds`, `rho_J = nJ / volume`).

--- a/docs/newsfragments/site-table.feature
+++ b/docs/newsfragments/site-table.feature
@@ -1,3 +1,0 @@
-Site chemistry is a ``site::Table`` of LAMMPS types and optional atom-ID
-overrides, not an extension of ``atom_state_type``. ``site::ionCloud``
-collapses each cation or anion ``molID`` to one unwrapped COM vertex.

--- a/docs/newsfragments/sphericart-nauty.feature
+++ b/docs/newsfragments/sphericart-nauty.feature
@@ -1,1 +1,0 @@
-Optional sphericart host path for Cartesian Steinhardt Ylm, and optional nauty certificates for HC/DDC ring graphs.

--- a/docs/newsfragments/structure-desc.feature
+++ b/docs/newsfragments/structure-desc.feature
@@ -1,1 +1,0 @@
-Python Trajectory wrappers for template overlay, SOAP spectra, Voronoi features and a linear prototype classifier.

--- a/docs/newsfragments/tilt-fallback-skin.feature
+++ b/docs/newsfragments/tilt-fallback-skin.feature
@@ -1,3 +1,0 @@
-Cutoff fallbacks and the skin Verlet refresh use the dump 3x3
-minimum image, not a diagonal of bound spans. ``residentFrameCell``
-is the shared dump-to-device Cell helper.

--- a/docs/newsfragments/twelve-factor-config.feature
+++ b/docs/newsfragments/twelve-factor-config.feature
@@ -1,5 +1,0 @@
-Runtime knobs (cutoff, *k*, occupancy, residency) come from a
-twelve-factor stack: code defaults, an optional dotenv file
-(``SEAMS_CONFIG`` or ``./seams.env``), then the environment, then
-CLI flags. ``seams --print-config`` dumps the resolved table.
-The 2020 ``conf.yaml`` driver is not this layer.

--- a/docs/newsfragments/unlike-nearest.feature
+++ b/docs/newsfragments/unlike-nearest.feature
@@ -1,3 +1,0 @@
-Nearest unlike neighbour and mutual-nearest unlike pair on a typed
-ion cloud (``nneigh::nearestUnlike``, ``nneigh::mutualNearestUnlike``).
-The mutual edge is a contact pair, not first-shell membership.

--- a/docs/newsfragments/vesin-3x3-gpubatch.feature
+++ b/docs/newsfragments/vesin-3x3-gpubatch.feature
@@ -1,3 +1,0 @@
-Cutoff lists (vesin) take the LAMMPS dump 3x3, not a diagonal of
-bound spans. Device ice-score batches pass
-``lammpsBoxToLinkcell`` when the dump tilt is present.

--- a/docs/newsfragments/vesin-remaining-builders.feature
+++ b/docs/newsfragments/vesin-remaining-builders.feature
@@ -1,4 +1,0 @@
-``neighList``, ``halfNeighList``, and the in-plane RDF sampler
-use the vesin cell list (same helper as ``neighListO``). Brute
-force remains the fallback. The GPU ice-score workspace is
-unchanged.

--- a/docs/newsfragments/yoda-fennel.feature
+++ b/docs/newsfragments/yoda-fennel.feature
@@ -1,1 +1,0 @@
-The `yodaStruct` Lua and Fennel CLI lives in https://github.com/d-SEAMS/yodaStruct.

--- a/docs/newsfragments/yoda-struct-lua.feature
+++ b/docs/newsfragments/yoda-struct-lua.feature
@@ -1,1 +1,0 @@
-Restore the yodaStruct Lua CLI and register template overlay, SOAP and Voronoi descriptors next to CHILL and rings.

--- a/docs/orgmode/changelog.org
+++ b/docs/orgmode/changelog.org
@@ -7,6 +7,18 @@ The C++ engine is this repository. Python is ~pydseams~
 
 * Unreleased
 
+* 2.5.0
+
+~--family~ (default ~waterIce~) is an input. Ice scores refuse
+non-water families and name the family. ~seams cn --ions~ is cage
+degree on ~site::ionCloud~; ~seams pairs~ is the mutual-nearest
+contact-pair count, not ionicity. ~seams domains~ is the largest
+polar or apolar Stoddard component. ~seams density-z~ is
+type-resolved \(\rho(z)\) with slab volume from dump H. Running CN
+and the first minimum of \(g_{IJ}\) come from ~rdf::runningCN~ /
+~firstMinimumBin~. Dump writers emit ~xy, xz, yz~ when the cloud
+carries tilt.
+
 * 2.4.0
 
 Partial 3D site-site \(g_{IJ}(r)\) and coordination numbers under

--- a/docs/source/Doxyfile_seams.cfg
+++ b/docs/source/Doxyfile_seams.cfg
@@ -33,7 +33,7 @@ GENERATE_LATEX          = NO
 
 # Project Settings
 PROJECT_NAME            = "seams-core"
-PROJECT_NUMBER          = "v2.4.0"
+PROJECT_NUMBER          = "v2.5.0"
 PROJECT_BRIEF           = "libyodaLib, the C++ engine of d-SEAMS"
 
 # Doxygen Settings

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 #-----------------------------------------------------------------------------------
 
 project('seams-core', ['cpp', 'c'],
-  version: '2.4.0',
+  version: '2.5.0',
   default_options: ['warning_level=2', 'cpp_std=c++20'],
   meson_version: '>=1.3.0')
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "seams";
-  version = "2.2.0";
+  version = "2.5.0";
 
   src = lib.fileset.toSource {
     root = ./..;

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "seams-core"
-version = "2.4.0"
+version = "2.5.0"
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "osx-arm64"]
 authors = ["Rohit Goswami <rgoswami@ieee.org>"]

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -2,4 +2,4 @@
 directory = "docs/newsfragments"
 filename = "CHANGELOG.rst"
 name = "seams-core"
-version = "2.4.0"
+version = "2.5.0"


### PR DESCRIPTION
# Description

Cut 2.5.0. Changelog covers the family gate, ion-cloud pairs, polar/apolar domains, density-z, running CN, and dump writers that emit tilt. Version strings in meson, pixi, CITATION.cff, towncrier, Doxygen, and nix match.

# Test plan

- Docs job on this PR
- Tag v2.5.0 after merge so release.yml mints the GitHub release
