### PR TITLE
fix(repro): run figshare Lua demos through require(dseams)

### DIFF
--- a/docs/newsfragments/figshare-lua-library.bugfix
+++ b/docs/newsfragments/figshare-lua-library.bugfix
@@ -1,0 +1,3 @@
+The reproducibility DAG builds yodaStruct as ``require("dseams")`` and
+runs the five figshare deposits through that library. There is no
+in-tree ``yodaStruct`` binary.

--- a/pixi.lock
+++ b/pixi.lock
@@ -1014,6 +1014,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-16-2.15.3-hca6bf5a_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libxml2-2.15.3-h49c6c72_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/libzlib-1.3.2-h25fd6f3_3.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/lua-5.4.8-h03e1676_1.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/matplotlib-base-3.11.1-py312h4c94fcb_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/multidict-6.7.1-py312h8a5da7c_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/ncurses-6.6-hdb14827_1.conda

--- a/pixi.toml
+++ b/pixi.toml
@@ -167,6 +167,7 @@ jupytext = ">=1.16"
 ipykernel = ">=6.0"
 papermill = ">=2.4"
 matplotlib-base = ">=3.8"
+lua = ">=5.4,<5.5"
 
 [feature.repro.pypi-dependencies]
 snakemake = ">=8.0"

--- a/repro/README.md
+++ b/repro/README.md
@@ -49,10 +49,11 @@ Datasets](https://figshare.com/projects/d-SEAMS_Datasets/73545). The DAG
 fetches those exact deposits (MD5-verified against figshare's records,
 `repro/scripts/figshare_demos.py`) and demonstrates on them twice over:
 
-- The published Lua workflows run unmodified with the current binary
-  (CHILL+ on the Ic lattice, the bulk topological criterion on the
-  crystallized end of the nucleation run, the quasi-one-dimensional
-  nanotube, the monolayer, and the in-plane 2D RDF).
+- The same five deposits run through `require("dseams")` in yodaStruct
+  (CHILL+ on the Ic lattice, cage affiliation on the crystallized end
+  of the nucleation run, prism analysis on the nanotube, ring analysis
+  on the monolayer, and the O--O RDF on the confined sheet). The 2020
+  `yodaStruct -c` driver is not in this tree.
 - The percent-format notebooks under `repro/notebooks/` rerun the same
   analyses through the `pydseamslib` Python bindings. Jupytext converts
   each source to ipynb and papermill executes it; execution is the

--- a/repro/Snakefile
+++ b/repro/Snakefile
@@ -25,6 +25,10 @@ BASE_TREE = config["base_tree"]
 BUILD = os.path.abspath(os.environ.get("SEAMS_BUILD_ROOT", "."))
 TIP_BUILD = os.path.join(BUILD, "build-repro")
 BASE_BUILD = os.path.join(BUILD, "build-base")
+YODA_ROOT = os.path.abspath(
+    os.environ.get("YODASTRUCT_ROOT", os.path.join("..", "yodaStruct"))
+)
+YODA_BUILD = os.path.join(BUILD, "build-yoda")
 
 
 def hq(cpus):
@@ -113,7 +117,7 @@ rule install_python:
     output:
         touch(R + "/py-install.done"),
     shell:
-        "python -c 'import pydseams as ds; print(ds.__version__)'"
+        "python -c 'import pydseams as ds; assert ds.__version__ == \"2.6.0\", ds.__version__'"
 
 
 rule build_base:
@@ -353,21 +357,49 @@ rule figshare_fetch:
         "python repro/scripts/figshare_demos.py fetch " + FIGSHARE_DIR
 
 
-rule figshare_demos:
-    # The five example workflows of the 1.0 paper on the exact figshare
-    # deposits they were published with; nonzero exit on any failed demo
+rule build_yoda:
+    # yodaStruct is require("dseams"), not an in-tree seams-core binary.
+    # Point its seams-core wrap at this tip so the Lua module links the
+    # same engine the benches just gated.
     input:
-        gate=R + "/tip-test.log",
+        R + "/tip-test.log",
+    output:
+        touch(R + "/yoda-build.done"),
+    params:
+        hq=lambda wc: hq(8),
+        yoda=YODA_ROOT,
+        bdir=YODA_BUILD,
+        tip=os.path.abspath("."),
+    shell:
+        r"""
+        test -d {params.yoda}/lua || {{ echo "YODASTRUCT_ROOT missing: {params.yoda}" >&2; exit 1; }}
+        mkdir -p {params.yoda}/subprojects
+        if [ -e {params.yoda}/subprojects/seams-core ] && [ ! -L {params.yoda}/subprojects/seams-core ]; then
+          rm -rf {params.yoda}/subprojects/seams-core
+        fi
+        ln -sfn {params.tip} {params.yoda}/subprojects/seams-core
+        meson setup {params.bdir} {params.yoda} --buildtype=release --wrap-mode=nodownload \
+          > repro/results/yoda-setup.log 2>&1
+        {params.hq} meson compile -C {params.bdir}
+        """
+
+
+rule figshare_demos:
+    # The five 1.0 figshare deposits through require("dseams"); nonzero
+    # exit on any failed demo
+    input:
+        yoda=R + "/yoda-build.done",
         traj=expand(FIGSHARE_DIR + "/{f}", f=FIGSHARE_FILES),
     output:
         R + "/figshare-demos/figshare-demos.json",
     params:
         hq=lambda wc: hq(4),
-        tbuild=TIP_BUILD,
+        yoda=YODA_ROOT,
+        bdir=YODA_BUILD,
     shell:
         "{params.hq} bash -c 'OMP_NUM_THREADS=4 "
         "python repro/scripts/figshare_demos.py demos "
-        "{params.tbuild}/yodaStruct " + FIGSHARE_DIR + " "
+        "{params.yoda} {params.bdir} " + FIGSHARE_DIR + " "
         + R + "/figshare-demos'"
 
 

--- a/repro/Snakefile
+++ b/repro/Snakefile
@@ -25,9 +25,17 @@ BASE_TREE = config["base_tree"]
 BUILD = os.path.abspath(os.environ.get("SEAMS_BUILD_ROOT", "."))
 TIP_BUILD = os.path.join(BUILD, "build-repro")
 BASE_BUILD = os.path.join(BUILD, "build-base")
-YODA_ROOT = os.path.abspath(
-    os.environ.get("YODASTRUCT_ROOT", os.path.join("..", "yodaStruct"))
-)
+def _yoda_root():
+    env = os.environ.get("YODASTRUCT_ROOT")
+    if env:
+        return os.path.abspath(env)
+    for cand in (os.path.join("..", "yodaStruct"), os.path.join("..", "yodaStruct-2.6")):
+        if os.path.isdir(os.path.join(cand, "lua")):
+            return os.path.abspath(cand)
+    return os.path.abspath(os.path.join("..", "yodaStruct"))
+
+
+YODA_ROOT = _yoda_root()
 YODA_BUILD = os.path.join(BUILD, "build-yoda")
 
 

--- a/repro/elja_submit.sh
+++ b/repro/elja_submit.sh
@@ -34,10 +34,14 @@ prep)
      meson subprojects download || true)
   # Compute nodes are offline; the figshare deposits download here
   pixi run -e repro -- python repro/scripts/figshare_demos.py fetch repro/figshare
