### PR TITLE
docs: fetch doxyYoda 0.2.2 for Doxyfile-prj.cfg

### DIFF
--- a/scripts/get_doxyyoda.sh
+++ b/scripts/get_doxyyoda.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# Fetch the doxyYoda HTML theme next to Doxyfile-prj.cfg.
+set -euo pipefail
+ver=0.2.2
+root=$(git rev-parse --show-toplevel)
+cd "$root"
+if [ -d doxyYoda/html ]; then
+  echo "doxyYoda already present"
+  exit 0
+fi
+curl -fSL "https://github.com/HaoZeke/doxyYoda/releases/download/v${ver}/doxyYoda_${ver}.tar.gz" -o doxyYoda.tar.gz
+tar xf doxyYoda.tar.gz
+rm -f doxyYoda.tar.gz
+echo "extracted doxyYoda ${ver}"


### PR DESCRIPTION
Doxyfile-prj.cfg still expects a local doxyYoda/ tree. Add a helper that pulls the current release tarball so the HTML theme paths resolve.