### PR TITLE
build: prefer FlexiBLAS for BLAS and LAPACK

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,6 +12,8 @@ dependencies:
   - catch2
   - liblapack
   - libblas
+  # Meson prefers FlexiBLAS when pkg-config finds it. These two are
+  # the conda-forge ABI packages (no FlexiBLAS build on that channel).
   - boost-cpp
   - cmake
   - meson

--- a/meson.build
+++ b/meson.build
@@ -49,9 +49,22 @@ _deps += m_dep
 eigen_dep = dependency('eigen3', version: '>=3.4.0', required: true)
 _deps += [eigen_dep]
 
-blas_dep = cppc.find_library('blas', required: true)
-lapack_dep = cppc.find_library('lapack', required: true)
-_deps += [blas_dep, lapack_dep]
+# Prefer FlexiBLAS (one wrapper for BLAS and LAPACK). The conda-forge
+# ABI packages still provide libblas/liblapack; those are the fallback
+# when pkg-config does not find FlexiBLAS.
+flexiblas_dep = dependency('flexiblas', required: false)
+if not flexiblas_dep.found()
+  flexiblas_dep = cppc.find_library('flexiblas', required: false)
+endif
+if flexiblas_dep.found()
+  _deps += flexiblas_dep
+  blas_backend = 'flexiblas'
+else
+  blas_dep = cppc.find_library('blas', required: true)
+  lapack_dep = cppc.find_library('lapack', required: true)
+  _deps += [blas_dep, lapack_dep]
+  blas_backend = 'blas+lapack'
+endif
 
 # Shared-memory parallelism. libstdc++ routes std::execution::par through TBB,
 # which conda-forge does not put in this environment, so a build relying on it
@@ -338,6 +351,7 @@ endif
 # formats are simply absent from the library, with nothing at run time
 # to say so.
 summary({
+  'BLAS/LAPACK': blas_backend,
   'SIMD distance kernel (hwy)': hwy_dep.found(),
   'Shared-memory parallelism (OpenMP)': openmp_found,
   'MPI atom split (Steinhardt)': mpi_found,

--- a/pixi.toml
+++ b/pixi.toml
@@ -8,6 +8,7 @@ authors = ["Rohit Goswami <rgoswami@ieee.org>"]
 [dependencies]
 compilers = ">=1.9.0,<2"
 eigen = "3.4.0.*"
+# conda-forge BLAS/LAPACK ABI. Meson prefers FlexiBLAS when present.
 libblas = ">=3.11.0,<4"
 liblapack = ">=3.11.0,<4"
 catch2 = ">=3.6.0,<4"

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   # add package specs to the `specs` list
   # use gcc or something local with spack install if needed
   # Typically not going to work on MacOS, remove that locally
-  specs: [eigen@3.4.0, openblas, catch2, ninja, meson, pkg-config, gcc@12.2]
+  specs: [eigen@3.4.0, flexiblas, catch2, ninja, meson, pkg-config, gcc@12.2]
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
Link FlexiBLAS when pkg-config or libflexiblas is present. Otherwise keep the conda-forge libblas/liblapack ABI packages.

conda-forge has no FlexiBLAS implementation today, so pixi and the environment file stay on those ABI names. Spack uses flexiblas.

Do not force-link -lblas -llapack -lgomp onto whatever backend the solver picks.