### PR TITLE
docs: publish doxyYoda C++ API next to the book

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,7 @@ build/
 # docs/source/*.rst is generated from orgmode, but track orgmode + conf.py
 docs/build/
 docs/doctrees/
+docs/doxygen-html/
 docs/source/*.rst
 docs/source/xml/
 docs/source/api/

--- a/Doxyfile-prj.cfg
+++ b/Doxyfile-prj.cfg
@@ -65,10 +65,10 @@ DOT_IMAGE_FORMAT       = svg
 HTML_DYNAMIC_SECTIONS  = YES
 INTERACTIVE_SVG        = YES
 # Theme
-HTML_HEADER            = "doxyYoda/html/header.html"
-HTML_FOOTER            = "doxyYoda/html/footer.html"
-HTML_EXTRA_STYLESHEET  = "doxyYoda/css/doxyYoda.min.css"
-LAYOUT_FILE            = "doxyYoda/xml/doxyYoda.xml"
+HTML_HEADER            = "docs/doxyYoda/html/header.html"
+HTML_FOOTER            = "docs/doxyYoda/html/footer.html"
+HTML_EXTRA_STYLESHEET  = "docs/doxyYoda/css/doxyYoda.min.css"
+LAYOUT_FILE            = "docs/doxyYoda/xml/doxyYoda.xml"
 
 # We link to standard definitions
 TAGFILES += "./tags/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"

--- a/docs/orgmode/contributing/index.org
+++ b/docs/orgmode/contributing/index.org
@@ -8,7 +8,8 @@ Do not add a language binding here.
 
 Documentation is authored in ~docs/orgmode/~ and exported with
 ~docs/export.el~ (ox-rst) before Sphinx. Run ~pixi run -e docs docbld~
-to export, run doxyrest, and build the Shibuya site.
+to export, run doxyrest, build the Shibuya site, and write the sibling
+doxyYoda C++ tree to =docs/build/api-cpp/=.
 
 * Prerequisites
 

--- a/docs/orgmode/index.org
+++ b/docs/orgmode/index.org
@@ -167,6 +167,11 @@ framework.
    contributing/index
 #+end_export
 
+The in-book C++ pages under =api/= are Doxygen via doxyrest. A sibling
+doxyYoda HTML tree (inline source, treeview) is at
+[[https://docs.dseams.info/api-cpp/][/api-cpp/]] after
+~pixi run -e docs docbld~.
+
 * Related projects
 
 - [[https://d-seams.github.io/PydSEAMSlib/][pydseams]] :: Python Frame API on ~yoda~

--- a/docs/orgmode/reference/api.org
+++ b/docs/orgmode/reference/api.org
@@ -33,6 +33,9 @@ The book includes that tree as =api/index= (Reference toctree), not
 as a second hand list of functions. The generated pages are the
 API; the header table below is only a map onto those pages.
 
+A sibling doxyYoda HTML tree of the same headers is at =/api-cpp/=
+(~pixi run -e docs doxyhtml~). That landing page points back here.
+
 #+begin_export rst
 .. toctree::
    :maxdepth: 2

--- a/docs/source/Doxyfile_doxyyoda.cfg
+++ b/docs/source/Doxyfile_doxyyoda.cfg
@@ -1,0 +1,48 @@
+# seams-core -- standalone Doxygen HTML via doxyYoda (sibling of the Sphinx book)
+# XML/doxyrest stays on Doxyfile_seams.cfg.
+
+PROJECT_NAME            = "seams-core"
+PROJECT_NUMBER          = "v2.6.0"
+PROJECT_BRIEF           = "libyodaLib, the C++ engine of d-SEAMS"
+
+OUTPUT_DIRECTORY        = "../doxygen-html"
+GENERATE_HTML           = YES
+GENERATE_LATEX          = NO
+GENERATE_XML            = NO
+HTML_OUTPUT             = html
+
+HTML_HEADER             = "../doxyYoda/html/header.html"
+HTML_FOOTER             = "../doxyYoda/html/footer.html"
+HTML_EXTRA_STYLESHEET   = "../doxyYoda/css/doxyYoda.min.css"
+LAYOUT_FILE             = "../doxyYoda/xml/doxyYoda.xml"
+
+GENERATE_TREEVIEW       = YES
+FULL_SIDEBAR            = NO
+HTML_DYNAMIC_SECTIONS   = YES
+HTML_CODE_FOLDING       = YES
+USE_MATHJAX             = YES
+MATHJAX_VERSION         = MathJax_3
+
+RECURSIVE               = YES
+INPUT                   = "./mainpage.dox" \
+                          "../../src/include/internal"
+EXCLUDE                 = "../../src/include/external" \
+                          "../../tests"
+FILE_PATTERNS           = *.h *.hpp *.hh *.dox
+
+EXTRACT_ALL             = YES
+EXTRACT_PRIVATE         = NO
+EXTRACT_STATIC          = YES
+INLINE_SOURCES          = YES
+SOURCE_BROWSER          = YES
+JAVADOC_AUTOBRIEF       = YES
+BUILTIN_STL_SUPPORT     = YES
+HAVE_DOT                = NO
+
+QUIET                   = YES
+WARNINGS                = YES
+WARN_IF_UNDOCUMENTED    = NO
+
+# Local Variables:
+# mode: conf
+# End:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -68,6 +68,11 @@ html_theme_options = {
     "toctree_titles_only": True,
     "nav_links": [
         {
+            "title": "C++ API",
+            "url": "/api-cpp/index.html",
+            "resource": True,
+        },
+        {
             "title": "Ecosystem",
             "children": [
                 {

--- a/docs/source/mainpage.dox
+++ b/docs/source/mainpage.dox
@@ -1,0 +1,9 @@
+/*! \mainpage seams-core C++ API
+
+The install, tutorials, and CLI live in the
+<a href="https://docs.dseams.info/">d-SEAMS book</a>.
+This tree is the public headers under <code>src/include/internal</code>.
+
+The in-book pages under <code>/api/</code> are the same comments via doxyrest.
+
+*/