-  # Lua module lives in yodaStruct; the tip tree no longer ships it
+  # Lua module lives in yodaStruct 2.x. A sibling named yodaStruct may
+  # be a symlink to the v1 baseline tree (example_lua only).
   YODA=${YODASTRUCT_ROOT:-$ROOT/../yodaStruct}
   if [ ! -d "$YODA/lua" ]; then
-    git clone --depth 1 --branch v2.6.0 https://github.com/d-SEAMS/yodaStruct.git "$YODA"
+    YODA=$ROOT/../yodaStruct-2.6
+    if [ ! -d "$YODA/lua" ]; then
+      git clone --depth 1 --branch v2.6.0 https://github.com/d-SEAMS/yodaStruct.git "$YODA"
+    fi
   fi
   mkdir -p "$YODA/subprojects"
   if [ -e "$YODA/subprojects/seams-core" ] && [ ! -L "$YODA/subprojects/seams-core" ]; then
@@ -64,10 +68,10 @@ submit)
 run)
   cd "$ROOT"
   mkdir -p repro/results
-  if [ -d "$ROOT/../yodaStruct/example_lua" ]; then
+  if [ -d "$ROOT/../yodaStruct/lua" ]; then
     export YODASTRUCT_ROOT=$ROOT/../yodaStruct
