### PR TITLE
chore: cut 2.6.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,16 @@ Changelog
 Unreleased
 ==========
 
+Version 2.6.0 (2026-08-17)
+===========================
+
+Meson links FlexiBLAS when pkg-config or libflexiblas is present,
+and falls back to the conda-forge libblas/liblapack ABI packages.
+The reproducibility campaign no longer configures in-tree Python;
+bindings come from pydseamslib on PyPI. The nucleation notebook
+reads CageScore fields. Figshare Lua demos resolve example_lua
+from yodaStruct.
+
 Version 2.5.0 (2026-08-16)
 ===========================
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,7 +2,7 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "d-SEAMS: Deferred Structural Elucidation Analysis for Molecular Simulations"
 type: software
-version: "2.5.0"
+version: "2.6.0"
 date-released: "2026-08-16"
 license: MIT
 repository-code: "https://github.com/d-SEAMS/seams-core"

--- a/docs/orgmode/changelog.org
+++ b/docs/orgmode/changelog.org
@@ -7,6 +7,15 @@ The C++ engine is this repository. Python is ~pydseams~
 
 * Unreleased
 
+* 2.6.0
+
+Meson links FlexiBLAS when pkg-config or ~libflexiblas~ is present,
+and falls back to the conda-forge ~libblas~ / ~liblapack~ ABI
+packages. The reproducibility campaign no longer configures in-tree
+Python; bindings come from ~pydseamslib~ on PyPI. The nucleation
+notebook reads ~CageScore~ fields. Figshare Lua demos resolve
+~example_lua~ from yodaStruct.
+
 * 2.5.0
 
 ~--family~ (default ~waterIce~) is an input. Ice scores refuse

--- a/docs/source/Doxyfile_seams.cfg
+++ b/docs/source/Doxyfile_seams.cfg
@@ -33,7 +33,7 @@ GENERATE_LATEX          = NO
 
 # Project Settings
 PROJECT_NAME            = "seams-core"
-PROJECT_NUMBER          = "v2.5.0"
+PROJECT_NUMBER          = "v2.6.0"
 PROJECT_BRIEF           = "libyodaLib, the C++ engine of d-SEAMS"
 
 # Doxygen Settings

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 #-----------------------------------------------------------------------------------
 
 project('seams-core', ['cpp', 'c'],
-  version: '2.5.0',
+  version: '2.6.0',
   default_options: ['warning_level=2', 'cpp_std=c++20'],
   meson_version: '>=1.3.0')
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "seams";
-  version = "2.5.0";
+  version = "2.6.0";
 
   src = lib.fileset.toSource {
     root = ./..;

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "seams-core"
-version = "2.5.0"
+version = "2.6.0"
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "osx-arm64"]
 authors = ["Rohit Goswami <rgoswami@ieee.org>"]

--- a/towncrier.toml
+++ b/towncrier.toml
@@ -2,4 +2,4 @@
 directory = "docs/newsfragments"
 filename = "CHANGELOG.rst"
 name = "seams-core"
-version = "2.5.0"
+version = "2.6.0"


### PR DESCRIPTION
Cut 2.6.0. Meson prefers FlexiBLAS. The reproducibility campaign no longer configures in-tree Python.