### PR TITLE
feat(phase): XVII channels, ice XXI cell match, glass density, compute dseams

### DIFF
--- a/changelog.d/+lammps-compute-dseams.added.md
+++ b/changelog.d/+lammps-compute-dseams.added.md
@@ -1,0 +1,1 @@
+Add extras/lammps compute dseams that writes seams_chill_plus per atom.

--- a/changelog.d/+phase-xvii-xxi-glass.added.md
+++ b/changelog.d/+phase-xvii-xxi-glass.added.md
@@ -1,0 +1,1 @@
+Add channel, proton-key, hydrogen MSD, ice XXI library and HDA/MDA density labels.

--- a/changelog.d/+phase-xvii-xxi-glass.added.md
+++ b/changelog.d/+phase-xvii-xxi-glass.added.md
@@ -1,1 +1,1 @@
-Add channel, proton-key, hydrogen MSD, ice XXI library and HDA/MDA density labels.
+Hexagonal channels are stacked six-ring prisms, not a raw six-ring count. Ice XXI (Lee et al. 2026, Z=152 BCT) also requires a tetrahedral 3.5 A graph and a primitive six-ring. Hydrogen MSD uses the minimum image. Glass labels use local-density windows for ice/LDA/MDA/HDA. `compute dseams` ships with `water.data` and `pair_style zero`.

--- a/extras/lammps/README.md
+++ b/extras/lammps/README.md
@@ -1,0 +1,16 @@
+# compute dseams
+
+In-run CHILL+ labels from the `seams_chill_plus` C ABI.
+
+```
+compute ice all dseams
+dump 1 all custom 1 dump.chill id type x y z c_ice
+```
+
+The dump column is the same integer table as `seams chill-plus`
+(0 cubic, 1 hexagonal, 2 water, 3 interfacial, 4 clathrate,
+5 interClathrate, 6 unclassified). Copy these two sources into
+`LAMMPS/src` and add `-I` to the seams-core include path.
+
+`tests/test_phase.cpp` checks that the compute's label function is
+`seams_chill_plus`.

--- a/extras/lammps/README.md
+++ b/extras/lammps/README.md
@@ -12,5 +12,10 @@ The dump column is the same integer table as `seams chill-plus`
 5 interClathrate, 6 unclassified). Copy these two sources into
 `LAMMPS/src` and add `-I` to the seams-core include path.
 
+`in.dseams` reads `water.data` (four oxygen sites) with `pair_style zero`
+and writes `dump.chill`. The compute still copies `nlocal` xyz and calls
+`seams_chill_plus`; it does not take the LAMMPS neighbour list.
+
 `tests/test_phase.cpp` checks that the compute's label function is
-`seams_chill_plus`.
+`seams_chill_plus`. A live `lmp -in in.dseams` run needs these two
+sources in `LAMMPS/src` and a link against `libyodaLib`.

--- a/extras/lammps/compute_dseams.cpp
+++ b/extras/lammps/compute_dseams.cpp
@@ -1,0 +1,54 @@
+#include "compute_dseams.h"
+#include "atom.h"
+#include "domain.h"
+#include "error.h"
+#include "memory.h"
+#include "update.h"
+
+#include <seams_c_api.h>
+
+#include <cstring>
+#include <vector>
+
+using namespace LAMMPS_NS;
+
+ComputeDseams::ComputeDseams(LAMMPS *lmp, int narg, char **arg)
+    : Compute(lmp, narg, arg), nmax(0), chill(nullptr) {
+  if (narg < 3) {
+    error->all(FLERR, "Illegal compute dseams command");
+  }
+  peratom_flag = 1;
+  size_peratom_cols = 0;
+}
+
+void ComputeDseams::init() {}
+
+void ComputeDseams::compute_peratom() {
+  invoked_peratom = update->ntimestep;
+  const int nlocal = atom->nlocal;
+  if (nlocal > nmax) {
+    memory->destroy(chill);
+    nmax = nlocal;
+    memory->create(chill, nmax, "dseams:chill");
+    vector_atom = chill;
+  }
+  std::vector<double> xyz(static_cast<std::size_t>(nlocal) * 3);
+  std::vector<int> labels(static_cast<std::size_t>(nlocal), 6);
+  for (int i = 0; i < nlocal; i++) {
+    xyz[static_cast<std::size_t>(i) * 3 + 0] = atom->x[i][0];
+    xyz[static_cast<std::size_t>(i) * 3 + 1] = atom->x[i][1];
+    xyz[static_cast<std::size_t>(i) * 3 + 2] = atom->x[i][2];
+  }
+  const double box[6] = {domain->boxlo[0], domain->boxlo[1], domain->boxlo[2],
+                         domain->xprd, domain->yprd, domain->zprd};
+  if (seams_chill_plus(xyz.data(), nlocal, box, labels.data()) != 0) {
+    error->one(FLERR, "compute dseams: seams_chill_plus failed");
+  }
+  for (int i = 0; i < nlocal; i++) {
+    chill[i] = static_cast<double>(labels[static_cast<std::size_t>(i)]);
+  }
+}
+
+double ComputeDseams::memory_usage() {
+  return static_cast<double>(nmax) * sizeof(double);
+}

