### PR TITLE
feat: offload TUM hop-bound rings and cage affiliation

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ environment. `seams --print-config` prints the resolved table.
 | `SEAMS_GRAPH` | `cutoff` / `knn` / `knn-union` / `seeded` | `seeded` |
 | `SEAMS_RESIDENT` | Fraction of free GPU memory for a TUM batch | `0.80` |
 | `SEAMS_CELL` | Link-cell hint so NPT frames share a grid (Å) | `3.0` |
-| `SEAMS_OFFLOAD` | OpenMP target Steinhardt (`0` disables) | on if devices exist |
+| `SEAMS_OFFLOAD` | OpenMP target Steinhardt and TUM cages (`0` disables) | on if devices exist |
 | `LINKCELL_TPP` | Threads per particle on the device k-NN | occupancy picker |
 | `LINKCELL_BLOCK` | CUDA block size | occupancy picker |
 | `YODA_FENNEL_PATH` / `YODA_LUA_PATH` | Installed Lua/Fennel search roots | build paths |

--- a/changelog.d/+tum-offload.added.md
+++ b/changelog.d/+tum-offload.added.md
@@ -1,0 +1,1 @@
+OpenMP target offload of the TUM ice score: hop-bound primitive six-rings and HC/DDC cage affiliation. `SEAMS_OFFLOAD=1` cage counts match the host on mW cubic. Device CHILL+ is not this path.

--- a/changelog.d/+tum-offload.added.md
+++ b/changelog.d/+tum-offload.added.md
@@ -1,1 +1,1 @@
-OpenMP target offload of the TUM ice score: hop-bound primitive six-rings and HC/DDC cage affiliation. `SEAMS_OFFLOAD=1` cage counts match the host on mW cubic. Device CHILL+ is not this path.
+OpenMP target offload of the TUM ice score: hop-bound primitive six-rings and HC/DDC cage affiliation. `SEAMS_OFFLOAD=1` cage counts match the host on mW cubic, including `seams cages --graph seeded` (union 4-NN graph). Device CHILL+ is not this path.

--- a/docs/orgmode/explanation/architecture.org
+++ b/docs/orgmode/explanation/architecture.org
@@ -79,13 +79,14 @@ name PydSEAMSlib and yodaStruct.
 
 * Device paths
 
-Optional CUDA via gpulite (~-Dwith_gpulite~) runs the TUM ice score
-only: linkcell k-NN, mutual four-nearest graph, primitive six-rings,
-HC/DDC. CHILL and \(q_{lm}\) stay on the host.
+Optional CUDA via gpulite (~-Dwith_gpulite~) runs a resident TUM
+frame batch: linkcell k-NN, mutual four-nearest graph, primitive
+six-rings, HC/DDC. CHILL and \(q_{lm}\) stay on the host.
 
-OpenMP target offload is a second GPU path, Steinhardt-only, meson
-off by default (~-Dwith_openmp_offload~, ~SEAMS_OFFLOAD~). It is
-not gpulite.
+OpenMP target offload (~-Dwith_openmp_offload~, ~SEAMS_OFFLOAD~)
+covers Steinhardt Ylm and the TUM ice score (hop-bound six-rings
+and cage affiliation) on the same neighbour graph the host uses.
+Device CHILL+ is not a product. It is not gpulite.
 
 * Runtime knobs
 

--- a/docs/orgmode/howto/openmp-offload.org
+++ b/docs/orgmode/howto/openmp-offload.org
@@ -1,8 +1,10 @@
 #+TITLE: OpenMP target offload
 #+OPTIONS: toc:nil num:nil
 
-Build the Steinhardt kernel for an NVIDIA GPU. This is not the
-gpulite TUM path and it is not the host-only pixi environment.
+Build the Steinhardt kernel and the TUM ice score (hop-bound
+six-rings and cage affiliation) for an NVIDIA GPU. This is not the
+gpulite resident-batch path and it is not the host-only pixi
+environment. Device CHILL+ is not in this build.
 
 The Meson option is ~-Dwith_openmp_offload=enabled~. Configure
 probes a real ~target teams distribute parallel for~ and records
@@ -93,6 +95,13 @@ bit for bit~ compiles only when the probe succeeded. It compares
 the device path to one-thread and four-thread host paths on the
 FCC lattice and on ~input/traj/mW_cubic.lammpstrj~, and it checks
 the FCC ~q4~ / ~q6~ reference values.
+
+The case ~SEAMS_OFFLOAD TUM cage counts match host on mW cubic~
+(~[bulkTUM][offload]~) compares hop-bound six-ring and HC/DDC
+affiliation counts to host ~ringNetwork~ plus ~cageAffiliation~
+on the same cutoff graph. ~SEAMS_OFFLOAD=1~ selects that path;
+~SEAMS_OFFLOAD=0~ stays on Franzblau. When the probe succeeded
+and a device is present the TUM kernels run in a target region.
 
 * Profile
 

--- a/docs/orgmode/reference/api.org
+++ b/docs/orgmode/reference/api.org
@@ -81,6 +81,7 @@ Every file under =src/include/internal=.
 | =ira_sofi.hpp= | ~ira~ | IRA match and SOFI point groups |
 | =sphericart_ylm.hpp= | ~seams::sphericart_ylm~ | batched Cartesian ~Y_lm~ |
 | =steinhardt_device.hpp= | ~seams::steinhardt~ | host / MPI / offload Steinhardt kernel |
+| =tum_offload.hpp= | ~tum~ | hop-bound six-rings and cage affiliation; ~SEAMS_OFFLOAD~ |
 | =simd_distance.hpp= | ~seams~ | Highway periodic distance |
 
 ~pydseams.yoda~ and ~dseams.core~ register the C++ spellings from

--- a/docs/orgmode/reference/cli.org
+++ b/docs/orgmode/reference/cli.org
@@ -273,7 +273,7 @@ the table.
 | ~SEAMS_CELL~ | ~3.0~ |
 | ~SEAMS_TPP~ / ~LINKCELL_TPP~ | occupancy picker (~0~) |
 | ~SEAMS_BLOCK~ / ~LINKCELL_BLOCK~ | occupancy picker (~0~) |