-  elif [ -d "$ROOT/../seams-base-repro/example_lua" ]; then
-    export YODASTRUCT_ROOT=$ROOT/../seams-base-repro
+  elif [ -d "$ROOT/../yodaStruct-2.6/lua" ]; then
+    export YODASTRUCT_ROOT=$ROOT/../yodaStruct-2.6
   fi
   # One HyperQueue server and one worker own the allocation; Snakemake
   # submits every heavy rule through it

--- a/repro/elja_submit.sh
+++ b/repro/elja_submit.sh
@@ -23,7 +23,7 @@ case "${1:-}" in
 prep)
   cd "$ROOT"
   pixi install -e repro
-  pixi run -e repro -- python -m pip install --no-deps pydseamslib==2.5.1
+  pixi run -e repro -- python -m pip install --no-deps pydseamslib==2.6.0
   pixi run -e repro -- meson subprojects download || true
   git rev-parse HEAD > .tip_sha
   if [ ! -d "$BASE_TREE" ]; then
@@ -34,11 +34,16 @@ prep)
      meson subprojects download || true)
   # Compute nodes are offline; the figshare deposits download here
   pixi run -e repro -- python repro/scripts/figshare_demos.py fetch repro/figshare
-  # Lua examples live in yodaStruct; the tip tree no longer ships them
+  # Lua module lives in yodaStruct; the tip tree no longer ships it
   YODA=${YODASTRUCT_ROOT:-$ROOT/../yodaStruct}
-  if [ ! -d "$YODA/example_lua" ]; then
-    git clone --depth 1 https://github.com/d-SEAMS/yodaStruct.git "$YODA"
+  if [ ! -d "$YODA/lua" ]; then
+    git clone --depth 1 --branch v2.6.0 https://github.com/d-SEAMS/yodaStruct.git "$YODA"
   fi
+  mkdir -p "$YODA/subprojects"
+  if [ -e "$YODA/subprojects/seams-core" ] && [ ! -L "$YODA/subprojects/seams-core" ]; then
+    rm -rf "$YODA/subprojects/seams-core"
+  fi
+  ln -sfn "$ROOT" "$YODA/subprojects/seams-core"
   export YODASTRUCT_ROOT=$YODA
   # HyperQueue is a single static binary
   if ! command -v hq > /dev/null; then