--- a/extras/lammps/compute_dseams.h
+++ b/extras/lammps/compute_dseams.h
@@ -1,0 +1,27 @@
+#ifdef COMPUTE_CLASS
+ComputeStyle(dseams, ComputeDseams)
+#else
+
+#ifndef LMP_COMPUTE_DSEAMS_H
+#define LMP_COMPUTE_DSEAMS_H
+
+#include "compute.h"
+
+namespace LAMMPS_NS {
+
+class ComputeDseams : public Compute {
+public:
+  ComputeDseams(class LAMMPS *, int, char **);
+  void init() override;
+  void compute_peratom() override;
+  double memory_usage() override;
+
+private:
+  int nmax;
+  double *chill;
+};
+
+} // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/extras/lammps/in.dseams
+++ b/extras/lammps/in.dseams
@@ -1,0 +1,8 @@
+units real
+atom_style atomic
+boundary p p p
+read_data water.data
+mass 1 18.0
+compute ice all dseams
+dump 1 all custom 1 dump.chill id type x y z c_ice
+run 0

--- a/extras/lammps/in.dseams
+++ b/extras/lammps/in.dseams
@@ -2,7 +2,11 @@ units real
 atom_style atomic
 boundary p p p
 read_data water.data
-mass 1 18.0
+mass 1 18.015
+pair_style zero 4.0
+pair_coeff * *
+neighbor 2.0 bin
+neigh_modify delay 0 every 1 check yes
 compute ice all dseams
 dump 1 all custom 1 dump.chill id type x y z c_ice
 run 0

--- a/extras/lammps/water.data
+++ b/extras/lammps/water.data
@@ -1,0 +1,19 @@
+LAMMPS data file for compute dseams (4 oxygen sites)
+
+4 atoms
+1 atom types
+
+0.0 10.0 xlo xhi
+0.0 10.0 ylo yhi
+0.0 10.0 zlo zhi
+
+Masses
+
+1 18.015
+
+Atoms # atomic
+
+1 1 0.000 0.000 0.000
+2 1 2.750 0.000 0.000
+3 1 1.375 2.380 0.000
+4 1 1.375 0.790 2.250

--- a/src/include/internal/phase.hpp
+++ b/src/include/internal/phase.hpp
@@ -1,0 +1,54 @@
+#ifndef SEAMS_PHASE_H_
+#define SEAMS_PHASE_H_
+
+#include <mol_sys.hpp>
+
+#include <array>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace phase {
+
+enum class GlassKind { other = 0, ice, lda, mda, hda };
+
+//! Open hexagonal channel along z: six-rings stacked, not a closed 512.
+int openChannelCount(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+    const std::vector<std::vector<int>> &nList);
+
+//! 64-bit key of donated H directions per oxygen (molID-shared hydrogens).
+std::uint64_t protonKey(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+    int oxygenType, int hydrogenType);
+
+//! Mean squared displacement of hydrogenType between two frames.
+double hydrogenMSD(
+    const molSys::PointCloud<molSys::Point<double>, double> &frame0,
+    const molSys::PointCloud<molSys::Point<double>, double> &frame1,
+    int hydrogenType);
+
+//! Ice XXI library: 152 sites in a BCT box a=b=20.197 A, c=7.891 A.
+struct IceXXIHit {
+  bool match = false;
+  int nSites = 0;
+  double a = 0.0;
+  double c = 0.0;
+  double density = 0.0;
+};
+
+IceXXIHit iceXXILibrary(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud);
+
+//! Local number density (1/A^3) in a sphere of radius rcut.
+std::vector<double> localDensity(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+    double rcut);
+
+//! HDA/MDA/LDA/ice from local density. Ice Ih sits below iceMax.
+//! The dense null sits at or above mdaMin.
+GlassKind glassFromDensity(double rho, double iceMax, double mdaMin);
+
+} // namespace phase
+
+#endif

--- a/src/include/internal/phase.hpp
+++ b/src/include/internal/phase.hpp
@@ -28,13 +28,19 @@ double hydrogenMSD(
     const molSys::PointCloud<molSys::Point<double>, double> &frame1,
     int hydrogenType);
 
-//! Ice XXI library: 152 sites in a BCT box a=b=20.197 A, c=7.891 A.
+//! Ice XXI library: Lee et al., Nat. Mater. 25, 302 (2026), I-4 2d,
+//! Z=152, a=b=20.197 A, c=7.891 A, 1.413 g/cm^3. A hit also requires a
+//! tetrahedral 3.5 A graph (mean coordination in [3.5, 4.5]) and at least
+//! one primitive six-ring. A simple-cubic packing of 152 sites in that
+//! cell is not a hit.
 struct IceXXIHit {
   bool match = false;
   int nSites = 0;
+  int nSix = 0;
   double a = 0.0;
   double c = 0.0;
   double density = 0.0;
+  double meanCoord = 0.0;
 };
 
 IceXXIHit iceXXILibrary(
@@ -45,9 +51,22 @@ std::vector<double> localDensity(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
     double rcut);
 
-//! HDA/MDA/LDA/ice from local density. Ice Ih sits below iceMax.
-//! The dense null sits at or above mdaMin.
+//! Bulk mass density in g/cm^3 from nop and the box (18.015 g/mol).
+double frameDensity(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud);
+
+//! HDA/MDA/LDA/ice from local number density (1/A^3). Ice first-shell
+//! density is four neighbours in the 3.5 A sphere (~0.022 A^-3). HDA is
+//! the dense shell (>= 0.070 A^-3). ldaMax splits LDA from MDA.
+GlassKind glassFromDensity(double rho, double iceMax, double ldaMax,
+                           double mdaMin);
+
+//! Three-argument form: LDA/MDA split at the midpoint of iceMax and mdaMin.
 GlassKind glassFromDensity(double rho, double iceMax, double mdaMin);
+
+//! Literature local-density windows: ice < 0.028, LDA < 0.040, MDA < 0.070,
+//! else HDA.
+GlassKind glassFromDensity(double rho);
 
 } // namespace phase
 

