### PR TITLE
docs: spell out LAMMPS type-filter keep vs slice

### DIFF
--- a/docs/newsfragments/lammps-slice-keep.doc
+++ b/docs/newsfragments/lammps-slice-keep.doc
@@ -1,0 +1,4 @@
+Document the two LAMMPS type-filtered readers: ~readLammpsTrjO~
+flags ~inSlice~ and keeps every atom of the type;
+~readLammpsTrjreduced~ drops atoms outside the slice. An axis with
+~lo == hi~ is unconstrained.

--- a/docs/orgmode/reference/api.org
+++ b/docs/orgmode/reference/api.org
@@ -48,7 +48,7 @@ Every file under =src/include/internal=.
 | Header | Namespace | Role |
 |--------+-----------+------|
 | =mol_sys.hpp= | ~molSys~ | ~Point~, ~PointCloud~, bond and ice enums |
-| =seams_input.hpp= | ~sinp~ | LAMMPS / XYZ / chemfiles / readcon readers |
+| =seams_input.hpp= | ~sinp~ | LAMMPS / XYZ / chemfiles / readcon readers. ~readLammpsTrjO~ keeps every atom of one type and flags ~inSlice~; ~readLammpsTrjreduced~ drops atoms outside the slice. Same slice arguments, different keep. |
 | =seams_output.hpp= | ~sout~ | dump, cage, ring, and cluster writers |
 | =neighbours.hpp= | ~nneigh~ | cutoff, k-nearest, skin neighbour lists |
 | =bop.hpp= | ~chill~, ~sph~ | CHILL, CHILL+, ~q6~, Steinhardt ~ql~ |

--- a/docs/orgmode/reference/cli.org
+++ b/docs/orgmode/reference/cli.org
@@ -154,7 +154,7 @@ only by ~cages~.
 | value | single frame (~load~) | ~--last~ range (~forEachLammpsFrame~) |
 |-------+------------------------+---------------------------------------|
 | ~0~ | LAMMPS: type 2, then type 1 if that cloud is empty. chemfiles: keep every atom. XYZ: every atom is type 1 | LAMMPS: every atom (~sinp::readLammpsTrj~). Classification uses ~cloud.pts[0].type~ |
-| ~I > 0~ | LAMMPS ~readLammpsTrjO~ / chemfiles filter ~I~ | LAMMPS ~readLammpsTrjO~ with that type |
+| ~I > 0~ | LAMMPS ~readLammpsTrjO~ / chemfiles filter ~I~ | LAMMPS ~readLammpsTrjO~ with that type. The CLI does not pass a coordinate slice. |
 
 XYZ always stores type 1. Classification still uses ~--type~ after
 the read (type 0 then becomes 1).

--- a/docs/orgmode/reference/data-formats.org
+++ b/docs/orgmode/reference/data-formats.org
@@ -125,10 +125,22 @@ walks do not rescan prior snapshots. ~seams --frame N --last M
 ~sinp::dropLammpsDumpIndex~ drops a cached session (tests that
 rewrite a path in place).
 
-The C++ readers also accept a coordinate slice (~isSlice~,
-~coordLow~, ~coordHigh~). An atom is kept when each component lies in
-the closed interval, or when that axis has ~lo == hi~ (ignored). The
-CLI does not expose the slice.
+The two type-filtered C++ readers take the same slice arguments
+(~isSlice~, ~coordLow~, ~coordHigh~) and do not keep the same atoms.
+
+| reader | keep |
+|--------+------|
+| ~readLammpsTrjO~ | Every atom of the requested type. ~isSlice~ sets ~inSlice~ on each point and does not drop. ~nop~ is the type-filtered count. The ~O~ in the name is historical; the type argument is any LAMMPS type. |
+| ~readLammpsTrjreduced~ | Atoms of the requested type that pass the slice, or every atom of that type when ~isSlice~ is false. ~nop~ is the kept count. |
+
+An axis is inside the box when the coordinate lies in the closed
+interval, or when that axis has ~lo == hi~ (unconstrained).
+~([0,0,0], [50,0,0])~ is ~x~ in ~[0, 50]~, ~y~ and ~z~ open.
+
+The CLI does not expose the slice. Python
+~Frame(..., region=(lo, hi))~ calls ~readLammpsTrjreduced~. Lua
+~dseams.read~ calls ~readLammpsTrjO~ and has no region; a shrinking
+read is ~dseams.core.readLammpsTrjreduced~.
 
 * XYZ
 

