### PR TITLE
fix(repro): stop configuring in-tree Python on the campaign

### DIFF
--- a/pixi.toml
+++ b/pixi.toml
@@ -169,4 +169,3 @@ matplotlib-base = ">=3.8"
 
 [feature.repro.pypi-dependencies]
 snakemake = ">=8.0"
-pydseamslib = "==2.5.1"

--- a/pixi.toml
+++ b/pixi.toml
@@ -169,3 +169,4 @@ matplotlib-base = ">=3.8"
 
 [feature.repro.pypi-dependencies]
 snakemake = ">=8.0"
+pydseamslib = "==2.5.1"

--- a/repro/Snakefile
+++ b/repro/Snakefile
@@ -78,7 +78,7 @@ rule setup_tip:
         bdir=TIP_BUILD,
     shell:
         "meson setup {params.bdir} --prefix=$CONDA_PREFIX --buildtype=release "
-        "-Dwith_python=true -Dwith_tests=true > {params.log} 2>&1"
+        "-Dwith_python=false -Dwith_tests=true > {params.log} 2>&1"
 
 
 rule build_tip:
@@ -107,13 +107,13 @@ rule identity_gate:
 
 
 rule install_python:
-    # The descriptor comparison imports the built bindings from the prefix
+    # Bindings are pydseamslib on PyPI, not this tree.
     input:
         R + "/tip-test.log",
     output:
         touch(R + "/py-install.done"),
     shell:
-        "meson install -C " + TIP_BUILD + " > /dev/null 2>&1"
+        "python -c 'import pydseams as ds; print(ds.__version__)'"
 
 
 rule build_base:

--- a/repro/elja_submit.sh
+++ b/repro/elja_submit.sh
@@ -23,6 +23,7 @@ case "${1:-}" in
 prep)
   cd "$ROOT"
   pixi install -e repro
+  pixi run -e repro -- python -m pip install --no-deps pydseamslib==2.5.1
   pixi run -e repro -- meson subprojects download || true
   git rev-parse HEAD > .tip_sha
   if [ ! -d "$BASE_TREE" ]; then


### PR DESCRIPTION
# Description

Elja job 1787775 died in \`meson setup\` because this tree errors on \`-Dwith_python=true\` (bindings are PydSEAMSlib). The campaign now configures \`-Dwith_python=false\` and the repro env imports \`pydseamslib==2.5.1\` from PyPI.

# Changes

- \`repro/Snakefile\` setup_tip / install_python
- \`pixi.toml\` repro feature