### PR TITLE
fix(repro): slice the monolayer dump on x only

### DIFF
--- a/repro/lua/figshare_demo.lua
+++ b/repro/lua/figshare_demo.lua
@@ -85,9 +85,10 @@ elseif key == "iceNanotube" then
   core.prismAnalysis(outdir .. "/", rings, hbn, cloud, 6, 1, frame, frame, false)
   emit({nop = cloud.nop, n_rings = #rings})
 elseif key == "monolayer" then
-  -- x in [0, 50]; equal y/z bounds leave those axes unconstrained
-  -- (same region as the Python monolayer notebook).
-  local cloud = core.readLammpsTrjO(
+  -- TypeInSlice, same region as the Python monolayer notebook:
+  -- x in [0, 50], equal y/z bounds leave those axes unconstrained.
+  -- readLammpsTrjO only flags inSlice and keeps every oxygen.
+  local cloud = core.readLammpsTrjreduced(
     traj, frame, 2, true, {0.0, 0.0, 0.0}, {50.0, 0.0, 0.0}
   )
   assert(

--- a/repro/lua/figshare_demo.lua
+++ b/repro/lua/figshare_demo.lua
@@ -85,10 +85,15 @@ elseif key == "iceNanotube" then
   core.prismAnalysis(outdir .. "/", rings, hbn, cloud, 6, 1, frame, frame, false)
   emit({nop = cloud.nop, n_rings = #rings})
 elseif key == "monolayer" then
+  -- x in [0, 50]; equal y/z bounds leave those axes unconstrained
+  -- (same region as the Python monolayer notebook).
   local cloud = core.readLammpsTrjO(
-    traj, frame, 2, true, {0.0, 0.0, 0.0}, {50.0, 1000.0, 1000.0}
+    traj, frame, 2, true, {0.0, 0.0, 0.0}, {50.0, 0.0, 0.0}
   )
-  assert(cloud.nop > 250 and cloud.nop < 400, "slice did not select the sheet")
+  assert(
+    cloud.nop > 250 and cloud.nop < 400,
+    string.format("slice did not select the sheet (nop=%d)", cloud.nop)
+  )
   local nList = dseams.neighbors(cloud, {cutoff = 3.5, type = 2})
   local hbn = core.getHbondNetwork(traj, cloud, nList, frame, 1)
   hbn = core.bondNetworkByIndex(cloud, hbn)
@@ -97,7 +102,7 @@ elseif key == "monolayer" then
   emit({nop = cloud.nop, n_rings = #rings})
 elseif key == "rdf2D" then
   local cloud = core.readLammpsTrjO(
-    traj, frame, 2, true, {0.0, 0.0, 0.0}, {50.0, 1000.0, 1000.0}
+    traj, frame, 2, true, {0.0, 0.0, 0.0}, {50.0, 0.0, 0.0}
   )
   assert(cloud.nop > 0, "empty cloud")
   local rdf = core.calcRDF3D(cloud, 2, 2, 12.0, 80)


### PR DESCRIPTION
## Summary

Elja 1788729 built yodaStruct and ran four of the five figshare Lua demos. `monolayer` died on `slice did not select the sheet` because the Lua script used `{0,0,0}..{50,1000,1000}`. `atomInSlice` leaves an axis open when low==high; the Python notebook uses `([0,0,0], [50,0,0])`.

chillPlus, bulkTopologicalCriterion, iceNanotube, and rdf2D already returned 0.

## Test plan

- [ ] CI
- [ ] Elja leftover `figshare_demos` writes `figshare-demos.json` with all five keys ok