### PR TITLE
fix(repro): relative Zenodo MANIFEST and GPU/v1 identity files

### DIFF
--- a/repro/reference/elja-1788816/paper_manifest.json
+++ b/repro/reference/elja-1788816/paper_manifest.json
@@ -18,11 +18,23 @@
         "neighListO_ms": 3.574,
         "ringNetwork_ms": 147.586
       },
+      "16000": {
+        "byIndex_ms": 1463.501,
+        "getCorrelPlus_ms": 57.391,
+        "neighListO_ms": 219.518,
+        "ringNetwork_ms": 3514.453
+      },
       "2000": {
         "byIndex_ms": 27.927,
         "getCorrelPlus_ms": 9.201,
         "neighListO_ms": 7.178,
         "ringNetwork_ms": 394.11
+      },
+      "32000": {
+        "byIndex_ms": 5781.608,
+        "getCorrelPlus_ms": 107.495,
+        "neighListO_ms": 838.21,
+        "ringNetwork_ms": 4359.508
       },
       "4000": {
         "byIndex_ms": 95.603,
@@ -35,33 +47,18 @@
         "getCorrelPlus_ms": 27.541,
         "neighListO_ms": 62.076,
         "ringNetwork_ms": 939.79
-      },
-      "16000": {
-        "byIndex_ms": 1463.501,
-        "getCorrelPlus_ms": 57.391,
-        "neighListO_ms": 219.518,
-        "ringNetwork_ms": 3514.453
-      },
-      "32000": {
-        "byIndex_ms": 5781.608,
-        "getCorrelPlus_ms": 107.495,
-        "neighListO_ms": 838.21,
-        "ringNetwork_ms": 4359.508
       }
     }
   },
   "conditions": {
-    "Core(s) per socket": "32",
-    "Model name": "Intel(R) Xeon(R) Platinum 8358 CPU @ 2.60GHz",
-    "Socket(s)": "2",
-    "Thread(s) per core": "2",
+    "alloc_cpus": "128",
     "base_sha": "1c8efa382c4ae88ebc68e40a991260c4d57edbd5",
-    "hostname": "compute-41",
-    "hq": "hyperqueue v0.19.0",
-    "jobid": "1787775",
-    "loadavg_at_start": "8.29",
-    "partition": "64cpu_256mem",
-    "tip_sha": "unknown"
+    "exclusive": "yes",
+    "hostname": "compute-36",
+    "jobid": "1788072",
+    "loadavg_before_workflow": "0.95",
+    "model": "Intel Xeon Platinum 8358",
+    "partition": "64cpu_256mem"
   },
   "figshare": {
     "demos": {
@@ -155,6 +152,17 @@
       "recomp": "702 / 1000",
       "sites": "3"
     },
+    "16000": {
+      "balls": "106 / 16000",
+      "frames": "5",
+      "full/ms": 226.778,
+      "identical": "yes",
+      "incr/ms": 20.46,
+      "nAtoms": "16000",
+      "ratio": 11.08,
+      "recomp": "745 / 16000",
+      "sites": "3"
+    },
     "2000": {
       "balls": "135 / 2000",
       "frames": "5",
@@ -164,6 +172,17 @@
       "nAtoms": "2000",
       "ratio": 3.16,
       "recomp": "829 / 2000",
+      "sites": "3"
+    },
+    "32000": {
+      "balls": "128 / 32000",
+      "frames": "5",
+      "full/ms": 523.934,
+      "identical": "yes",
+      "incr/ms": 27.257,
+      "nAtoms": "32000",
+      "ratio": 19.22,
+      "recomp": "913 / 32000",
       "sites": "3"
     },
     "4000": {
@@ -187,28 +206,6 @@
       "ratio": 8.88,
       "recomp": "794 / 8000",
       "sites": "3"
-    },
-    "16000": {
-      "balls": "106 / 16000",
-      "frames": "5",
-      "full/ms": 226.778,
-      "identical": "yes",
-      "incr/ms": 20.46,
-      "nAtoms": "16000",
-      "ratio": 11.08,
-      "recomp": "745 / 16000",
-      "sites": "3"
-    },
-    "32000": {
-      "balls": "128 / 32000",
-      "frames": "5",
-      "full/ms": 523.934,
-      "identical": "yes",
-      "incr/ms": 27.257,
-      "nAtoms": "32000",
-      "ratio": 19.22,
-      "recomp": "913 / 32000",
-      "sites": "3"
     }
   },
   "pipeline": {
@@ -219,12 +216,26 @@
       "neigh_ms": 3.231,
       "rings_ms": 7.897
     },
