### PR TITLE
docs: pip install pydseamslib

### DIFF
--- a/docs/orgmode/howto/faq.org
+++ b/docs/orgmode/howto/faq.org
@@ -8,8 +8,8 @@
 * Where is Python?
 
 [[https://github.com/d-SEAMS/PydSEAMSlib][PydSEAMSlib]].
-~pip install pydseams~. ~import pydseamslib~ is an alias of
-~pydseams~. The compiled module is ~yoda~.
+~pip install pydseamslib~. ~import pydseams~. ~import pydseamslib~
+is an alias. The compiled module is ~yoda~.
 
 * Where is Lua / Fennel?
 

--- a/docs/orgmode/tutorials/bulk-ice.org
+++ b/docs/orgmode/tutorials/bulk-ice.org
@@ -156,7 +156,7 @@ repository does not install Python.
 - Unknown command, exit 2: the binary is ~seams~, not ~yodaStruct~.
   Commands are ~read~, ~chill~, ~chill-plus~, and ~cages~.
 - ~ModuleNotFoundError: pydseams~: this repo does not install Python.
-  ~pip install pydseams~.
+  ~pip install pydseamslib~.
 - Lua ~require("dseams")~: that module lives in yodaStruct.
 
 * Next steps


### PR DESCRIPTION
# Description

PydSEAMSlib 2.5.1 ships as the existing PyPI project `pydseamslib`. Install line in the FAQ and bulk-ice troubleshooting matches that. `import pydseams` is unchanged.

# Changes

- `docs/orgmode/howto/faq.org`
- `docs/orgmode/tutorials/bulk-ice.org`