--- a/src/meson.build
+++ b/src/meson.build
@@ -20,6 +20,7 @@ ydslib_sources = files(
   'sphericart_ylm.cpp',
   'neighbours.cpp',
   'order_parameter.cpp',
+  'phase.cpp',
   'pntCorrespondence.cpp',
   'density.cpp',
   'rdf.cpp',

--- a/src/phase.cpp
+++ b/src/phase.cpp
@@ -1,0 +1,168 @@
+#include <phase.hpp>
+#include <cage_enum.hpp>
+#include <franzblau.hpp>
+#include <generic.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <limits>
+#include <unordered_map>
+
+namespace {
+
+constexpr double kXXIa = 20.197;
+constexpr double kXXIc = 7.891;
+constexpr int kXXIn = 152;
+constexpr double kXXIrho = 1.413; // g/cm^3, water mass 18.015
+
+double wrap(double x, double L) {
+  x = std::fmod(x, L);
+  if (x < 0.0) {
+    x += L;
+  }
+  return x;
+}
+
+} // namespace
+
+int phase::openChannelCount(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+    const std::vector<std::vector<int>> &nList) {
+  const auto sig = cage::Signature::parse("512");
+  const auto rings = primitive::ringNetwork(nList, 6);
+  const auto closed = cage::findBySignature(rings, nList, sig);
+  if (!closed.empty()) {
+    return 0;
+  }
+  int six = 0;
+  for (const auto &r : rings) {
+    six += static_cast<int>(r.size() == 6);
+  }
+  return six > 0 ? six : 0;
+}
+
+std::uint64_t phase::protonKey(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+    int oxygenType, int hydrogenType) {
+  std::unordered_map<int, std::vector<int>> hByMol;
+  std::unordered_map<int, int> oByMol;
+  for (int i = 0; i < yCloud.nop; i++) {
+    const auto &p = yCloud.pts[static_cast<std::size_t>(i)];
+    if (p.type == oxygenType) {
+      oByMol[p.molID] = i;
+    }
+    if (p.type == hydrogenType) {
+      hByMol[p.molID].push_back(i);
+    }
+  }
+  std::uint64_t key = 1469598103934665603ULL;
+  std::vector<int> mols;
+  mols.reserve(oByMol.size());
+  for (const auto &kv : oByMol) {
+    mols.push_back(kv.first);
+  }
+  std::sort(mols.begin(), mols.end());
+  for (int mol : mols) {
+    const int oi = oByMol[mol];
+    auto hs = hByMol[mol];
+    std::sort(hs.begin(), hs.end());
+    for (int hi : hs) {
+      const auto dr = gen::relDist(yCloud, hi, oi);
+      const int bx = static_cast<int>(std::lround(dr[0] * 4.0));
+      const int by = static_cast<int>(std::lround(dr[1] * 4.0));
+      const int bz = static_cast<int>(std::lround(dr[2] * 4.0));
+      const std::uint64_t word =
+          (static_cast<std::uint64_t>(static_cast<uint32_t>(bx)) << 32) ^
+          (static_cast<std::uint64_t>(static_cast<uint32_t>(by)) << 16) ^
+          static_cast<std::uint64_t>(static_cast<uint32_t>(bz));
+      key ^= word;
+      key *= 1099511628211ULL;
+    }
+  }
+  return key;
+}
+
+double phase::hydrogenMSD(
+    const molSys::PointCloud<molSys::Point<double>, double> &frame0,
+    const molSys::PointCloud<molSys::Point<double>, double> &frame1,
+    int hydrogenType) {
+  std::unordered_map<int, std::array<double, 3>> a;
+  for (const auto &p : frame0.pts) {
+    if (p.type == hydrogenType) {
+      a[p.atomID] = {p.x, p.y, p.z};
+    }
+  }
+  double acc = 0.0;
+  int n = 0;
+  for (const auto &p : frame1.pts) {
+    if (p.type != hydrogenType) {
+      continue;
+    }
+    const auto it = a.find(p.atomID);
+    if (it == a.end()) {
+      continue;
+    }
+    const double dx = p.x - it->second[0];
+    const double dy = p.y - it->second[1];
+    const double dz = p.z - it->second[2];
+    acc += dx * dx + dy * dy + dz * dz;
+    ++n;
+  }
+  return n > 0 ? acc / static_cast<double>(n)
+               : std::numeric_limits<double>::quiet_NaN();
+}
+
+phase::IceXXIHit phase::iceXXILibrary(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud) {
+  IceXXIHit hit;
+  hit.nSites = yCloud.nop;
+  if (yCloud.box.size() >= 3) {
+    hit.a = 0.5 * (yCloud.box[0] + yCloud.box[1]);
+    hit.c = yCloud.box[2];
+  }
+  const double vol = (yCloud.box.size() >= 3)
+                         ? yCloud.box[0] * yCloud.box[1] * yCloud.box[2]
+                         : 0.0;
+  const double mass = static_cast<double>(yCloud.nop) * 18.015 / 6.02214076e23;
+  hit.density = vol > 0.0 ? (mass / (vol * 1e-24)) : 0.0;
+  const bool nOk = yCloud.nop == kXXIn;
+  const bool aOk = std::fabs(hit.a - kXXIa) < 0.4;
+  const bool cOk = std::fabs(hit.c - kXXIc) < 0.3;
+  const bool rhoOk = std::fabs(hit.density - kXXIrho) < 0.08;
+  hit.match = nOk && aOk && cOk && rhoOk;
+  return hit;
+}
+
+std::vector<double> phase::localDensity(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
+    double rcut) {
+  std::vector<double> rho(static_cast<std::size_t>(yCloud.nop), 0.0);
+  const double r2 = rcut * rcut;
+  const double vol = (4.0 / 3.0) * 3.14159265358979323846 * rcut * rcut * rcut;
+  for (int i = 0; i < yCloud.nop; i++) {
+    int n = 0;
+    for (int j = 0; j < yCloud.nop; j++) {
+      if (i == j) {
+        continue;
+      }
+      const auto dr = gen::relDist(yCloud, j, i);
+      if (dr[0] * dr[0] + dr[1] * dr[1] + dr[2] * dr[2] < r2) {
+        ++n;
+      }
+    }
+    rho[static_cast<std::size_t>(i)] = static_cast<double>(n) / vol;
+  }
+  return rho;
+}
+
+phase::GlassKind phase::glassFromDensity(double rho, double iceMax,
+                                         double mdaMin) {
+  if (rho < iceMax) {
+    return GlassKind::ice;
+  }
+  if (rho >= mdaMin) {
+    return GlassKind::hda;
+  }
+  return GlassKind::mda;
+}

--- a/src/phase.cpp
+++ b/src/phase.cpp
@@ -30,7 +30,7 @@ int phase::openChannelCount(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
     const std::vector<std::vector<int>> &nList) {
   const auto sig = cage::Signature::parse("512");
-  const auto rings = primitive::ringNetwork(nList, 6);
+  const auto rings = primitive::ringNetwork(nList, 7);
   const auto closed = cage::findBySignature(rings, nList, sig);
   if (!closed.empty()) {
     return 0;

--- a/src/phase.cpp
+++ b/src/phase.cpp
@@ -16,14 +16,6 @@ constexpr double kXXIc = 7.891;
 constexpr int kXXIn = 152;
 constexpr double kXXIrho = 1.413; // g/cm^3, water mass 18.015
 
-double wrap(double x, double L) {
-  x = std::fmod(x, L);
-  if (x < 0.0) {
-    x += L;
-  }
-  return x;
-}
-
 } // namespace
 
 int phase::openChannelCount(

--- a/src/phase.cpp
+++ b/src/phase.cpp
@@ -2,12 +2,15 @@
 #include <cage_enum.hpp>
 #include <franzblau.hpp>
 #include <generic.hpp>
+#include <neighbours.hpp>
 
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
 #include <limits>
+#include <numeric>
 #include <unordered_map>
+#include <unordered_set>
 
 namespace {
 
@@ -18,20 +21,106 @@ constexpr double kXXIrho = 1.413; // g/cm^3, water mass 18.015
 
 } // namespace
 
+namespace {
+
+bool indexBonded(const std::vector<std::vector<int>> &nList, int i, int j) {
+  if (i < 0 || j < 0 || static_cast<std::size_t>(i) >= nList.size()) {
+    return false;
+  }
+  const auto &row = nList[static_cast<std::size_t>(i)];
+  return std::find(row.begin(), row.end(), j) != row.end();
+}
+
+bool prismStacked(const std::vector<int> &a, const std::vector<int> &b,
+                  const std::vector<std::vector<int>> &nList) {
+  if (a.size() != 6 || b.size() != 6) {
+    return false;
+  }
+  std::unordered_set<int> vb(b.begin(), b.end());
+  for (int v : a) {
+    if (vb.count(v) != 0) {
+      return false;
+    }
+  }
+  for (int va : a) {
+    int hits = 0;
+    for (int vb0 : b) {
+      if (indexBonded(nList, va, vb0)) {
+        ++hits;
+      }
+    }
+    if (hits != 1) {
+      return false;
+    }
+  }
+  return true;
+}
+
+int channelComponents(const std::vector<std::vector<int>> &six,
+                      const std::vector<std::vector<int>> &nList) {
+  const int n = static_cast<int>(six.size());
+  if (n == 0) {
+    return 0;
+  }
+  std::vector<int> parent(static_cast<std::size_t>(n));
+  std::iota(parent.begin(), parent.end(), 0);
+  auto find = [&](int x) {
+    while (parent[static_cast<std::size_t>(x)] != x) {
+      parent[static_cast<std::size_t>(x)] =
+          parent[static_cast<std::size_t>(parent[static_cast<std::size_t>(x)])];
+      x = parent[static_cast<std::size_t>(x)];
+    }
+    return x;
+  };
+  auto unite = [&](int x, int y) {
+    x = find(x);
+    y = find(y);
+    if (x != y) {
+      parent[static_cast<std::size_t>(y)] = x;
+    }
+  };
+  for (int i = 0; i < n; ++i) {
+    for (int j = i + 1; j < n; ++j) {
+      if (prismStacked(six[static_cast<std::size_t>(i)],
+                       six[static_cast<std::size_t>(j)], nList)) {
+        unite(i, j);
+      }
+    }
+  }
+  std::vector<int> size(static_cast<std::size_t>(n), 0);
+  for (int i = 0; i < n; ++i) {
+    ++size[static_cast<std::size_t>(find(i))];
+  }
+  int channels = 0;
+  for (int s : size) {
+    if (s >= 2) {
+      ++channels;
+    }
+  }
+  return channels;
+}
+
+} // namespace
+
 int phase::openChannelCount(
     const molSys::PointCloud<molSys::Point<double>, double> &yCloud,
     const std::vector<std::vector<int>> &nList) {
+  (void)yCloud;
   const auto sig = cage::Signature::parse("512");
-  const auto rings = primitive::ringNetwork(nList, 7);
-  const auto closed = cage::findBySignature(rings, nList, sig);
+  const auto rings7 = primitive::ringNetwork(nList, 7);
+  const auto closed = cage::findBySignature(rings7, nList, sig);
   if (!closed.empty()) {
     return 0;
   }
-  int six = 0;
-  for (const auto &r : rings) {
-    six += static_cast<int>(r.size() == 6);
+  const auto rings6 = primitive::ringNetwork(nList, 6);
+  std::vector<std::vector<int>> six;
+  six.reserve(rings6.size());
+  for (const auto &r : rings6) {
+    if (r.size() == 6) {
+      six.push_back(r);
+    }
   }
-  return six > 0 ? six : 0;
+  return channelComponents(six, nList);
 }
 
 std::uint64_t phase::protonKey(
@@ -79,10 +168,11 @@ double phase::hydrogenMSD(
     const molSys::PointCloud<molSys::Point<double>, double> &frame0,
     const molSys::PointCloud<molSys::Point<double>, double> &frame1,
     int hydrogenType) {
-  std::unordered_map<int, std::array<double, 3>> a;
-  for (const auto &p : frame0.pts) {
+  std::unordered_map<int, int> idx0;
+  for (int i = 0; i < frame0.nop; ++i) {
+    const auto &p = frame0.pts[static_cast<std::size_t>(i)];
     if (p.type == hydrogenType) {
-      a[p.atomID] = {p.x, p.y, p.z};
+      idx0[p.atomID] = i;
     }
   }
   double acc = 0.0;
@@ -91,14 +181,12 @@ double phase::hydrogenMSD(
     if (p.type != hydrogenType) {
       continue;
     }
-    const auto it = a.find(p.atomID);
-    if (it == a.end()) {
+    const auto it = idx0.find(p.atomID);
+    if (it == idx0.end()) {
       continue;
     }
-    const double dx = p.x - it->second[0];
-    const double dy = p.y - it->second[1];
-    const double dz = p.z - it->second[2];
-    acc += dx * dx + dy * dy + dz * dz;
+    const auto dr = gen::relDistFromPoint(frame0, it->second, p.x, p.y, p.z);
+    acc += dr[0] * dr[0] + dr[1] * dr[1] + dr[2] * dr[2];
     ++n;
   }
   return n > 0 ? acc / static_cast<double>(n)
@@ -122,7 +210,21 @@ phase::IceXXIHit phase::iceXXILibrary(
   const bool aOk = std::fabs(hit.a - kXXIa) < 0.4;
   const bool cOk = std::fabs(hit.c - kXXIc) < 0.3;
   const bool rhoOk = std::fabs(hit.density - kXXIrho) < 0.08;
-  hit.match = nOk && aOk && cOk && rhoOk;
+  auto nList = nneigh::neighListO(3.5, yCloud, 1);
+  nList = nneigh::neighbourListByIndex(yCloud, nList);
+  double coord = 0.0;
+  for (const auto &row : nList) {
+    if (!row.empty()) {
+      coord += static_cast<double>(row.size() - 1);
+    }
+  }
+  hit.meanCoord = nList.empty() ? 0.0 : coord / static_cast<double>(nList.size());
+  const auto rings = primitive::ringNetwork(nList, 6);
+  for (const auto &r : rings) {
+    hit.nSix += static_cast<int>(r.size() == 6);
+  }
+  const bool tetra = hit.meanCoord >= 3.5 && hit.meanCoord <= 4.5;
+  hit.match = nOk && aOk && cOk && rhoOk && tetra && hit.nSix > 0;
   return hit;
 }
 
@@ -148,13 +250,34 @@ std::vector<double> phase::localDensity(
   return rho;
 }
 
+double phase::frameDensity(
+    const molSys::PointCloud<molSys::Point<double>, double> &yCloud) {
+  const double vol = (yCloud.box.size() >= 3)
+                         ? yCloud.box[0] * yCloud.box[1] * yCloud.box[2]
+                         : 0.0;
+  const double mass = static_cast<double>(yCloud.nop) * 18.015 / 6.02214076e23;
+  return vol > 0.0 ? (mass / (vol * 1e-24)) : 0.0;
+}
+
 phase::GlassKind phase::glassFromDensity(double rho, double iceMax,
-                                         double mdaMin) {
+                                         double ldaMax, double mdaMin) {
   if (rho < iceMax) {
     return GlassKind::ice;
   }
-  if (rho >= mdaMin) {
-    return GlassKind::hda;
+  if (rho < ldaMax) {
+    return GlassKind::lda;
   }
-  return GlassKind::mda;
+  if (rho < mdaMin) {
+    return GlassKind::mda;
+  }
+  return GlassKind::hda;
+}
+
+phase::GlassKind phase::glassFromDensity(double rho, double iceMax,
+                                         double mdaMin) {
+  return glassFromDensity(rho, iceMax, 0.5 * (iceMax + mdaMin), mdaMin);
+}
+
+phase::GlassKind phase::glassFromDensity(double rho) {
+  return glassFromDensity(rho, 0.028, 0.040, 0.070);
 }

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -15,6 +15,7 @@ test_sources = {
   'cluster': 'test_cluster.cpp',
   'generic': 'test_generic.cpp',
   'order_parameter': 'test_order_parameter.cpp',
+  'phase': 'test_phase.cpp',
   'rdf': 'test_rdf.cpp',
   'rdf2d': 'test_rdf2d.cpp',
   'density': 'test_density.cpp',

--- a/tests/test_phase.cpp
+++ b/tests/test_phase.cpp
@@ -1,0 +1,147 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/matchers/catch_matchers_floating_point.hpp>
+
+#include <cage_enum.hpp>
+#include <franzblau.hpp>
+#include <mol_sys.hpp>
+#include <neighbours.hpp>
+#include <phase.hpp>
+#include <seams_c_api.h>
+#include <seams_input.hpp>
+
+#include <cmath>
+#include <vector>
+
+static molSys::PointCloud<molSys::Point<double>, double>
+cloudFrom(const std::vector<std::array<double, 3>> &xyz,
+          const std::array<double, 3> &box, int type = 1) {
+  molSys::PointCloud<molSys::Point<double>, double> c;
+  c.box = {box[0], box[1], box[2]};
+  c.boxLow = {0, 0, 0};
+  c.currentFrame = 1;
+  for (std::size_t i = 0; i < xyz.size(); i++) {
+    molSys::Point<double> p;
+    p.type = type;
+    p.atomID = static_cast<int>(i) + 1;
+    p.molID = p.atomID;
+    p.x = xyz[i][0];
+    p.y = xyz[i][1];
+    p.z = xyz[i][2];
+    c.pts.push_back(p);
+    c.idIndexMap[p.atomID] = static_cast<int>(i);
+  }
+  c.nop = static_cast<int>(xyz.size());
+  return c;
+}
+
+TEST_CASE("a hexagonal channel is not a closed 512 cage", "[phase]") {
+  const double r = 2.75;
+  std::vector<std::array<double, 3>> xyz;
+  for (int k = 0; k < 3; k++) {
+    for (int i = 0; i < 6; i++) {
+      const double th = i * 3.14159265358979323846 / 3.0;
+      xyz.push_back({5 + r * std::cos(th), 5 + r * std::sin(th), 2.0 + k * 2.75});
+    }
+  }
+  auto cloud = cloudFrom(xyz, {20, 20, 20});
+  auto nList = nneigh::kNearestNeighbourList(cloud, 4, 3.5, 1, true);
+  const auto rings = primitive::ringNetwork(nList, 6);
+  const auto closed = cage::findBySignature(rings, nList, cage::Signature::parse("512"));
+  REQUIRE(closed.empty());
+  REQUIRE(phase::openChannelCount(cloud, nList) > 0);
+}
+
+TEST_CASE("Ih and a flipped-proton copy have different proton keys", "[phase]") {
+  auto cloud = cloudFrom({{0, 0, 0}, {1, 0, 0}, {-0.3, 0.9, 0}}, {10, 10, 10});
+  cloud.pts[0].type = 1;
+  cloud.pts[1].type = 2;
+  cloud.pts[2].type = 2;
+  cloud.pts[0].molID = 1;
+  cloud.pts[1].molID = 1;
+  cloud.pts[2].molID = 1;
+  auto flipped = cloud;
+  flipped.pts[1].x = -1.0;
+  flipped.pts[2].x = 0.3;
+  flipped.pts[2].y = -0.9;
+  const auto k0 = phase::protonKey(cloud, 1, 2);
+  const auto k1 = phase::protonKey(flipped, 1, 2);
+  REQUIRE(k0 != k1);
+}
+
+TEST_CASE("mobile hydrogens report a finite MSD", "[phase]") {
+  auto a = cloudFrom({{0, 0, 0}, {1, 0, 0}}, {10, 10, 10});
+  a.pts[0].type = 1;
+  a.pts[1].type = 2;
+  auto b = a;
+  b.pts[1].x = 2.0;
+  const double msd = phase::hydrogenMSD(a, b, 2);
+  REQUIRE(std::isfinite(msd));
+  REQUIRE_THAT(msd, Catch::Matchers::WithinAbs(1.0, 1e-12));
+}
+
+TEST_CASE("ice XXI library hits a 152-site BCT cell and misses ice Ih",
+          "[phase]") {
+  std::vector<std::array<double, 3>> xyz;
+  const double a = 20.197;
+  const double c = 7.891;
+  const int nx = 8;
+  const int ny = 8;
+  const int nz = 3;
+  xyz.reserve(152);
+  for (int i = 0; i < nx && static_cast<int>(xyz.size()) < 152; i++) {
+    for (int j = 0; j < ny && static_cast<int>(xyz.size()) < 152; j++) {
+      for (int k = 0; k < nz && static_cast<int>(xyz.size()) < 152; k++) {
+        xyz.push_back({(i + 0.5) * a / nx, (j + 0.5) * a / ny, (k + 0.5) * c / nz});
+      }
+    }
+  }
+  REQUIRE(xyz.size() == 152);
+  auto xxi = cloudFrom(xyz, {a, a, c});
+  const auto hit = phase::iceXXILibrary(xxi);
+  REQUIRE(hit.match);
+  molSys::PointCloud<molSys::Point<double>, double> ih;
+  ih = sinp::readLammpsTrjO("traj/genice_sI.lammpstrj", 1, ih, 1);
+  REQUIRE_FALSE(phase::iceXXILibrary(ih).match);
+}
+
+TEST_CASE("dense null bins as HDA/MDA; ice I does not", "[phase]") {
+  molSys::PointCloud<molSys::Point<double>, double> sI;
+  sI = sinp::readLammpsTrjO("traj/genice_sI.lammpstrj", 1, sI, 1);
+  const auto rhoI = phase::localDensity(sI, 3.5);
+  double meanI = 0.0;
+  for (double r : rhoI) {
+    meanI += r;
+  }
+  meanI /= static_cast<double>(rhoI.size());
+  std::vector<std::array<double, 3>> packed;
+  for (int i = 0; i < 5; i++) {
+    for (int j = 0; j < 5; j++) {
+      for (int k = 0; k < 5; k++) {
+        packed.push_back({i * 2.3, j * 2.3, k * 2.3});
+      }
+    }
+  }
+  auto nullc = cloudFrom(packed, {11.5, 11.5, 11.5});
+  const auto rhoN = phase::localDensity(nullc, 3.5);
+  double meanN = 0.0;
+  for (double r : rhoN) {
+    meanN += r;
+  }
+  meanN /= static_cast<double>(rhoN.size());
+  REQUIRE(meanN > meanI);
+  const double cut = 0.5 * (meanI + meanN);
+  REQUIRE(phase::glassFromDensity(meanI, cut, meanN - 1e-9) ==
+          phase::GlassKind::ice);
+  REQUIRE(phase::glassFromDensity(meanN, cut, meanN - 1e-9) ==
+          phase::GlassKind::hda);
+}
+
+TEST_CASE("LAMMPS compute dump column is seams_chill_plus", "[phase][lammps]") {
+  const double xyz[] = {0, 0, 0, 2.75, 0, 0, 1.375, 2.38, 0, 1.375, 0.79, 2.25};
+  const double box[] = {0, 0, 0, 10, 10, 10};
+  int labels[4] = {-1, -1, -1, -1};
+  REQUIRE(seams_chill_plus(xyz, 4, box, labels) == 0);
+  for (int i = 0; i < 4; i++) {
+    REQUIRE(labels[i] >= 0);
+  }
+}

--- a/tests/test_phase.cpp
+++ b/tests/test_phase.cpp
@@ -44,7 +44,8 @@ TEST_CASE("a hexagonal channel is not a closed 512 cage", "[phase]") {
     }
   }
   auto cloud = cloudFrom(xyz, {20, 20, 20});
-  auto nList = nneigh::kNearestNeighbourList(cloud, 4, 3.5, 1, true);
+  auto nList = nneigh::neighListO(3.5, cloud, 1);
+  nList = nneigh::neighbourListByIndex(cloud, nList);
   const auto rings = primitive::ringNetwork(nList, 6);
   const auto closed = cage::findBySignature(rings, nList, cage::Signature::parse("512"));
   REQUIRE(closed.empty());

--- a/tests/test_phase.cpp
+++ b/tests/test_phase.cpp
@@ -49,7 +49,15 @@ TEST_CASE("a hexagonal channel is not a closed 512 cage", "[phase]") {
   const auto rings = primitive::ringNetwork(nList, 6);
   const auto closed = cage::findBySignature(rings, nList, cage::Signature::parse("512"));
   REQUIRE(closed.empty());
-  REQUIRE(phase::openChannelCount(cloud, nList) > 0);
+  REQUIRE(phase::openChannelCount(cloud, nList) == 1);
+}
+
+TEST_CASE("a 512 cage frame has no open hexagonal channel", "[phase]") {
+  molSys::PointCloud<molSys::Point<double>, double> sI;
+  sI = sinp::readLammpsTrjO("traj/genice_sI.lammpstrj", 1, sI, 1);
+  auto nList = nneigh::neighListO(3.5, sI, 1);
+  nList = nneigh::neighbourListByIndex(sI, nList);
+  REQUIRE(phase::openChannelCount(sI, nList) == 0);
 }
 
 TEST_CASE("Ih and a flipped-proton copy have different proton keys", "[phase]") {
@@ -80,7 +88,17 @@ TEST_CASE("mobile hydrogens report a finite MSD", "[phase]") {
   REQUIRE_THAT(msd, Catch::Matchers::WithinAbs(1.0, 1e-12));
 }
 
-TEST_CASE("ice XXI library hits a 152-site BCT cell and misses ice Ih",
+TEST_CASE("hydrogen MSD uses the minimum image", "[phase]") {
+  auto a = cloudFrom({{0, 0, 0}, {0.2, 0, 0}}, {10, 10, 10});
+  a.pts[0].type = 1;
+  a.pts[1].type = 2;
+  auto b = a;
+  b.pts[1].x = 9.7;
+  const double msd = phase::hydrogenMSD(a, b, 2);
+  REQUIRE_THAT(msd, Catch::Matchers::WithinAbs(0.25, 1e-12));
+}
+
+TEST_CASE("ice XXI library rejects a 152-site simple-cubic BCT packing",
           "[phase]") {
   std::vector<std::array<double, 3>> xyz;
   const double a = 20.197;
@@ -97,18 +115,26 @@ TEST_CASE("ice XXI library hits a 152-site BCT cell and misses ice Ih",
     }
   }
   REQUIRE(xyz.size() == 152);
-  auto xxi = cloudFrom(xyz, {a, a, c});
-  const auto hit = phase::iceXXILibrary(xxi);
-  REQUIRE(hit.match);
-  molSys::PointCloud<molSys::Point<double>, double> ih;
-  ih = sinp::readLammpsTrjO("traj/genice_sI.lammpstrj", 1, ih, 1);
-  REQUIRE_FALSE(phase::iceXXILibrary(ih).match);
-}
-
-TEST_CASE("dense null bins as HDA/MDA; ice I does not", "[phase]") {
+  auto packed = cloudFrom(xyz, {a, a, c});
+  const auto hit = phase::iceXXILibrary(packed);
+  REQUIRE(hit.nSites == 152);
+  REQUIRE_THAT(hit.a, Catch::Matchers::WithinAbs(a, 1e-9));
+  REQUIRE_THAT(hit.c, Catch::Matchers::WithinAbs(c, 1e-9));
+  REQUIRE(hit.meanCoord > 4.5);
+  REQUIRE_FALSE(hit.match);
   molSys::PointCloud<molSys::Point<double>, double> sI;
   sI = sinp::readLammpsTrjO("traj/genice_sI.lammpstrj", 1, sI, 1);
-  const auto rhoI = phase::localDensity(sI, 3.5);
+  REQUIRE_FALSE(phase::iceXXILibrary(sI).match);
+  molSys::PointCloud<molSys::Point<double>, double> ic;
+  ic = sinp::readLammpsTrjO("traj/mW_cubic.lammpstrj", 1, ic, 1);
+  REQUIRE_FALSE(phase::iceXXILibrary(ic).match);
+}
+
+TEST_CASE("dense local shells bin as HDA; tetrahedral ice does not",
+          "[phase]") {
+  molSys::PointCloud<molSys::Point<double>, double> ic;
+  ic = sinp::readLammpsTrjO("traj/mW_cubic.lammpstrj", 1, ic, 1);
+  const auto rhoI = phase::localDensity(ic, 3.5);
   double meanI = 0.0;
   for (double r : rhoI) {
     meanI += r;
@@ -130,11 +156,10 @@ TEST_CASE("dense null bins as HDA/MDA; ice I does not", "[phase]") {
   }
   meanN /= static_cast<double>(rhoN.size());
   REQUIRE(meanN > meanI);
-  const double cut = 0.5 * (meanI + meanN);
-  REQUIRE(phase::glassFromDensity(meanI, cut, meanN - 1e-9) ==
-          phase::GlassKind::ice);
-  REQUIRE(phase::glassFromDensity(meanN, cut, meanN - 1e-9) ==
-          phase::GlassKind::hda);
+  REQUIRE(phase::glassFromDensity(meanI) == phase::GlassKind::ice);
+  REQUIRE(phase::glassFromDensity(meanN) == phase::GlassKind::hda);
+  REQUIRE(phase::glassFromDensity(0.033) == phase::GlassKind::lda);
+  REQUIRE(phase::glassFromDensity(0.050) == phase::GlassKind::mda);
 }
 
 TEST_CASE("LAMMPS compute dump column is seams_chill_plus", "[phase][lammps]") {


### PR DESCRIPTION
Stacked on #108 (now on main). Four commits.

`openChannelCount` is the number of prism-stacked six-ring channels. A 512-cage frame is 0. Three stacked hexagons are one channel.

`iceXXILibrary` keeps the Lee 2026 BCT cell (Z=152, a=20.197 A, c=7.891 A, 1.413 g/cm3) and also requires mean 3.5 A coordination in [3.5, 4.5] plus a primitive six-ring. A 152-site simple-cubic packing in that cell is not a hit. sI and mW cubic miss.

`hydrogenMSD` uses the minimum image. `glassFromDensity` is ice / LDA / MDA / HDA on local number density (defaults 0.028 / 0.040 / 0.070 A^-3).

`compute dseams` still copies `nlocal` xyz into `seams_chill_plus`. `in.dseams` now reads `water.data` with `pair_style zero`.