--- a/pixi.lock
+++ b/pixi.lock
@@ -333,7 +333,7 @@ environments:
       - conda: https://conda.anaconda.org/conda-forge/linux-64/conda-gcc-specs-14.3.0-he8ccf15_18.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/cxx-compiler-1.11.0-hfcd1e18_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/dbus-1.16.2-h24cb091_1.conda
-      - conda: https://conda.anaconda.org/conda-forge/linux-64/doxygen-1.13.2-h8e693c7_0.conda
+      - conda: https://conda.anaconda.org/conda-forge/linux-64/doxygen-1.17.0-py313hfca462b_0.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/doxyrest-2.1.2-lua54h06f1a30_0.tar.bz2
       - conda: https://conda.anaconda.org/conda-forge/linux-64/eigen-3.4.0-h54a6638_2.conda
       - conda: https://conda.anaconda.org/conda-forge/linux-64/emacs-30.2-h7b27564_4.conda
@@ -1767,19 +1767,21 @@ packages:
   run_exports: {}
   size: 2821960
   timestamp: 1780390159181
-- conda: https://conda.anaconda.org/conda-forge/linux-64/doxygen-1.13.2-h8e693c7_0.conda
-  sha256: 349c4c872357b4a533e127b2ade8533796e8e062abc2cd685756a1a063ae1e35
-  md5: 0869f41ea5c64643dd2f5b47f32709ca
+- conda: https://conda.anaconda.org/conda-forge/linux-64/doxygen-1.17.0-py313hfca462b_0.conda
+  sha256: c27f0c1aed5ca4b28bf7d84132c85907cf59740a1a3fa50395cff27d517b5b56
+  md5: 203fdb48d08089c8de9bf3f2df52f0ed
   depends:
+  - libiconv
+  - libstdcxx >=14
+  - libgcc >=14
   - __glibc >=2.17,<3.0.a0
-  - libgcc >=13
-  - libiconv >=1.17,<2.0a0
-  - libstdcxx >=13
+  - libiconv >=1.18,<2.0a0
   license: GPL-2.0-only
   license_family: GPL
   purls: []
-  size: 13148627
-  timestamp: 1738164137421
+  run_exports: {}
+  size: 13762539
+  timestamp: 1782819135560
 - conda: https://conda.anaconda.org/conda-forge/linux-64/doxyrest-2.1.2-lua54h06f1a30_0.tar.bz2
   sha256: 1eaeb06495468e2f452c6db5ce98c8f3d5d180d62d905f5cb5987c64ccf9f5ac
   md5: a65c6b491a4a46bbd7da418a5f822aed