--- a/repro/lua/figshare_demo.lua
+++ b/repro/lua/figshare_demo.lua
@@ -102,7 +102,7 @@ elseif key == "monolayer" then
   core.ringAnalysis(outdir .. "/", rings, hbn, cloud, 4, 50.0 * 50.0, frame)
   emit({nop = cloud.nop, n_rings = #rings})
 elseif key == "rdf2D" then
-  local cloud = core.readLammpsTrjO(
+  local cloud = core.readLammpsTrjreduced(
     traj, frame, 2, true, {0.0, 0.0, 0.0}, {50.0, 0.0, 0.0}
   )
   assert(cloud.nop > 0, "empty cloud")

--- a/src/include/internal/seams_input.hpp
+++ b/src/include/internal/seams_input.hpp
@@ -82,8 +82,10 @@ readLammpsTrj(std::string filename, int targetFrame,
               std::array<double, 3> coordLow = std::array<double, 3>{0, 0, 0},
               std::array<double, 3> coordHigh = std::array<double, 3>{0, 0, 0});
 
-//! Function for reading in a specified frame (frame number and not timestep
-//! value) / This only reads in oxygen atoms
+//! One LAMMPS dump frame, one atom type. The type argument is any
+//! LAMMPS type (the O in the name is historical). If isSlice is true,
+//! each kept point gets inSlice set; atoms outside the box stay in
+//! the cloud. nop is the type-filtered count.
 molSys::PointCloud<molSys::Point<double>, double> readLammpsTrjO(
     std::string filename, int targetFrame,
     molSys::PointCloud<molSys::Point<double>, double> &yCloud, int typeO,
@@ -91,8 +93,9 @@ molSys::PointCloud<molSys::Point<double>, double> readLammpsTrjO(
     std::array<double, 3> coordLow = std::array<double, 3>{0, 0, 0},
     std::array<double, 3> coordHigh = std::array<double, 3>{0, 0, 0});
 
-//! Function that reads in only atoms pf the desired type and ignores all atoms
-//! which are not in the slice as well
+//! One LAMMPS dump frame, one atom type, dropping atoms outside the
+//! slice when isSlice is true. nop is the kept count. An axis with
+//! lo == hi is unconstrained.
 molSys::PointCloud<molSys::Point<double>, double> readLammpsTrjreduced(
     std::string filename, int targetFrame,
     molSys::PointCloud<molSys::Point<double>, double> &yCloud, int typeI,
@@ -121,6 +124,8 @@ readCon(std::string filename, int targetFrame,
         molSys::PointCloud<molSys::Point<double>, double> &yCloud);
 #endif
 
+//! True when each component lies in [lo, hi], or that axis has lo == hi
+//! (unconstrained). ([0,0,0], [50,0,0]) is x in [0, 50], y and z open.
 inline bool atomInSlice(double x, double y, double z,
                         std::array<double, 3> coordLow,
                         std::array<double, 3> coordHigh) {

--- a/src/seams_input.cpp
+++ b/src/seams_input.cpp
@@ -771,17 +771,17 @@ sinp::readLammpsTrj(std::string filename, int targetFrame,
 }
 
 /**
- * @details Function for reading in a lammps file; and saves only the Oxygen
- * atoms. This is an overloaded function. The Oxygen atom ID must be specified.
+ * @details One LAMMPS dump frame, one atom type. The type argument is
+ *  any LAMMPS type (the O in the name is historical). isSlice sets
+ *  inSlice and does not drop atoms. nop is the type-filtered count.
  * @param[in] filename The name of the lammps trajectory file to be read in
  * @param[in] targetFrame The frame number whose information will be read in
  * @param[out] yCloud The outputted PointCloud
- * @param[in] typeO The type ID of the Oxygen atoms
- * @param[in] isSlice This decides whether a slice will be created or not
- * @param[in] coordLow Contains the lower limits of the slice, if a slice is to
- *  be created
- * @param[in] coordHigh Contains the upper limits of the slice, if a slice is
- *  to be created
+ * @param[in] typeO The LAMMPS type ID to keep
+ * @param[in] isSlice If true, set inSlice from the box; do not drop
+ * @param[in] coordLow Lower limits of the slice. An axis with lo == hi
+ *  is unconstrained.
+ * @param[in] coordHigh Upper limits of the slice
  */
 molSys::PointCloud<molSys::Point<double>, double>
 sinp::readLammpsTrjO(std::string filename, int targetFrame,
@@ -794,19 +794,16 @@ sinp::readLammpsTrjO(std::string filename, int targetFrame,
 }
 
 /**
- * @details Function for reading in a lammps file; and saves only the atoms of
- * the desired type. Atoms which are not inside the slice or not of type I are
- * not saved at all This is an overloaded function. The type atom ID must be
- *  specified.
+ * @details One LAMMPS dump frame, one atom type, dropping atoms
+ *  outside the slice when isSlice is true. nop is the kept count.
  * @param[in] filename The name of the lammps trajectory file to be read in
  * @param[in] targetFrame The frame number whose information will be read in
  * @param[out] yCloud The outputted PointCloud
- * @param[in] typeI The type ID of the desired type of atoms
- * @param[in] isSlice This decides whether a slice will be created or not
- * @param[in] coordLow Contains the lower limits of the slice, if a slice is to
- *  be created
- *  @param[in] coordHigh Contains the upper limits of the slice, if a slice is
- *  to be created
+ * @param[in] typeI The LAMMPS type ID to keep
+ * @param[in] isSlice If true, drop atoms outside the box
+ * @param[in] coordLow Lower limits of the slice. An axis with lo == hi
+ *  is unconstrained.
+ * @param[in] coordHigh Upper limits of the slice
  */
 molSys::PointCloud<molSys::Point<double>, double> sinp::readLammpsTrjreduced(
     std::string filename, int targetFrame,


### PR DESCRIPTION
## Summary

`readLammpsTrjO` and `readLammpsTrjreduced` take the same slice arguments and do not keep the same atoms. The book, Doxygen comments, and the rdf2D figshare demo now say so.

`readLammpsTrjO` keeps every atom of the type and sets `inSlice`. `readLammpsTrjreduced` drops atoms outside the box. An axis with `lo == hi` is unconstrained.

## Test plan

- [ ] Docs build
- [ ] CI