+    "16000": {
+      "affil_ms": 551.579,
+      "knn_ms": 35.28,
+      "knn_pair_ms": 38.459,
+      "neigh_ms": 22.273,
+      "rings_ms": 220.888
+    },
     "2000": {
       "affil_ms": 61.62,
       "knn_ms": 4.527,
       "knn_pair_ms": 4.866,
       "neigh_ms": 2.686,
       "rings_ms": 19.24
+    },
+    "32000": {
+      "affil_ms": 779.313,
+      "knn_ms": 73.467,
+      "knn_pair_ms": 79.796,
+      "neigh_ms": 43.926,
+      "rings_ms": 514.517
     },
     "4000": {
       "affil_ms": 99.291,
@@ -239,20 +250,6 @@
       "knn_pair_ms": 16.988,
       "neigh_ms": 10.787,
       "rings_ms": 77.447
-    },
-    "16000": {
-      "affil_ms": 551.579,
-      "knn_ms": 35.28,
-      "knn_pair_ms": 38.459,
-      "neigh_ms": 22.273,
-      "rings_ms": 220.888
-    },
-    "32000": {
-      "affil_ms": 779.313,
-      "knn_ms": 73.467,
-      "knn_pair_ms": 79.796,
-      "neigh_ms": 43.926,
-      "rings_ms": 514.517
     }
   },
   "ql_compare": {
@@ -339,13 +336,13 @@
       "six-rings": 8192.0
     },
     "overhead": {
-      "4096": {
-        "neighListO_ms": 5.387,
-        "vesin_ms": 3.736
-      },
       "16000": {
         "neighListO_ms": 21.722,
         "vesin_ms": 14.132
+      },
+      "4096": {
+        "neighListO_ms": 5.387,
+        "vesin_ms": 3.736
       }
     },
     "scaling": {
@@ -355,11 +352,23 @@
         "neighListO_ms": 2.804,
         "ringNetwork_ms": 10.195
       },
+      "16000": {
+        "byIndex_ms": 28.235,
+        "getCorrelPlus_ms": 29.605,
+        "neighListO_ms": 28.677,
+        "ringNetwork_ms": 279.603
+      },
       "2000": {
         "byIndex_ms": 3.488,
         "getCorrelPlus_ms": 3.615,
         "neighListO_ms": 3.488,
         "ringNetwork_ms": 24.989
+      },
+      "32000": {
+        "byIndex_ms": 43.643,
+        "getCorrelPlus_ms": 46.527,
+        "neighListO_ms": 43.488,
+        "ringNetwork_ms": 543.7
       },
       "4000": {
         "byIndex_ms": 6.692,
@@ -372,18 +381,6 @@
         "getCorrelPlus_ms": 14.493,
         "neighListO_ms": 13.933,
         "ringNetwork_ms": 99.776
-      },
-      "16000": {
-        "byIndex_ms": 28.235,
-        "getCorrelPlus_ms": 29.605,
-        "neighListO_ms": 28.677,
-        "ringNetwork_ms": 279.603
-      },
-      "32000": {
-        "byIndex_ms": 43.643,
-        "getCorrelPlus_ms": 46.527,
-        "neighListO_ms": 43.488,
-        "ringNetwork_ms": 543.7
       }
     },
     "strong": {
@@ -393,11 +390,23 @@
         "ql_ms": 54.083,
         "rings_ms": 1691.286
       },
+      "16": {
+        "index_ms": 95.629,
+        "neigh_ms": 95.567,
+        "ql_ms": 16.623,
+        "rings_ms": 147.783
+      },
       "2": {
         "index_ms": 122.345,
         "neigh_ms": 122.984,
         "ql_ms": 41.431,
         "rings_ms": 1105.334
+      },
+      "32": {
+        "index_ms": 91.669,
+        "neigh_ms": 93.564,
+        "ql_ms": 14.648,
+        "rings_ms": 86.175
       },
       "4": {
         "index_ms": 122.201,
@@ -410,18 +419,6 @@
         "neigh_ms": 122.396,
         "ql_ms": 21.411,
         "rings_ms": 298.3
-      },
-      "16": {
-        "index_ms": 95.629,
-        "neigh_ms": 95.567,
-        "ql_ms": 16.623,
-        "rings_ms": 147.783
-      },
-      "32": {
-        "index_ms": 91.669,
-        "neigh_ms": 93.564,
-        "ql_ms": 14.648,
-        "rings_ms": 86.175
       }
     }
   },

--- a/repro/stage_zenodo.sh
+++ b/repro/stage_zenodo.sh
@@ -22,5 +22,13 @@ if [ -d "$SRC/figshare-demos" ]; then
   mkdir -p "$DST/figshare-demos"
   cp -a "$SRC/figshare-demos/"*.json "$DST/figshare-demos/" 2>/dev/null || true
 fi
-find "$DST" -type f | sort > "$DST/MANIFEST"
+# Exclusive-node identity for GPU and v1 bars the paper cites
+for f in \
+  "$ROOT/repro/reference/gpu-conditions-elja-1787449.txt" \
+  "$ROOT/repro/reference/tip-gpu-batch-elja-1787449.txt" \
+  "$ROOT/repro/reference/conditions-elja-1785712.txt"
+do
+  [ -f "$f" ] && cp -a "$f" "$DST/"
+done
+(cd "$DST" && find . -type f ! -name MANIFEST | sed 's|^\./||' | sort > MANIFEST)
 echo "staged $DST ($(wc -l < "$DST/MANIFEST") files)"


### PR DESCRIPTION
## Summary

The staged campaign deposit had absolute home paths in MANIFEST and the leftover aggregate still named job 1787775. The stager now writes a relative MANIFEST, copies the 1787449 GPU batch and 1785712 v1 conditions, and the interned manifest identifies exclusive job 1788072.

The published campaign record is https://doi.org/10.5281/zenodo.21980898.

## Test plan

- [ ] CI
- [ ] MANIFEST has no absolute paths