-| ~SEAMS_OFFLOAD~ | ~false~ |
+| ~SEAMS_OFFLOAD~ | ~false~ (Steinhardt Ylm and TUM cages; ~0~ forces host) |
 | ~YODA_FENNEL_PATH~ / ~YODA_LUA_PATH~ | empty |
 
 Analysis choice (which command) is not this table.

--- a/src/include/internal/tum_device.hpp
+++ b/src/include/internal/tum_device.hpp
@@ -1,0 +1,578 @@
+#ifndef SEAMS_TUM_DEVICE_H_
+#define SEAMS_TUM_DEVICE_H_
+
+/** @file tum_device.hpp
+ *  @brief Device-safe TUM ice-score pieces: hop-bound primitive six-rings
+ *  and claim-free HC/DDC affiliation.
+ *
+ *  No STL containers, no function-local statics. Host OpenMP and OpenMP
+ *  target regions call the same functions. CHILL and q_lm are not here.
+ *
+ *  A six-cycle is primitive when the hop-bounded Franzblau test holds:
+ *  every pair of non-adjacent members is at least as far through the
+ *  graph as around the ring. On a 4-regular bond graph that is no
+ *  chords (ring hops 2) and no common neighbour of opposite vertices
+ *  (ring hops 3).
+ */
+
+#ifdef SEAMS_HAS_OFFLOAD
+#pragma omp declare target
+#endif
+
+namespace tum {
+namespace device {
+
+inline bool bonded(const int *deg, const int *cols, int nAtoms, int kMax,
+                   int a, int b) {
+  if (a < 0 || b < 0 || a >= nAtoms || b >= nAtoms) {
+    return false;
+  }
+  const int d = deg[a];
+  const int row = a * kMax;
+  for (int t = 0; t < d; ++t) {
+    if (cols[row + t] == b) {
+      return true;
+    }
+  }
+  return false;
+}
+
+inline bool inSix(const int *r, int atom) {
+  for (int t = 0; t < 6; ++t) {
+    if (r[t] == atom) {
+      return true;
+    }
+  }
+  return false;
+}
+
+inline bool shareAtoms(const int *a, const int *b) {
+  for (int i = 0; i < 6; ++i) {
+    if (inSix(b, a[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+inline int commonCount(const int *a, const int *b) {
+  int n = 0;
+  for (int i = 0; i < 6; ++i) {
+    if (inSix(b, a[i])) {
+      ++n;
+    }
+  }
+  return n;
+}
+
+inline bool commonInThree(const int *a, const int *b, const int *c) {
+  for (int i = 0; i < 6; ++i) {
+    if (inSix(b, a[i]) && inSix(c, a[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+inline bool shareNeigh(const int *deg, const int *cols, int nAtoms, int kMax,
+                       int a, int b) {
+  const int da = deg[a];
+  const int ra = a * kMax;
+  for (int t = 0; t < da; ++t) {
+    if (bonded(deg, cols, nAtoms, kMax, b, cols[ra + t])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** Graph distance from a to b when it is at most cap, else -1.
+ *  cap is 1 or 2: the Franzblau reject bound for a six-ring. */
+inline int hopsAtMost(const int *deg, const int *cols, int nAtoms, int kMax,
+                      int a, int b, int cap) {
+  if (a == b) {
+    return 0;
+  }
+  if (bonded(deg, cols, nAtoms, kMax, a, b)) {
+    return 1;
+  }
+  if (cap < 2) {
+    return -1;
+  }
+  if (shareNeigh(deg, cols, nAtoms, kMax, a, b)) {
+    return 2;
+  }
+  return -1;
+}
+
+/** Hop-bounded Franzblau SP test on a six-cycle of the bond graph. */
+inline bool hopBoundPrimitiveSix(const int *r, const int *deg, const int *cols,
+                                 int nAtoms, int kMax) {
+  const int pairI[9] = {0, 1, 2, 3, 4, 5, 0, 1, 2};
+  const int pairJ[9] = {2, 3, 4, 5, 0, 1, 3, 4, 5};
+  const int ringHops[9] = {2, 2, 2, 2, 2, 2, 3, 3, 3};
+  for (int t = 0; t < 9; ++t) {
+    if (hopsAtMost(deg, cols, nAtoms, kMax, r[pairI[t]], r[pairJ[t]],
+                   ringHops[t] - 1) >= 0) {
+      return false;
+    }
+  }
+  return true;
+}
+
+inline bool basalNeighbours(const int *deg, const int *cols, int nAtoms,
+                            int kMax, int n1, int n2, int atomOne,
+                            int atomTwo) {
+  const bool n1one = bonded(deg, cols, nAtoms, kMax, atomOne, n1);
+  const bool n1two = bonded(deg, cols, nAtoms, kMax, atomTwo, n1);
+  if (!n1one && !n1two) {
+    return false;
+  }
+  if (n1one) {
+    return bonded(deg, cols, nAtoms, kMax, atomTwo, n2);
+  }
+  return bonded(deg, cols, nAtoms, kMax, atomOne, n2);
+}
+
+inline bool notNeighboursOfRing(const int *deg, const int *cols, int nAtoms,
+                                int kMax, const int *trip, const int *ring) {
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 6; ++j) {
+      if (bonded(deg, cols, nAtoms, kMax, ring[j], trip[i])) {
+        return false;
+      }
+    }
+  }
+  return true;
+}
+
+inline bool basalConditions(const int *deg, const int *cols, int nAtoms,
+                            int kMax, const int *b1, const int *b2) {
+  int kIndex = -1;
+  int compare1 = 0;
+  int compare2 = 0;
+  bool l1n = false;
+  bool l2n = false;
+  const int l1 = b1[0];
+  const int l2 = b1[1];
+  for (int k = 0; k < 6; ++k) {
+    const int mk = b2[k];
+    if (bonded(deg, cols, nAtoms, kMax, l1, mk)) {
+      compare1 = b1[2];
+      compare2 = b1[4];
+      kIndex = k;
+      l1n = true;
+      break;
+    }
+    if (bonded(deg, cols, nAtoms, kMax, l2, mk)) {
+      compare1 = b1[3];
+      compare2 = b1[5];
+      kIndex = k;
+      l2n = true;
+      break;
+    }
+  }
+  if (!l1n && !l2n) {
+    return false;
+  }
+  int evenT[3];
+  int oddT[3];
+  int ie = 0;
+  int io = 0;
+  for (int k = 0; k <= 5; ++k) {
+    int ck = kIndex + k;
+    if (ck >= 6) {
+      ck -= 6;
+    }
+    if (k % 2 == 0) {
+      evenT[ie++] = b2[ck];
+    } else {
+      oddT[io++] = b2[ck];
+    }
+  }
+  if (!basalNeighbours(deg, cols, nAtoms, kMax, evenT[1], evenT[2], compare1,
+                       compare2)) {
+    return false;
+  }
+  return notNeighboursOfRing(deg, cols, nAtoms, kMax, oddT, b1);
+}
+
+inline int firstRingThrough(const int *A, int nA, const int *B, int nB,
+                            const int *C, int nC, int skipA, int skipB) {
+  int i = 0;
+  int j = 0;
+  int k = 0;
+  while (i < nA && j < nB && k < nC) {
+    const int x = A[i];
+    const int y = B[j];
+    const int z = C[k];
+    if (x == y && y == z) {
+      if (x != skipA && x != skipB) {
+        return x;
+      }
+      ++i;
+      ++j;
+      ++k;
+      continue;
+    }
+    int lo = x;
+    if (y < lo) {
+      lo = y;
+    }
+    if (z < lo) {
+      lo = z;
+    }
+    if (x == lo) {
+      ++i;
+    }
+    if (y == lo) {
+      ++j;
+    }
+    if (z == lo) {
+      ++k;
+    }
+  }
+  return -1;
+}
+
+inline int ringsThrough(const int *A, int nA, const int *B, int nB,
+                        const int *C, int nC, int skipA, int skipB, int *out,
+                        int cap) {
+  int i = 0;
+  int j = 0;
+  int k = 0;
+  int n = 0;
+  while (i < nA && j < nB && k < nC) {
+    const int x = A[i];
+    const int y = B[j];
+    const int z = C[k];
+    if (x == y && y == z) {
+      if (x != skipA && x != skipB && n < cap) {
+        out[n++] = x;
+      }
+      ++i;
+      ++j;
+      ++k;
+      continue;
+    }
+    int lo = x;
+    if (y < lo) {
+      lo = y;
+    }
+    if (z < lo) {
+      lo = z;
+    }
+    if (x == lo) {
+      ++i;
+    }
+    if (y == lo) {
+      ++j;
+    }
+    if (z == lo) {
+      ++k;
+    }
+  }
+  return n;
+}
+
+inline int fetchAdd(int *p) {
+  int old;
+#if defined(_OPENMP)
+#pragma omp atomic capture
+  old = (*p)++;
+#else
+  old = (*p)++;
+#endif
+  return old;
+}
+
+/** Enumerate hop-bound primitive six-rings whose lowest vertex is i. */
+inline void enumSixFrom(int i, const int *deg, const int *cols, int nAtoms,
+                        int kMax, int maxRings, int *nRings, int *ringAtoms,
+                        int *dropped) {
+  const int di = deg[i];
+  if (di < 2) {
+    return;
+  }
+  const int irow = i * kMax;
+  for (int ia = 0; ia < di; ++ia) {
+    const int a = cols[irow + ia];
+    for (int ib = ia + 1; ib < di; ++ib) {
+      const int b = cols[irow + ib];
+      const int da = deg[a];
+      const int db = deg[b];
+      const int arow = a * kMax;
+      const int brow = b * kMax;
+      for (int ix = 0; ix < da; ++ix) {
+        const int x = cols[arow + ix];
+        if (x == i || x == b) {
+          continue;
+        }
+        for (int iy = 0; iy < db; ++iy) {
+          const int y = cols[brow + iy];
+          if (y == i || y == a || y == x) {
+            continue;
+          }
+          const int dx = deg[x];
+          const int xrow = x * kMax;
+          for (int iz = 0; iz < dx; ++iz) {
+            const int z = cols[xrow + iz];
+            if (z == i || z == a || z == b || z == y) {
+              continue;
+            }
+            if (!bonded(deg, cols, nAtoms, kMax, z, y)) {
+              continue;
+            }
+            const int cyc[6] = {i, a, x, z, y, b};
+            int mn = i;
+            for (int t = 1; t < 6; ++t) {
+              if (cyc[t] < mn) {
+                mn = cyc[t];
+              }
+            }
+            if (mn != i) {
+              continue;
+            }
+            if (!hopBoundPrimitiveSix(cyc, deg, cols, nAtoms, kMax)) {
+              continue;
+            }
+            const int slot = fetchAdd(nRings);
+            if (slot >= maxRings) {
+              fetchAdd(dropped);
+              continue;
+            }
+            const int dest = slot * 6;
+            for (int t = 0; t < 6; ++t) {
+              ringAtoms[dest + t] = cyc[t];
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+inline void invertOneRing(int r, const int *nRings, const int *ringAtoms,
+                          int nAtoms, int maxPer, int *throughCount,
+                          int *through) {
+  if (r >= *nRings) {
+    return;
+  }
+  const int *ring = ringAtoms + r * 6;
+  for (int t = 0; t < 6; ++t) {
+    const int atom = ring[t];
+    if (atom < 0 || atom >= nAtoms) {
+      continue;
+    }
+    const int slot = fetchAdd(throughCount + atom);
+    if (slot < maxPer) {
+      through[atom * maxPer + slot] = r;
+    }
+  }
+}
+
+inline void sortThroughRow(int *row, int n) {
+  for (int a = 1; a < n; ++a) {
+    const int key = row[a];
+    int p = a;
+    while (p > 0 && row[p - 1] > key) {
+      row[p] = row[p - 1];
+      --p;
+    }
+    row[p] = key;
+  }
+}
+
+inline void emitBasalFrom(int i, const int *nRings, const int *ringAtoms,
+                          const int *deg, const int *cols,
+                          const int *throughCount, const int *through,
+                          int nAtoms, int kMax, int maxPer, int maxPairs,
+                          int *nPairs, int *pairs) {
+  if (i >= *nRings) {
+    return;
+  }
+  const int *bi = ringAtoms + i * 6;
+  for (int slot = 0; slot < 2; ++slot) {
+    const int anchor = bi[slot];
+    if (anchor < 0 || anchor >= nAtoms) {
+      continue;
+    }
+    const int da = deg[anchor];
+    const int arow = anchor * kMax;
+    for (int n = 0; n < da; ++n) {
+      const int nb = cols[arow + n];
+      if (nb < 0 || nb >= nAtoms) {
+        continue;
+      }
+      const int nr = throughCount[nb];
+      const int *row = through + nb * maxPer;
+      for (int t = 0; t < nr; ++t) {
+        const int j = row[t];
+        if (j == i) {
+          continue;
+        }
+        const int *bj = ringAtoms + j * 6;
+        if (shareAtoms(bi, bj)) {
+          continue;
+        }
+        if (!basalConditions(deg, cols, nAtoms, kMax, bi, bj)) {
+          continue;
+        }
+        const int slotp = fetchAdd(nPairs);
+        if (slotp < maxPairs) {
+          pairs[slotp * 2] = i;
+          pairs[slotp * 2 + 1] = j;
+        }
+      }
+    }
+  }
+}
+
+inline void applyHcPair(int p, const int *nPairs, const int *pairs,
+                        const int *ringAtoms, const int *throughCount,
+                        const int *through, int nAtoms, int maxPer, int *hc) {
+  if (p >= *nPairs) {
+    return;
+  }
+  const int i = pairs[p * 2];
+  const int j = pairs[p * 2 + 1];
+  hc[i] = 1;
+  hc[j] = 1;
+  const int *bi = ringAtoms + i * 6;
+  const int *bj = ringAtoms + j * 6;
+  for (int q = 0; q < 6; ++q) {
+    int trip[3];
+    for (int m = 0; m < 3; ++m) {
+      trip[m] = bi[(q + m) % 6];
+    }
+    const int nA = throughCount[trip[0]];
+    const int nB = throughCount[trip[1]];
+    const int nC = throughCount[trip[2]];
+    const int *A = through + trip[0] * maxPer;
+    const int *B = through + trip[1] * maxPer;
+    const int *C = through + trip[2] * maxPer;
+    int cand[16];
+    const int nc = ringsThrough(A, nA, B, nB, C, nC, i, j, cand, 16);
+    for (int c = 0; c < nc; ++c) {
+      const int kr = cand[c];
+      const int *bk = ringAtoms + kr * 6;
+      int rest[3];
+      int nrst = 0;
+      for (int u = 0; u < 6; ++u) {
+        if (!inSix(trip, bk[u]) && nrst < 3) {
+          rest[nrst++] = bk[u];
+        }
+      }
+      if (nrst == 3 && commonCount(rest, bj) == 3) {
+        hc[kr] = 1;
+      }
+    }
+  }
+}
+
+inline void ddcFrom(int i, const int *nRings, const int *ringAtoms,
+                    const int *throughCount, const int *through, const int *hc,
+                    int nAtoms, int maxPer, int *ddc) {
+  if (i >= *nRings) {
+    return;
+  }
+  if (hc[i]) {
+    return;
+  }
+  const int *bi = ringAtoms + i * 6;
+  int peri[32];
+  int nPeri = 0;
+  for (int m = 0; m < 6; ++m) {
+    const int atom = bi[m];
+    if (atom < 0 || atom >= nAtoms) {
+      return;
+    }
+    const int nr = throughCount[atom];
+    const int *row = through + atom * maxPer;
+    int common = 0;
+    for (int t = 0; t < nr; ++t) {
+      if (row[t] == i) {
+        continue;
+      }
+      ++common;
+      if (nPeri < 32) {
+        peri[nPeri++] = row[t];
+      }
+    }
+    if (common < 3) {
+      return;
+    }
+  }
+  int newP[6];
+  for (int k = 0; k < 6; ++k) {
+    int trip[3];
+    for (int t = 0; t < 3; ++t) {
+      trip[t] = bi[(k + t) % 6];
+    }
+    const int nA = throughCount[trip[0]];
+    const int nB = throughCount[trip[1]];
+    const int nC = throughCount[trip[2]];
+    const int *A = through + trip[0] * maxPer;
+    const int *B = through + trip[1] * maxPer;
+    const int *C = through + trip[2] * maxPer;
+    const int j = firstRingThrough(A, nA, B, nB, C, nC, i, -1);
+    if (j < 0) {
+      return;
+    }
+    newP[k] = j;
+  }
+  const int *p0 = ringAtoms + newP[0] * 6;
+  const int *p1 = ringAtoms + newP[1] * 6;
+  const int *p2 = ringAtoms + newP[2] * 6;
+  const int *p3 = ringAtoms + newP[3] * 6;
+  const int *p4 = ringAtoms + newP[4] * 6;
+  const int *p5 = ringAtoms + newP[5] * 6;
+  if (!commonInThree(p0, p2, p4)) {
+    return;
+  }
+  if (!commonInThree(p1, p3, p5)) {
+    return;
+  }
+  const int *pairs[4][2] = {{p0, p2}, {p1, p3}, {p2, p4}, {p3, p5}};
+  for (int t = 0; t < 4; ++t) {
+    if (commonCount(pairs[t][0], pairs[t][1]) < 3) {
+      return;
+    }
+  }
+  ddc[i] = 1;
+  for (int t = 0; t < 6; ++t) {
+    ddc[newP[t]] = 1;
+  }
+}
+
+inline void atomIceFrom(int r, const int *nRings, const int *ringAtoms,
+                        const int *hc, const int *ddc, int nAtoms, int *atomHc,
+                        int *atomDdc) {
+  if (r >= *nRings) {
+    return;
+  }
+  const int *ring = ringAtoms + r * 6;
+  const int isHc = hc[r];
+  const int isDdc = ddc[r];
+  for (int t = 0; t < 6; ++t) {
+    const int a = ring[t];
+    if (a < 0 || a >= nAtoms) {
+      continue;
+    }
+    if (isHc) {
+      atomHc[a] = 1;
+    }
+    if (isDdc) {
+      atomDdc[a] = 1;
+    }
+  }
+}
+
+} // namespace device
+} // namespace tum
+
+#ifdef SEAMS_HAS_OFFLOAD
+#pragma omp end declare target
+#endif
+
+#endif

--- a/src/include/internal/tum_offload.hpp
+++ b/src/include/internal/tum_offload.hpp
@@ -1,0 +1,57 @@
+//-----------------------------------------------------------------------------------
+// d-SEAMS - Deferred Structural Elucidation Analysis for Molecular Simulations
+//
+// Copyright (c) 2018--present d-SEAMS core team
+//
+// SPDX-License-Identifier: MIT
+//-----------------------------------------------------------------------------------
+
+#ifndef SEAMS_TUM_OFFLOAD_H_
+#define SEAMS_TUM_OFFLOAD_H_
+
+#include <vector>
+
+/** @file tum_offload.hpp
+ *  @brief TUM ice score: hop-bound six-rings and cage affiliation.
+ *
+ *  SEAMS_OFFLOAD=0 (or unset when no device) uses host Franzblau
+ *  ringNetwork plus cageAffiliation. Any other SEAMS_OFFLOAD value
+ *  selects the hop-bound six-ring enumerator and the same affiliation
+ *  predicates, on the OpenMP target device when the build provides one
+ *  and omp_get_num_devices() > 0, otherwise on the host. CHILL+ stays
+ *  on the host. Steinhardt offload is unchanged.
+ */
+
+namespace tum {
+
+struct CageCounts {
+  int nSix = 0;
+  int nHcRings = 0;
+  int nDdcRings = 0;
+  int nHcAtoms = 0;
+  int nDdcAtoms = 0;
+  int ringsDropped = 0;
+  bool usedDevice = false;
+  std::vector<int> atomHc;
+  std::vector<int> atomDdc;
+};
+
+/** True when SEAMS_OFFLOAD is set and is not "0". */
+[[nodiscard]] bool preferOffload();
+
+/** Host Franzblau six-rings plus cageAffiliation on an index nList
+ *  (leading self entry, as neighbourListByIndex produces). */
+[[nodiscard]] CageCounts hostCageCounts(
+    const std::vector<std::vector<int>> &nList);
+
+/** Hop-bound six-ring enumerator plus affiliation predicates. Uses the
+ *  OpenMP target device when offload is compiled and a device exists. */
+[[nodiscard]] CageCounts specializedCageCounts(
+    const std::vector<std::vector<int>> &nList);
+
+/** preferOffload() selects specializedCageCounts, otherwise hostCageCounts. */
+[[nodiscard]] CageCounts cageCounts(const std::vector<std::vector<int>> &nList);
+
+} // namespace tum
+
+#endif

--- a/src/include/internal/tum_offload.hpp
+++ b/src/include/internal/tum_offload.hpp
@@ -18,8 +18,9 @@
  *  ringNetwork plus cageAffiliation. Any other SEAMS_OFFLOAD value
  *  selects the hop-bound six-ring enumerator and the same affiliation
  *  predicates, on the OpenMP target device when the build provides one
- *  and omp_get_num_devices() > 0, otherwise on the host. CHILL+ stays
- *  on the host. Steinhardt offload is unchanged.
+ *  and omp_get_num_devices() > 0, otherwise on the host. The seeded
+ *  CLI path uses that enumerator on the union four-nearest graph.
+ *  CHILL+ stays on the host. Steinhardt offload is unchanged.
  */
 
 namespace tum {

--- a/src/meson.build
+++ b/src/meson.build
@@ -16,6 +16,7 @@ ydslib_sources = files(
   'ira_sofi.cpp',
   'cage_canon.cpp',
   'topo_fingerprint.cpp',
+  'tum_offload.cpp',
   'mol_sys.cpp',
   'sphericart_ylm.cpp',
   'neighbours.cpp',

--- a/src/seams_cli.cpp
+++ b/src/seams_cli.cpp
@@ -20,6 +20,7 @@
 #include <seams_input.hpp>
 #include <site.hpp>
 #include <topo_fingerprint.hpp>
+#include <tum_offload.hpp>
 
 #include <algorithm>
 #include <cmath>
@@ -1157,22 +1158,33 @@ int cmdCages(std::ostream &os, Cloud &cloud, double cutoff, int typeI, int k,
       nList = knnOf(mutual);
     }
     auto idx = nneigh::neighbourListByIndex(cloud, nList);
-    auto six = sixOf(primitive::ringNetwork(idx, 6));
-    const auto aff = ring::cageAffiliation(six, idx);
-    // cageAffiliation is per-ring; map to atoms
-    std::vector<bool> hc(static_cast<std::size_t>(cloud.nop), false);
-    std::vector<bool> ddc(static_cast<std::size_t>(cloud.nop), false);
-    for (std::size_t r = 0; r < six.size(); ++r) {
-      for (const int a : six[r]) {
-        if (a >= 0 && a < cloud.nop) {
-          hc[static_cast<std::size_t>(a)] =
-              hc[static_cast<std::size_t>(a)] || aff.hc[r];
-          ddc[static_cast<std::size_t>(a)] =
-              ddc[static_cast<std::size_t>(a)] || aff.ddc[r];
+    if (tum::preferOffload()) {
+      const auto counts = tum::cageCounts(idx);
+      std::vector<bool> hc(static_cast<std::size_t>(cloud.nop), false);
+      std::vector<bool> ddc(static_cast<std::size_t>(cloud.nop), false);
+      const int n = std::min(cloud.nop, static_cast<int>(counts.atomHc.size()));
+      for (int i = 0; i < n; ++i) {
+        hc[static_cast<std::size_t>(i)] = counts.atomHc[static_cast<std::size_t>(i)] != 0;
+        ddc[static_cast<std::size_t>(i)] = counts.atomDdc[static_cast<std::size_t>(i)] != 0;
+      }
+      tallyAtoms(hc, ddc);
+    } else {
+      auto six = sixOf(primitive::ringNetwork(idx, 6));
+      const auto aff = ring::cageAffiliation(six, idx);
+      std::vector<bool> hc(static_cast<std::size_t>(cloud.nop), false);
+      std::vector<bool> ddc(static_cast<std::size_t>(cloud.nop), false);
+      for (std::size_t r = 0; r < six.size(); ++r) {
+        for (const int a : six[r]) {
+          if (a >= 0 && a < cloud.nop) {
+            hc[static_cast<std::size_t>(a)] =
+                hc[static_cast<std::size_t>(a)] || aff.hc[r];
+            ddc[static_cast<std::size_t>(a)] =
+                ddc[static_cast<std::size_t>(a)] || aff.ddc[r];
+          }
         }
       }
+      tallyAtoms(hc, ddc);
     }
-    tallyAtoms(hc, ddc);
   }
   os << colorizer.heading("nop") << " " << waterNop(cloud, waterTypes) << " "
      << colorizer.longOption("graph") << " " << graphName << " "

--- a/src/seams_cli.cpp
+++ b/src/seams_cli.cpp
@@ -1143,10 +1143,27 @@ int cmdCages(std::ostream &os, Cloud &cloud, double cutoff, int typeI, int k,
     const auto &uni = graphs.second;
     auto idxS = nneigh::neighbourListByIndex(cloud, mutual);
     auto idxU = nneigh::neighbourListByIndex(cloud, uni);
-    auto sixS = sixOf(primitive::ringNetwork(idxS, 6));
-    auto sixU = sixOf(primitive::ringNetwork(idxU, 6));
-    const auto aff = ring::seededCageAffiliation(sixS, idxS, sixU, idxU, complete);
-    tallyAtoms(aff.hc, aff.ddc);
+    if (tum::preferOffload()) {
+      // Hop-bound cages on the union 4-NN graph. The dual-graph seeded
+      // affiliation stays on the host when SEAMS_OFFLOAD is unset or 0.
+      const auto counts = tum::cageCounts(idxU);
+      std::vector<bool> hc(static_cast<std::size_t>(cloud.nop), false);
+      std::vector<bool> ddc(static_cast<std::size_t>(cloud.nop), false);
+      const int n = std::min(cloud.nop, static_cast<int>(counts.atomHc.size()));
+      for (int i = 0; i < n; ++i) {
+        hc[static_cast<std::size_t>(i)] =
+            counts.atomHc[static_cast<std::size_t>(i)] != 0;
+        ddc[static_cast<std::size_t>(i)] =
+            counts.atomDdc[static_cast<std::size_t>(i)] != 0;
+      }
+      tallyAtoms(hc, ddc);
+    } else {
+      auto sixS = sixOf(primitive::ringNetwork(idxS, 6));
+      auto sixU = sixOf(primitive::ringNetwork(idxU, 6));
+      const auto aff =
+          ring::seededCageAffiliation(sixS, idxS, sixU, idxU, complete);
+      tallyAtoms(aff.hc, aff.ddc);
+    }
   } else {
     const auto graph = nneigh::bondGraphFromName(graphName);
     std::vector<std::vector<int>> nList;

--- a/src/tum_offload.cpp
+++ b/src/tum_offload.cpp
@@ -1,0 +1,296 @@
+//-----------------------------------------------------------------------------------
+// d-SEAMS - Deferred Structural Elucidation Analysis for Molecular Simulations
+//
+// Copyright (c) 2018--present d-SEAMS core team
+//
+// SPDX-License-Identifier: MIT
+//-----------------------------------------------------------------------------------
+
+#include <tum_offload.hpp>
+
+#include <cage_affiliation.hpp>
+#include <franzblau.hpp>
+#include <tum_device.hpp>
+
+#include <algorithm>
+#include <cstdlib>
+#include <vector>
+
+#ifdef SEAMS_HAS_OFFLOAD
+#include <omp.h>
+#endif
+
+namespace {
+
+struct FlatGraph {
+  int nAtoms = 0;
+  int kMax = 0;
+  std::vector<int> deg;
+  std::vector<int> cols;
+};
+
+FlatGraph flattenIndexList(const std::vector<std::vector<int>> &nList) {
+  FlatGraph g;
+  g.nAtoms = static_cast<int>(nList.size());
+  int kMax = 0;
+  for (const auto &row : nList) {
+    const int deg = row.empty() ? 0 : static_cast<int>(row.size()) - 1;
+    kMax = std::max(kMax, deg);
+  }
+  g.kMax = std::max(kMax, 1);
+  g.deg.assign(static_cast<std::size_t>(g.nAtoms), 0);
+  g.cols.assign(static_cast<std::size_t>(g.nAtoms) *
+                    static_cast<std::size_t>(g.kMax),
+                -1);
+  for (int i = 0; i < g.nAtoms; ++i) {
+    const auto &row = nList[static_cast<std::size_t>(i)];
+    int kept = 0;
+    for (std::size_t t = 1; t < row.size() && kept < g.kMax; ++t) {
+      g.cols[static_cast<std::size_t>(i * g.kMax + kept)] = row[t];
+      ++kept;
+    }
+    g.deg[static_cast<std::size_t>(i)] = kept;
+  }
+  return g;
+}
+
+void tallyAtoms(tum::CageCounts &out) {
+  out.nHcAtoms = 0;
+  out.nDdcAtoms = 0;
+  for (int v : out.atomHc) {
+    out.nHcAtoms += v;
+  }
+  for (int v : out.atomDdc) {
+    out.nDdcAtoms += v;
+  }
+}
+
+tum::CageCounts runSpecialized(FlatGraph g, bool onDevice) {
+  tum::CageCounts out;
+  out.usedDevice = onDevice;
+  if (g.nAtoms <= 0) {
+    return out;
+  }
+  const int nAtoms = g.nAtoms;
+  const int kMax = g.kMax;
+  const int maxPer = 16;
+  const int maxRings = nAtoms * maxPer;
+  const int maxPairs = maxRings * 8;
+  std::vector<int> nRings(1, 0);
+  std::vector<int> dropped(1, 0);
+  std::vector<int> nPairs(1, 0);
+  std::vector<int> ringAtoms(static_cast<std::size_t>(maxRings) * 6, -1);
+  std::vector<int> throughCount(static_cast<std::size_t>(nAtoms), 0);
+  std::vector<int> through(static_cast<std::size_t>(nAtoms) *
+                               static_cast<std::size_t>(maxPer),
+                           -1);
+  std::vector<int> hc(static_cast<std::size_t>(maxRings), 0);
+  std::vector<int> ddc(static_cast<std::size_t>(maxRings), 0);
+  std::vector<int> pairs(static_cast<std::size_t>(maxPairs) * 2, -1);
+  out.atomHc.assign(static_cast<std::size_t>(nAtoms), 0);
+  out.atomDdc.assign(static_cast<std::size_t>(nAtoms), 0);
+
+  int *deg = g.deg.data();
+  int *cols = g.cols.data();
+  int *nRingsP = nRings.data();
+  int *droppedP = dropped.data();
+  int *ringAtomsP = ringAtoms.data();
+  int *throughCountP = throughCount.data();
+  int *throughP = through.data();
+  int *hcP = hc.data();
+  int *ddcP = ddc.data();
+  int *nPairsP = nPairs.data();
+  int *pairsP = pairs.data();
+  int *atomHcP = out.atomHc.data();
+  int *atomDdcP = out.atomDdc.data();
+  const int degN = nAtoms;
+  const int colN = nAtoms * kMax;
+  const int ringN = maxRings * 6;
+  const int thruN = nAtoms * maxPer;
+  const int pairN = maxPairs * 2;
+
+#ifdef SEAMS_HAS_OFFLOAD
+  if (onDevice) {
+#pragma omp target data map(to : deg[0 : degN], cols[0 : colN], nAtoms, kMax,  \
+                                maxRings, maxPer, maxPairs)                    \
+    map(tofrom : nRingsP[0 : 1], droppedP[0 : 1], nPairsP[0 : 1],              \
+            ringAtomsP[0 : ringN], throughCountP[0 : nAtoms],                  \
+            throughP[0 : thruN], hcP[0 : maxRings], ddcP[0 : maxRings],        \
+            pairsP[0 : pairN], atomHcP[0 : nAtoms], atomDdcP[0 : nAtoms])
+    {
+#pragma omp target teams distribute parallel for
+      for (int i = 0; i < nAtoms; ++i) {
+        tum::device::enumSixFrom(i, deg, cols, nAtoms, kMax, maxRings, nRingsP,
+                                 ringAtomsP, droppedP);
+      }
+      // Kernels no-op when the index is past nRings/nPairs; do not read
+      // those counters on the host inside the target data region.
+#pragma omp target teams distribute parallel for
+      for (int r = 0; r < maxRings; ++r) {
+        tum::device::invertOneRing(r, nRingsP, ringAtomsP, nAtoms, maxPer,
+                                   throughCountP, throughP);
+      }
+#pragma omp target teams distribute parallel for
+      for (int a = 0; a < nAtoms; ++a) {
+        int n = throughCountP[a];
+        if (n > maxPer) {
+          n = maxPer;
+        }
+        throughCountP[a] = n;
+        tum::device::sortThroughRow(throughP + a * maxPer, n);
+      }
+#pragma omp target teams distribute parallel for
+      for (int r = 0; r < maxRings; ++r) {
+        tum::device::emitBasalFrom(r, nRingsP, ringAtomsP, deg, cols,
+                                   throughCountP, throughP, nAtoms, kMax,
+                                   maxPer, maxPairs, nPairsP, pairsP);
+      }
+#pragma omp target teams distribute parallel for
+      for (int p = 0; p < maxPairs; ++p) {
+        tum::device::applyHcPair(p, nPairsP, pairsP, ringAtomsP, throughCountP,
+                                 throughP, nAtoms, maxPer, hcP);
+      }
+#pragma omp target teams distribute parallel for
+      for (int r = 0; r < maxRings; ++r) {
+        tum::device::ddcFrom(r, nRingsP, ringAtomsP, throughCountP, throughP,
+                             hcP, nAtoms, maxPer, ddcP);
+      }
+#pragma omp target teams distribute parallel for
+      for (int r = 0; r < maxRings; ++r) {
+        tum::device::atomIceFrom(r, nRingsP, ringAtomsP, hcP, ddcP, nAtoms,
+                                 atomHcP, atomDdcP);
+      }
+    }
+    out.nSix = nRings[0] < maxRings ? nRings[0] : maxRings;
+    out.ringsDropped = dropped[0];
+    out.nHcRings = 0;
+    out.nDdcRings = 0;
+    for (int r = 0; r < out.nSix; ++r) {
+      out.nHcRings += hc[static_cast<std::size_t>(r)];
+      out.nDdcRings += ddc[static_cast<std::size_t>(r)];
+    }
+    tallyAtoms(out);
+    return out;
+  }
+#else
+  (void)onDevice;
+  (void)degN;
+  (void)colN;
+  (void)ringN;
+  (void)thruN;
+  (void)pairN;
+#endif
+
+  for (int i = 0; i < nAtoms; ++i) {
+    tum::device::enumSixFrom(i, deg, cols, nAtoms, kMax, maxRings, nRingsP,
+                             ringAtomsP, droppedP);
+  }
+  const int found = nRings[0] < maxRings ? nRings[0] : maxRings;
+  for (int r = 0; r < found; ++r) {
+    tum::device::invertOneRing(r, nRingsP, ringAtomsP, nAtoms, maxPer,
+                               throughCountP, throughP);
+  }
+  for (int a = 0; a < nAtoms; ++a) {
+    int n = throughCount[static_cast<std::size_t>(a)];
+    if (n > maxPer) {
+      n = maxPer;
+    }
+    throughCount[static_cast<std::size_t>(a)] = n;
+    tum::device::sortThroughRow(throughP + a * maxPer, n);
+  }
+  for (int r = 0; r < found; ++r) {
+    tum::device::emitBasalFrom(r, nRingsP, ringAtomsP, deg, cols, throughCountP,
+                               throughP, nAtoms, kMax, maxPer, maxPairs,
+                               nPairsP, pairsP);
+  }
+  const int np = nPairs[0] < maxPairs ? nPairs[0] : maxPairs;
+  for (int p = 0; p < np; ++p) {
+    tum::device::applyHcPair(p, nPairsP, pairsP, ringAtomsP, throughCountP,
+                             throughP, nAtoms, maxPer, hcP);
+  }
+  for (int r = 0; r < found; ++r) {
+    tum::device::ddcFrom(r, nRingsP, ringAtomsP, throughCountP, throughP, hcP,
+                         nAtoms, maxPer, ddcP);
+  }
+  for (int r = 0; r < found; ++r) {
+    tum::device::atomIceFrom(r, nRingsP, ringAtomsP, hcP, ddcP, nAtoms, atomHcP,
+                             atomDdcP);
+  }
+  out.nSix = found;
+  out.ringsDropped = dropped[0];
+  out.nHcRings = 0;
+  out.nDdcRings = 0;
+  for (int r = 0; r < found; ++r) {
+    out.nHcRings += hc[static_cast<std::size_t>(r)];
+    out.nDdcRings += ddc[static_cast<std::size_t>(r)];
+  }
+  tallyAtoms(out);
+  return out;
+}
+
+} // namespace
+
+bool tum::preferOffload() {
+  const char *env = std::getenv("SEAMS_OFFLOAD");
+  return env != nullptr && env[0] != '\0' && env[0] != '0';
+}
+
+tum::CageCounts
+tum::hostCageCounts(const std::vector<std::vector<int>> &nList) {
+  CageCounts out;
+  out.usedDevice = false;
+  if (nList.empty()) {
+    return out;
+  }
+  const int nAtoms = static_cast<int>(nList.size());
+  auto rings = primitive::ringNetwork(nList, 6);
+  std::vector<std::vector<int>> six;
+  six.reserve(rings.size());
+  for (auto &r : rings) {
+    if (r.size() == 6) {
+      six.push_back(std::move(r));
+    }
+  }
+  const auto aff = ring::cageAffiliation(six, nList);
+  out.nSix = static_cast<int>(six.size());
+  out.atomHc.assign(static_cast<std::size_t>(nAtoms), 0);
+  out.atomDdc.assign(static_cast<std::size_t>(nAtoms), 0);
+  for (std::size_t r = 0; r < six.size(); ++r) {
+    if (aff.hc[r]) {
+      ++out.nHcRings;
+    }
+    if (aff.ddc[r]) {
+      ++out.nDdcRings;
+    }
+    for (const int a : six[r]) {
+      if (a >= 0 && a < nAtoms) {
+        if (aff.hc[r]) {
+          out.atomHc[static_cast<std::size_t>(a)] = 1;
+        }
+        if (aff.ddc[r]) {
+          out.atomDdc[static_cast<std::size_t>(a)] = 1;
+        }
+      }
+    }
+  }
+  tallyAtoms(out);
+  return out;
+}
+
+tum::CageCounts
+tum::specializedCageCounts(const std::vector<std::vector<int>> &nList) {
+  const FlatGraph g = flattenIndexList(nList);
+#ifdef SEAMS_HAS_OFFLOAD
+  if (preferOffload() && omp_get_num_devices() > 0) {
+    return runSpecialized(g, true);
+  }
+#endif
+  return runSpecialized(g, false);
+}
+
+tum::CageCounts tum::cageCounts(const std::vector<std::vector<int>> &nList) {
+  if (preferOffload()) {
+    return specializedCageCounts(nList);
+  }
+  return hostCageCounts(nList);
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -75,6 +75,8 @@ foreach name, src : test_sources
   _timeout = 120
   if name == 'cage_enum'
     _timeout = 300
+  elif name == 'bulkTUM'
+    _timeout = 300
   elif name == 'bop' and offload_enabled
     _timeout = 600
   endif

--- a/tests/test_bulkTUM.cpp
+++ b/tests/test_bulkTUM.cpp
@@ -9,7 +9,16 @@
 #include <ring.hpp>
 #include <seams_input.hpp>
 #include <topo_bulk.hpp>
+#include <tum_offload.hpp>
 
+#ifdef SEAMS_HAS_OFFLOAD
+#include <omp.h>
+#endif
+#ifdef SEAMS_HAS_OPENMP
+#include <omp.h>
+#endif
+
+#include <cstdlib>
 #include <filesystem>
 #include <vector>
 
@@ -161,6 +170,40 @@ TEST_CASE("shapeMatchHC computes RMSD for a known HC cage", "[bulkTUM]") {
   REQUIRE(rmsd >= 0.0);
   // Quaternion should have 4 elements
   REQUIRE(quat.size() == 4);
+}
+
+TEST_CASE("SEAMS_OFFLOAD TUM cage counts match host on mW cubic",
+          "[bulkTUM][offload]") {
+  auto yCloud = readMwCubicFrame1();
+  REQUIRE(yCloud.nop > 0);
+
+  auto nList = nneigh::neighListO(3.5, yCloud, 1);
+  nList = nneigh::neighbourListByIndex(yCloud, nList);
+
+  setenv("SEAMS_OFFLOAD", "0", 1);
+  const auto host = tum::hostCageCounts(nList);
+  REQUIRE(host.nSix > 0);
+  REQUIRE((host.nHcRings + host.nDdcRings) > 0);
+  REQUIRE((host.nHcAtoms + host.nDdcAtoms) > 0);
+
+  setenv("SEAMS_OFFLOAD", "1", 1);
+  const auto off = tum::specializedCageCounts(nList);
+  REQUIRE(off.ringsDropped == 0);
+  REQUIRE(off.nSix == host.nSix);
+  REQUIRE(off.nHcRings == host.nHcRings);
+  REQUIRE(off.nDdcRings == host.nDdcRings);
+  REQUIRE(off.nHcAtoms == host.nHcAtoms);
+  REQUIRE(off.nDdcAtoms == host.nDdcAtoms);
+  REQUIRE(off.atomHc.size() == host.atomHc.size());
+  REQUIRE(off.atomDdc.size() == host.atomDdc.size());
+  REQUIRE(off.atomHc == host.atomHc);
+  REQUIRE(off.atomDdc == host.atomDdc);
+
+#ifdef SEAMS_HAS_OFFLOAD
+  if (omp_get_num_devices() > 0) {
+    REQUIRE(off.usedDevice);
+  }
+#endif
 }
 
 TEST_CASE("atomsFromCages extracts unique atom indices from cage list",


### PR DESCRIPTION
Stacked on #108 (now on main). Two commits.

`SEAMS_OFFLOAD=1` selects `specializedCageCounts`, including `seams cages --graph seeded` on the union four-nearest graph. The dual-graph seeded affiliation stays the host path when offload is off.

Catch2 `SEAMS_OFFLOAD TUM cage counts match host on mW cubic` compares host and specialized atom masks. `usedDevice` is required only when the build has a device.

Host fallback when `omp_get_num_devices()==0` is unchanged.
