### PR TITLE
refactor: dump MIC and vesin pairs through minimage

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -232,6 +232,13 @@ if linkcell_dep.found()
   _args += ['-DSEAMS_HAS_LINKCELL=1']
 endif
 
+minimage_dep = dependency('minimage', required: false,
+                          fallback: ['minimage', 'minimage_dep'])
+if minimage_dep.found()
+  _deps += [minimage_dep]
+  _args += ['-DSEAMS_HAS_MINIMAGE=1']
+endif
+
 chemfiles_dep = dependency('chemfiles', required: false)
 if chemfiles_dep.found()
   _deps += [chemfiles_dep]
@@ -415,6 +422,7 @@ summary({
   'Device-resident batches (gpulite)': gpulite_dep.found() and not gpulite_opt.disabled(),
   'Cell-list neighbours (vesin)': vesin_dep.found(),
   'Periodic k-nearest (linkcell)': linkcell_dep.found(),
+  'Minimum-image wrap (minimage)': minimage_dep.found(),
   'PDB/GRO/DCD readers (chemfiles)': chemfiles_dep.found(),
   '.con reader (readcon-core)': readcon_dep.found(),
   'IRA/SOFI shape matching (libira)': ira_found,

--- a/src/include/internal/generic.hpp
+++ b/src/include/internal/generic.hpp
@@ -26,6 +26,10 @@
 #include <vector>
 #include <mol_sys.hpp>
 
+#ifdef SEAMS_HAS_MINIMAGE
+#include <minimage.h>
+#endif
+
 // C++20
 #include <numbers>
 // Eigen
@@ -99,6 +103,29 @@ inline double calcMedian(std::vector<double> *input) {
   return median;
 }
 
+#ifdef SEAMS_HAS_MINIMAGE
+// Dump bound spans plus optional tilt onto an mi_cell.
+inline mi_cell pointCloudCell(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud) {
+  const auto &box = yCloud.box;
+  const auto &boxLow = yCloud.boxLow;
+  const double xlo_b = boxLow.size() > 0 ? boxLow[0] : 0.0;
+  const double ylo_b = boxLow.size() > 1 ? boxLow[1] : 0.0;
+  const double zlo_b = boxLow.size() > 2 ? boxLow[2] : 0.0;
+  mi_cell c = mi_cell_ortho(0.0, 0.0, 0.0);
+  if (box.size() >= 6) {
+    mi_cell_from_lammps_bounds(box[0], box[1], box[2], box[3], box[4], box[5],
+                               xlo_b, ylo_b, zlo_b, &c);
+  } else if (box.size() >= 3) {
+    c = mi_cell_ortho(box[0], box[1], box[2]);
+    c.ox = xlo_b;
+    c.oy = ylo_b;
+    c.oz = zlo_b;
+  }
+  return c;
+}
+#endif
+
 // Recover H (columns a, b, c) and origin from a LAMMPS dump box with the
 // same mapping as nneigh::lammpsBoxToLcCell: box[0..3] are bound spans,
 // box[3..6] are tilt factors xy, xz, yz, boxLow is the bound lo.
@@ -107,6 +134,14 @@ inline double calcMedian(std::vector<double> *input) {
 inline std::array<double, 3> triclinicMinImage(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud, double xi,
     double yi, double zi, double xj, double yj, double zj) {
+#ifdef SEAMS_HAS_MINIMAGE
+  const mi_cell cell = pointCloudCell(yCloud);
+  const double p[3] = {xj, yj, zj};
+  const double q[3] = {xi, yi, zi};
+  double dr[3] = {0.0, 0.0, 0.0};
+  mi_displacement(&cell, p, q, dr);
+  return {dr[0], dr[1], dr[2]};
+#else
   const auto &box = yCloud.box;
   const auto &boxLow = yCloud.boxLow;
   const double xspan = box[0];
@@ -144,6 +179,7 @@ inline std::array<double, 3> triclinicMinImage(
   dsy -= std::round(dsy);
   dsz -= std::round(dsz);
   return {lx * dsx + xy * dsy + xz * dsz, ly * dsy + yz * dsz, lz * dsz};
+#endif
 }
 
 // Generic function for getting the unwrapped distance
@@ -159,6 +195,16 @@ inline std::array<double, 3> triclinicMinImage(
 inline double
 periodicDistSq(const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
                int iatom, int jatom) {
+#ifdef SEAMS_HAS_MINIMAGE
+  const mi_cell cell = pointCloudCell(yCloud);
+  const double p[3] = {yCloud.pts[iatom].x, yCloud.pts[iatom].y,
+                       yCloud.pts[iatom].z};
+  const double q[3] = {yCloud.pts[jatom].x, yCloud.pts[jatom].y,
+                       yCloud.pts[jatom].z};
+  double out = 0.0;
+  mi_dist2(&cell, p, q, &out);
+  return out;
+#else
   if (yCloud.box.size() >= 6) {
     const auto dr = triclinicMinImage(
         yCloud, yCloud.pts[iatom].x, yCloud.pts[iatom].y, yCloud.pts[iatom].z,
@@ -181,6 +227,7 @@ periodicDistSq(const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
   }
 
   return r2;
+#endif
 }
 
 /**
@@ -258,6 +305,15 @@ inline void writeDumpBoxBounds(
 inline std::array<double, 3> relDistFromPoint(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud, int iatom,
     double xj, double yj, double zj) {
+#ifdef SEAMS_HAS_MINIMAGE
+  const mi_cell cell = pointCloudCell(yCloud);
+  const double p[3] = {xj, yj, zj};
+  const double q[3] = {yCloud.pts[iatom].x, yCloud.pts[iatom].y,
+                       yCloud.pts[iatom].z};
+  double dr[3] = {0.0, 0.0, 0.0};
+  mi_displacement(&cell, p, q, dr);
+  return {dr[0], dr[1], dr[2]};
+#else
   if (yCloud.box.size() >= 6) {
     return triclinicMinImage(yCloud, yCloud.pts[iatom].x, yCloud.pts[iatom].y,
                              yCloud.pts[iatom].z, xj, yj, zj);
@@ -274,6 +330,7 @@ inline std::array<double, 3> relDistFromPoint(
     }
   }
   return dr;
+#endif
 }
 
 inline double unWrappedDistFromPoint(

--- a/src/include/internal/neighbours.hpp
+++ b/src/include/internal/neighbours.hpp
@@ -28,6 +28,9 @@
 #ifdef SEAMS_HAS_LINKCELL
 #include <linkcell.hpp>
 #endif
+#ifdef SEAMS_HAS_MINIMAGE
+#include <minimage.h>
+#endif
 
 /** @file neighbours.hpp
  *  @brief Header file for neighbour list generation.
@@ -172,6 +175,34 @@ inline double dumpVolume(
 /// Map a LAMMPS dump box onto lc_cell.
 inline lc_cell lammpsBoxToLcCell(const std::vector<double> &box,
                                  const std::vector<double> &boxLow) {
+#ifdef SEAMS_HAS_MINIMAGE
+  const double xspan = box.size() > 0 ? box[0] : 0.0;
+  const double yspan = box.size() > 1 ? box[1] : 0.0;
+  const double zspan = box.size() > 2 ? box[2] : 0.0;
+  const double xy = box.size() >= 6 ? box[3] : 0.0;
+  const double xz = box.size() >= 6 ? box[4] : 0.0;
+  const double yz = box.size() >= 6 ? box[5] : 0.0;
+  const double xlo_b = boxLow.size() > 0 ? boxLow[0] : 0.0;
+  const double ylo_b = boxLow.size() > 1 ? boxLow[1] : 0.0;
+  const double zlo_b = boxLow.size() > 2 ? boxLow[2] : 0.0;
+  mi_cell raw;
+  mi_cell_from_lammps_bounds(xspan, yspan, zspan, xy, xz, yz, xlo_b, ylo_b,
+                             zlo_b, &raw);
+  lc_cell c = lc_cell_ortho(raw.ax, raw.by, raw.cz);
+  c.ax = raw.ax;
+  c.ay = raw.ay;
+  c.az = raw.az;
+  c.bx = raw.bx;
+  c.by = raw.by;
+  c.bz = raw.bz;
+  c.cx = raw.cx;
+  c.cy = raw.cy;
+  c.cz = raw.cz;
+  c.ox = raw.ox;
+  c.oy = raw.oy;
+  c.oz = raw.oz;
+  return c;
+#else
   double H[3][3], o[3];
   dumpBoundsToH(box, boxLow, H, o);
   lc_cell c = lc_cell_ortho(H[0][0], H[1][1], H[2][2]);
@@ -188,6 +219,7 @@ inline lc_cell lammpsBoxToLcCell(const std::vector<double> &box,
   c.oy = o[1];
   c.oz = o[2];
   return c;
+#endif
 }
 
 inline linkcell::Cell lammpsBoxToLinkcell(const std::vector<double> &box,

--- a/src/include/internal/simd_distance.hpp
+++ b/src/include/internal/simd_distance.hpp
@@ -11,6 +11,10 @@
 #endif
 #endif
 
+#ifdef SEAMS_HAS_MINIMAGE
+#include <minimage.h>
+#endif
+
 #ifdef SEAMS_HAS_HWY
 
 #include "hwy/highway.h"
@@ -32,6 +36,10 @@ inline HWY_ATTR void BatchPeriodicDistSq(const double* HWY_RESTRICT dx,
                                 const double* HWY_RESTRICT dz,
                                 double bx, double by, double bz,
                                 double* HWY_RESTRICT out, size_t n) {
+#ifdef SEAMS_HAS_MINIMAGE
+  mi_dist2_ortho_diffs(dx, dy, dz, bx, by, bz, out, n);
+  return;
+#endif
   const hn::ScalableTag<double> d;
   const size_t N = hn::Lanes(d);
 
@@ -93,6 +101,10 @@ namespace seams {
 inline void BatchPeriodicDistSq(const double* dx, const double* dy,
                                 const double* dz, double bx, double by,
                                 double bz, double* out, size_t n) {
+#ifdef SEAMS_HAS_MINIMAGE
+  mi_dist2_ortho_diffs(dx, dy, dz, bx, by, bz, out, n);
+  return;
+#endif
   // Matches the vectorised path: one reciprocal per axis for the whole batch
   const double rbx = 1.0 / bx;
   const double rby = 1.0 / by;

--- a/src/neighbours.cpp
+++ b/src/neighbours.cpp
@@ -33,6 +33,9 @@
 #ifdef SEAMS_HAS_VESIN
 #include <vesin.h>
 #endif
+#ifdef SEAMS_HAS_MINIMAGE
+#include <minimage.h>
+#endif
 #ifdef SEAMS_HAS_LINKCELL
 #include <linkcell.hpp>
 #endif
@@ -160,6 +163,19 @@ bool cellListPairs(const molSys::PointCloud<molSys::Point<double>, double> &yClo
 
   pairs.clear();
   pairs.reserve(neighbors.length);
+#ifdef SEAMS_HAS_MINIMAGE
+  std::vector<int> packed(neighbors.length * 2);
+  for (size_t k = 0; k < neighbors.length; k++) {
+    packed[2 * k] = subset[neighbors.pairs[k][0]];
+    packed[2 * k + 1] = subset[neighbors.pairs[k][1]];
+  }
+  std::vector<int> kept(neighbors.length * 2, 0);
+  size_t nkept = 0;
+  mi_reduce_pairs(packed.data(), neighbors.length, kept.data(), &nkept);
+  for (size_t k = 0; k < nkept; k++) {
+    pairs.emplace_back(kept[2 * k], kept[2 * k + 1]);
+  }
+#else
   for (size_t k = 0; k < neighbors.length; k++) {
     const int iatom = subset[neighbors.pairs[k][0]];
     const int jatom = subset[neighbors.pairs[k][1]];
@@ -175,11 +191,11 @@ bool cellListPairs(const molSys::PointCloud<molSys::Point<double>, double> &yClo
     }
     pairs.emplace_back(iatom, jatom);
   }
-
-  vesin_free(&neighbors);
-
   std::sort(pairs.begin(), pairs.end());
   pairs.erase(std::unique(pairs.begin(), pairs.end()), pairs.end());
+#endif
+
+  vesin_free(&neighbors);
 
   return true;
 }

--- a/subprojects/minimage.wrap
+++ b/subprojects/minimage.wrap
@@ -1,0 +1,7 @@
+[wrap-git]
+url = https://github.com/lode-org/minimage.git
+revision = v0.1.1
+depth = 1
+
+[provide]
+minimage = minimage_dep

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -96,6 +96,9 @@ if hwy_dep.found()
   _simd_deps += [hwy_dep]
   _simd_args += ['-DSEAMS_HAS_HWY=1']
 endif
+if minimage_dep.found()
+  _simd_deps += [minimage_dep]
+endif
 test('simd',
   executable('test_simd', 'test_simd.cpp',
     dependencies: _simd_deps,


### PR DESCRIPTION
Independent of the F4/cages stack. Two commits on v2.9.2.

Dump MIC and the vesin pair reduction go through `minimage` (`subprojects/minimage.wrap`). The simd Catch2 binary links it when the wrap is there. `walk_compare` already links `yds_dep`, so it picks the same MIC without a second executable target.

The neighbour graph builders stay as they are.