--- a/repro/lua/figshare_demo.lua
+++ b/repro/lua/figshare_demo.lua
@@ -1,0 +1,115 @@
+-- Figshare v1 deposits through require("dseams").
+-- Env: FIGSHARE_TRAJ, FIGSHARE_OUTDIR, FIGSHARE_FRAME (optional).
+-- Arg 1: demo key (chillPlus, bulkTopologicalCriterion, iceNanotube, monolayer, rdf2D).
+
+local dseams = require("dseams")
+local core = dseams.core
+
+local key = arg[1]
+local traj = os.getenv("FIGSHARE_TRAJ")
+local outdir = os.getenv("FIGSHARE_OUTDIR") or "."
+local frame = tonumber(os.getenv("FIGSHARE_FRAME") or "1")
+assert(key and traj, "usage: FIGSHARE_TRAJ=... lua run_demo.lua <key>")
+
+local function ntrue(t)
+  local n = 0
+  if t == nil then
+    return 0
+  end
+  for i = 1, #t do
+    if t[i] then
+      n = n + 1
+    end
+  end
+  return n
+end
+
+local function count_types(types)
+  local c = {}
+  for i = 1, #types do
+    local name = types[i]
+    c[name] = (c[name] or 0) + 1
+  end
+  return c
+end
+
+local function emit(fields)
+  local parts = {string.format("demo=%s", key)}
+  local keys = {}
+  for k in pairs(fields) do
+    keys[#keys + 1] = k
+  end
+  table.sort(keys)
+  for i = 1, #keys do
+    parts[#parts + 1] = string.format("%s=%s", keys[i], tostring(fields[keys[i]]))
+  end
+  print(table.concat(parts, " "))
+end
+
+if key == "chillPlus" then
+  local cloud = dseams.read(traj, {type = 1, frame = frame})
+  assert(cloud.nop > 0, "empty cloud")
+  local types = dseams.chill_plus(cloud, {cutoff = 3.5, type = 1})
+  local counts = count_types(types)
+  local cages = dseams.cages(cloud, {type = 1, cutoff = 5.0})
+  local n_ddc = ntrue(cages.ddc)
+  local n_hc = ntrue(cages.hc)
+  assert((counts.cubic or 0) == cloud.nop, "Ic lattice is not all cubic")
+  assert(n_ddc > 0 and n_hc == 0, "Ic cages are not all DDC")
+  emit({
+    nop = cloud.nop,
+    cubic = counts.cubic or 0,
+    n_ddc = n_ddc,
+    n_hc = n_hc,
+  })
+elseif key == "bulkTopologicalCriterion" then
+  local cloud = dseams.read(traj, {type = 1, frame = frame})
+  assert(cloud.nop > 0, "empty cloud")
+  local cages = dseams.cages(cloud, {type = 1, cutoff = 5.0})
+  local n_ddc = ntrue(cages.ddc)
+  local n_hc = ntrue(cages.hc)
+  assert(n_ddc + n_hc > 0, "crystallized frame has no cage labels")
+  emit({
+    nop = cloud.nop,
+    frame = frame,
+    n_ddc = n_ddc,
+    n_hc = n_hc,
+  })
+elseif key == "iceNanotube" then
+  local cloud = dseams.read(traj, {type = 2, frame = frame})
+  assert(cloud.nop > 0, "empty cloud")
+  local nList = dseams.neighbors(cloud, {cutoff = 3.5, type = 2})
+  local hbn = core.getHbondNetwork(traj, cloud, nList, frame, 1)
+  hbn = core.bondNetworkByIndex(cloud, hbn)
+  local rings = core.getPrimitiveRings(hbn, 6)
+  core.prismAnalysis(outdir .. "/", rings, hbn, cloud, 6, 1, frame, frame, false)
+  emit({nop = cloud.nop, n_rings = #rings})
+elseif key == "monolayer" then
+  local cloud = core.readLammpsTrjO(
+    traj, frame, 2, true, {0.0, 0.0, 0.0}, {50.0, 1000.0, 1000.0}
+  )
+  assert(cloud.nop > 250 and cloud.nop < 400, "slice did not select the sheet")
+  local nList = dseams.neighbors(cloud, {cutoff = 3.5, type = 2})
+  local hbn = core.getHbondNetwork(traj, cloud, nList, frame, 1)
+  hbn = core.bondNetworkByIndex(cloud, hbn)
+  local rings = core.getPrimitiveRings(hbn, 4)
+  core.ringAnalysis(outdir .. "/", rings, hbn, cloud, 4, 50.0 * 50.0, frame)
+  emit({nop = cloud.nop, n_rings = #rings})
+elseif key == "rdf2D" then
+  local cloud = core.readLammpsTrjO(
+    traj, frame, 2, true, {0.0, 0.0, 0.0}, {50.0, 1000.0, 1000.0}
+  )
+  assert(cloud.nop > 0, "empty cloud")
+  local rdf = core.calcRDF3D(cloud, 2, 2, 12.0, 80)
+  local gmax, rpeak = 0.0, 0.0
+  for i = 1, #rdf.g do
+    if rdf.r[i] < 4.0 and rdf.g[i] > gmax then
+      gmax = rdf.g[i]
+      rpeak = rdf.r[i]
+    end
+  end
+  assert(gmax > 1.5, "O-O first peak is missing")
+  emit({nop = cloud.nop, gmax = string.format("%.4f", gmax), rpeak = string.format("%.4f", rpeak)})
+else
+  error("unknown demo " .. tostring(key))
+end

--- a/repro/scripts/figshare_demos.py
+++ b/repro/scripts/figshare_demos.py
@@ -5,13 +5,14 @@ The d-SEAMS 1.0 paper (10.1021/acs.jcim.0c00031) demonstrated on five
 LAMMPS trajectories archived in the figshare project "d-SEAMS Datasets"
 (https://figshare.com/projects/d-SEAMS_Datasets/73545). This script
 fetches those exact deposits (MD5-verified against figshare's records)
-and runs each corresponding published example workflow, unmodified,
-with the current yoda binary.
+and runs each corresponding analysis through require("dseams") in
+yodaStruct.
 
 Subcommands (all paths relative to the repository root):
 
   fetch <trajdir>                       download + verify the deposits
-  demos <yoda> <trajdir> <outdir>       run the five example workflows (Lua CLI)
+  demos <yoda_src> <yoda_build> <trajdir> <outdir>
+                                        run the five deposits via require("dseams")
 
 The Python-bindings demonstrations live as percent-format notebooks
 under repro/notebooks/; jupytext converts them and papermill executes
@@ -21,7 +22,7 @@ import hashlib
 import json
 import os
 import pathlib
-import re
+import shutil
 import subprocess
 import sys
 import time
@@ -84,48 +85,26 @@ def example_lua_root():
     )
 
 
-# Each demo pairs a figshare trajectory with the example workflow that
-# consumed it in the 1.0 paper. The example_lua trees live in
-# https://github.com/d-SEAMS/yodaStruct . frame="last" retargets the
-# workflow at the final frame of the deposit (the crystallized end of
-# the nucleation run); frame=None keeps the example's own frame settings.
+# Each demo pairs a figshare trajectory with the 2.x Lua library
+# (require("dseams")). frame="last" is the crystallized end of the
+# nucleation run.
 DEMOS = [
-    {
-        "key": "chillPlus",
-        "config": "example_lua/chillPlus/config.yml",
-        "vars": "example_lua/chillPlus/iceType/vars.lua",
-        "traj": "chillplus",
-        "frame": None,
-    },
-    {
-        "key": "bulkTopologicalCriterion",
-        "config": "example_lua/bulkTopologicalCriterion/config.yml",
-        "vars": "example_lua/bulkTopologicalCriterion/iceType/vars.lua",
-        "traj": "nucleation",
-        "frame": "last",
-    },
-    {
-        "key": "iceNanotube",
-        "config": "example_lua/iceNanotube/strictCriterion/config.yml",
-        "vars": "example_lua/iceNanotube/strictCriterion/iceType/vars.lua",
-        "traj": "nanotube",
-        "frame": None,
-    },
-    {
-        "key": "monolayer",
-        "config": "example_lua/monolayer/config.yml",
-        "vars": "example_lua/monolayer/iceType/vars.lua",
-        "traj": "monolayer",
-        "frame": None,
-    },
-    {
-        "key": "rdf2D",
-        "config": "example_lua/rdf2D-example/config.yml",
-        "vars": "example_lua/rdf2D-example/iceType/vars.lua",
-        "traj": "rdf2d",
-        "frame": None,
-    },
+    {"key": "chillPlus", "traj": "chillplus", "frame": 1},
+    {"key": "bulkTopologicalCriterion", "traj": "nucleation", "frame": "last"},
+    {"key": "iceNanotube", "traj": "nanotube", "frame": 1},
+    {"key": "monolayer", "traj": "monolayer", "frame": 1},
+    {"key": "rdf2D", "traj": "rdf2d", "frame": 1},
 ]
+
+SCRIPT = pathlib.Path(__file__).resolve().parent.parent / "lua" / "figshare_demo.lua"
+
+
+def find_lua():
+    for name in ("lua5.4", "lua-5.4", "lua5.3", "lua"):
+        path = shutil.which(name)
+        if path:
+            return path
+    raise FileNotFoundError("lua 5.3/5.4 not on PATH; add lua to the repro env")
 
 def md5sum(path):
     h = hashlib.md5()
@@ -168,48 +147,12 @@ def count_frames(path):
     return n
 
 
-def patch_demo(demo, trajdir, rundir):
-    """Write the patched vars.lua and config.yml for one demo; return the
-    config path and the frame count of its trajectory."""
-    traj = (pathlib.Path(trajdir) / FILES[demo["traj"]]["name"]).resolve()
-    frames = count_frames(traj)
-    outrun = rundir / "run"
-    outrun.mkdir(parents=True, exist_ok=True)
-
-    lua_root = example_lua_root()
-    vtext = (lua_root / demo["vars"]).read_text()
-    vtext = re.sub(
-        r"^outDir\s*=.*$",
-        f'outDir="{outrun}/";',
-        vtext,
-        flags=re.M,
-    )
-    if demo["frame"] == "last":
-        vtext = re.sub(
-            r"^targetFrame\s*=.*$", f"targetFrame={frames};", vtext, flags=re.M
-        )
-        vtext = re.sub(
-            r"^finalFrame\s*=.*$", f"finalFrame={frames};", vtext, flags=re.M
-        )
-    vpath = rundir / "vars.lua"
-    vpath.write_text(vtext)
-
-    ctext = (lua_root / demo["config"]).read_text()
-    ctext = re.sub(
-        r'^trajectory:.*$', f'trajectory: "{traj}"', ctext, flags=re.M
-    )
-    ctext = re.sub(
-        r'^variables:.*$', f'variables: "{vpath}"', ctext, flags=re.M
-    )
-    cpath = rundir / "config.yml"
-    cpath.write_text(ctext)
-    return cpath, frames
-
-
 def summarize_run(outrun):
     """Inventory the files a demo produced; keep the last line of small
     text outputs so the manifest carries the headline numbers."""
     out = {}
+    if not outrun.is_dir():
+        return out
     for p in sorted(outrun.rglob("*")):
         if not p.is_file():
             continue
@@ -224,18 +167,37 @@ def summarize_run(outrun):
     return out
 
 
-def demos(yoda, trajdir, outdir):
+def demos(yoda_src, yoda_build, trajdir, outdir):
     outdir = pathlib.Path(outdir)
+    yoda_src = pathlib.Path(yoda_src).resolve()
+    yoda_build = pathlib.Path(yoda_build).resolve()
+    so = yoda_build / "dseams_core.so"
+    if not so.is_file():
+        sys.exit(f"missing {so}; build yodaStruct first")
+    if not SCRIPT.is_file():
+        sys.exit(f"missing {SCRIPT}")
+    lua = find_lua()
+    env = os.environ.copy()
+    env["LUA_PATH"] = str(yoda_src / "lua" / "?.lua") + ";;"
+    env["LUA_CPATH"] = str(yoda_build / "?.so") + ";;"
     results = {}
     for demo in DEMOS:
         key = demo["key"]
         rundir = outdir / key
-        cpath, frames = patch_demo(demo, trajdir, rundir)
+        rundir.mkdir(parents=True, exist_ok=True)
+        traj = (pathlib.Path(trajdir) / FILES[demo["traj"]]["name"]).resolve()
+        frames = count_frames(traj)
+        frame = frames if demo["frame"] == "last" else int(demo["frame"])
+        env["FIGSHARE_TRAJ"] = str(traj)
+        env["FIGSHARE_OUTDIR"] = str(rundir)
+        env["FIGSHARE_FRAME"] = str(frame)
         t0 = time.perf_counter()
         proc = subprocess.run(
-            [yoda, "-c", str(cpath)],
+            [lua, str(SCRIPT), key],
             capture_output=True,
             text=True,
+            env=env,
+            cwd=str(yoda_src),
         )
         secs = time.perf_counter() - t0
         (rundir / "stdout.log").write_text(proc.stdout)
@@ -244,12 +206,16 @@ def demos(yoda, trajdir, outdir):
             "trajectory": FILES[demo["traj"]]["name"],
             "doi": FILES[demo["traj"]]["doi"],
             "frames_in_deposit": frames,
+            "frame": frame,
             "returncode": proc.returncode,
             "seconds": round(secs, 2),
-            "outputs": summarize_run(rundir / "run"),
+            "stdout": proc.stdout.strip(),
+            "outputs": summarize_run(rundir),
         }
         status = "ok" if proc.returncode == 0 else f"rc={proc.returncode}"
         print(f"{key}: {status} in {secs:.1f}s", flush=True)
+        if proc.returncode != 0:
+            print(proc.stderr, file=sys.stderr)
     (outdir / "figshare-demos.json").write_text(
         json.dumps(results, indent=2, sort_keys=True) + "\n"
     )
@@ -262,8 +228,8 @@ def main():
     cmd = sys.argv[1] if len(sys.argv) > 1 else ""
     if cmd == "fetch" and len(sys.argv) == 3:
         fetch(sys.argv[2])
-    elif cmd == "demos" and len(sys.argv) == 5:
-        demos(sys.argv[2], sys.argv[3], sys.argv[4])
+    elif cmd == "demos" and len(sys.argv) == 6:
+        demos(sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5])
     else:
         sys.exit(__doc__)
 


### PR DESCRIPTION
## Summary

Elja 1788500 died on `figshare_demos` because the DAG still invoked `{build}/yodaStruct`, and 2.x does not ship that binary.

This builds yodaStruct as `dseams_core.so` against the tip engine and runs the five figshare deposits through `require("dseams")`. Prep installs `pydseamslib==2.6.0` and clones yodaStruct at `v2.6.0`.

Paper CPU numbers stay the 1788072 exclusive-node benches. This is the leftover Lua path.

## Test plan

- [ ] CI on this PR
- [ ] Elja leftover DAG: `figshare_demos` writes `repro/results/figshare-demos/figshare-demos.json` and `aggregate` emits `paper_manifest.json`