--- a/pixi.toml
+++ b/pixi.toml
@@ -99,7 +99,7 @@ platforms = ["linux-64"]
 python = "3.12.*"
 emacs = ">=30"
 graphviz = ">=12"
-doxygen = ">=1.13"
+doxygen = ">=1.17"
 doxyrest = ">=2.1"
 
 [feature.docs.pypi-dependencies]
@@ -137,8 +137,23 @@ cmd = "doxygen Doxyfile_seams.cfg && doxyrest -c doxyrest-config.lua"
 depends-on = ["mkrst", "doxybuild"]
 cmd = "sphinx-build -d docs/doctrees docs/source/ docs/build"
 
+[feature.docs.tasks.fetch-doxyyoda]
+description = "Download the doxyYoda 0.2.2 HTML theme"
+cmd = "bash scripts/get_doxyyoda.sh"
+
+[feature.docs.tasks.doxyhtml]
+description = "Standalone doxyYoda C++ API HTML"
+cwd = "docs/source"
+depends-on = ["fetch-doxyyoda"]
+cmd = "doxygen Doxyfile_doxyyoda.cfg"
+
+[feature.docs.tasks.install-doxyhtml]
+description = "Copy doxyYoda HTML into the Sphinx publish tree"
+depends-on = ["sphinxbld", "doxyhtml"]
+cmd = "rm -rf docs/build/api-cpp && cp -R docs/doxygen-html/html docs/build/api-cpp"
+
 [feature.docs.tasks.docbld]
-depends-on = ["sphinxbld"]
+depends-on = ["sphinxbld", "install-doxyhtml"]
 
 [feature.docs.tasks.docdel]
 cwd = "docs"
@@ -146,6 +161,7 @@ cwd = "docs"
 cmd = """
 rm -rf build
 rm -rf doctrees
+rm -rf doxygen-html
 rm -rf source/xml
 rm -rf source/api
 rm -rf source/contributing

--- a/pixi.toml
+++ b/pixi.toml
@@ -99,7 +99,7 @@ platforms = ["linux-64"]
 python = "3.12.*"
 emacs = ">=30"
 graphviz = ">=12"
-doxygen = ">=1.17"
+doxygen = ">=1.13"
 doxyrest = ">=2.1"
 
 [feature.docs.pypi-dependencies]

--- a/pixi.toml
+++ b/pixi.toml
@@ -99,7 +99,7 @@ platforms = ["linux-64"]
 python = "3.12.*"
 emacs = ">=30"
 graphviz = ">=12"
-doxygen = ">=1.13"
+doxygen = ">=1.17,<2"
 doxyrest = ">=2.1"
 
 [feature.docs.pypi-dependencies]

--- a/scripts/get_doxyyoda.sh
+++ b/scripts/get_doxyyoda.sh
@@ -1,14 +1,16 @@
 #!/usr/bin/env bash
-# Fetch the doxyYoda HTML theme next to Doxyfile-prj.cfg.
+# Fetch the doxyYoda HTML theme into docs/doxyYoda/.
 set -euo pipefail
 ver=0.2.2
 root=$(git rev-parse --show-toplevel)
-cd "$root"
-if [ -d doxyYoda/html ]; then
+dest="$root/docs/doxyYoda"
+if [ -f "$dest/html/header.html" ]; then
   echo "doxyYoda already present"
   exit 0
 fi
-curl -fSL "https://github.com/HaoZeke/doxyYoda/releases/download/v${ver}/doxyYoda_${ver}.tar.gz" -o doxyYoda.tar.gz
-tar xf doxyYoda.tar.gz
-rm -f doxyYoda.tar.gz
-echo "extracted doxyYoda ${ver}"
+tmp=$(mktemp)
+trap 'rm -f "$tmp"' EXIT
+curl -fSL "https://github.com/HaoZeke/doxyYoda/releases/download/v${ver}/doxyYoda_${ver}.tar.gz" -o "$tmp"
+mkdir -p "$root/docs"
+tar -xf "$tmp" -C "$root/docs"
+echo "extracted doxyYoda ${ver} -> docs/doxyYoda"


### PR DESCRIPTION
The book folds Doxygen through `doxyrest` at `/api/`. It never built or linked the standalone doxyYoda tree, so there was no C++ HTML site to point at.

`docbld` now writes `/api-cpp/`. The book nav and the API map name that tree. The Doxygen landing page points back at docs.dseams.info.
