### PR TITLE
chore: cut 2.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,36 @@ by [towncrier](https://towncrier.readthedocs.io/).
 
 <!-- towncrier release notes start -->
 
+## [2.10.0] - 2026-09-06
+
+### Added
+
+- Add Rodger F4 and host-only Steinhardt l=12 so the Zeron q3/q12 hydrate pair is a per-atom field.
+- Add TUM/rings stacking planes (HC-basal and DDC-equatorial) next to the CHILL+ I_sd molecule-bin reference.
+- Add a C ABI seams_chill_plus for native and emscripten builds.
+- Add extras/lammps compute dseams that writes seams_chill_plus per atom.
+- Assign guests by ray-parity inside fan-triangulated cage faces, and count ions per ice cluster on the oxygen graph.
+- Bin CHILL+ cubic and hexagonal molecules into basal layers and emit cubicity Phi_c plus the H/C stacking string.
+- Build CHILL+, cages, seeded ions and k-NN on an explicit water-type mask (`--water-types`) so substrate and ions never enter the four-neighbour list. The flag loads the mixed dump; ice and cage counts are the water types only.
+- Enumerate cups and incomplete cages on the ring graph; closed signature counts stay the closed path.
+- Hexagonal channels are stacked six-ring prisms, not a raw six-ring count. Ice XXI (Lee et al. 2026, Z=152 BCT) also requires a tetrahedral 3.5 A graph and a primitive six-ring. Hydrogen MSD uses the minimum image. Glass labels use local-density windows for ice/LDA/MDA/HDA. `compute dseams` ships with `water.data` and `pair_style zero`.
+- Name 51264, 51268 and sH cages, and report a per-cage occupancy histogram.
+- OpenMP target offload of the TUM ice score: hop-bound primitive six-rings and HC/DDC cage affiliation. `SEAMS_OFFLOAD=1` cage counts match the host on mW cubic, including `seams cages --graph seeded` (union 4-NN graph). Device CHILL+ is not this path.
+- Update topology keys only on the hop-ball of atoms whose neighbourhood changed.
+
+### Changed
+
+- CHILL and CHILL+ default to the mutual four-nearest graph. vesin still owns cutoff pairs; linkcell still owns k-nearest.
+- Dump MIC and vesin pair reduction go through the minimage wrap. The simd Catch2 binary links it when the wrap is present.
+
+### Fixed
+
+- Accept a cup that fills the signature face count with dangling edges.
+- Evaluate Steinhardt l=12 qlBar on the host so the 25-component average does not overflow the device barRe[17] buffer.
+- Load oxygen and hydrogen together for `seams f4` so Rodger F4 is finite when mol IDs exist.
+- Place sI hydrogens with TIP3P HOH and a 15 degree libration so Rodger F4 sits near 0.7, score Zeron q12bar against a disordered liquid, and evaluate host l=12 Ylm when sphericart is off.
+
+
 ## [2.9.2] - 2026-09-02
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -2,8 +2,8 @@ cff-version: 1.2.0
 message: "If you use this software, please cite it using the metadata below."
 title: "d-SEAMS: Deferred Structural Elucidation Analysis for Molecular Simulations"
 type: software
-version: "2.9.2"
-date-released: "2026-09-02"
+version: "2.10.0"
+date-released: "2026-09-06"
 license: MIT
 repository-code: "https://github.com/d-SEAMS/seams-core"
 url: https://dseams.info

--- a/changelog.d/+c-api-wasm.added.md
+++ b/changelog.d/+c-api-wasm.added.md
@@ -1,1 +1,0 @@
-Add a C ABI seams_chill_plus for native and emscripten builds.

--- a/changelog.d/+chill-knn.changed.md
+++ b/changelog.d/+chill-knn.changed.md
@@ -1,1 +1,0 @@
-CHILL and CHILL+ default to the mutual four-nearest graph. vesin still owns cutoff pairs; linkcell still owns k-nearest.

--- a/changelog.d/+f4-cli-hydrogens.fixed.md
+++ b/changelog.d/+f4-cli-hydrogens.fixed.md
@@ -1,1 +1,0 @@
-Load oxygen and hydrogen together for `seams f4` so Rodger F4 is finite when mol IDs exist.

--- a/changelog.d/+f4-zeron-lit-windows.fixed.md
+++ b/changelog.d/+f4-zeron-lit-windows.fixed.md
@@ -1,1 +1,0 @@
-Place sI hydrogens with TIP3P HOH and a 15 degree libration so Rodger F4 sits near 0.7, score Zeron q12bar against a disordered liquid, and evaluate host l=12 Ylm when sphericart is off.

--- a/changelog.d/+f4-zeron-q12.added.md
+++ b/changelog.d/+f4-zeron-q12.added.md
@@ -1,1 +1,0 @@
-Add Rodger F4 and host-only Steinhardt l=12 so the Zeron q3/q12 hydrate pair is a per-atom field.

--- a/changelog.d/+incomplete-cages.added.md
+++ b/changelog.d/+incomplete-cages.added.md
@@ -1,1 +1,0 @@
-Enumerate cups and incomplete cages on the ring graph; closed signature counts stay the closed path.

--- a/changelog.d/+incomplete-full-census.fixed.md
+++ b/changelog.d/+incomplete-full-census.fixed.md
@@ -1,1 +1,0 @@
-Accept a cup that fills the signature face count with dangling edges.

--- a/changelog.d/+incremental-fingerprint.added.md
+++ b/changelog.d/+incremental-fingerprint.added.md
@@ -1,1 +1,0 @@
-Update topology keys only on the hop-ball of atoms whose neighbourhood changed.

--- a/changelog.d/+lammps-compute-dseams.added.md
+++ b/changelog.d/+lammps-compute-dseams.added.md
@@ -1,1 +1,0 @@
-Add extras/lammps compute dseams that writes seams_chill_plus per atom.

--- a/changelog.d/+layer-cubicity.added.md
+++ b/changelog.d/+layer-cubicity.added.md
@@ -1,1 +1,0 @@
-Bin CHILL+ cubic and hexagonal molecules into basal layers and emit cubicity Phi_c plus the H/C stacking string.

--- a/changelog.d/+occupancy-inside.added.md
+++ b/changelog.d/+occupancy-inside.added.md
@@ -1,1 +1,0 @@
-Assign guests by ray-parity inside fan-triangulated cage faces, and count ions per ice cluster on the oxygen graph.

--- a/changelog.d/+phase-xvii-xxi-glass.added.md
+++ b/changelog.d/+phase-xvii-xxi-glass.added.md
@@ -1,1 +1,0 @@
-Hexagonal channels are stacked six-ring prisms, not a raw six-ring count. Ice XXI (Lee et al. 2026, Z=152 BCT) also requires a tetrahedral 3.5 A graph and a primitive six-ring. Hydrogen MSD uses the minimum image. Glass labels use local-density windows for ice/LDA/MDA/HDA. `compute dseams` ships with `water.data` and `pair_style zero`.

--- a/changelog.d/+q12-host-qlbar.fixed.md
+++ b/changelog.d/+q12-host-qlbar.fixed.md
@@ -1,1 +1,0 @@
-Evaluate Steinhardt l=12 qlBar on the host so the 25-component average does not overflow the device barRe[17] buffer.

--- a/changelog.d/+sh-occupancy-hist.added.md
+++ b/changelog.d/+sh-occupancy-hist.added.md
@@ -1,1 +1,0 @@
-Name 51264, 51268 and sH cages, and report a per-cage occupancy histogram.

--- a/changelog.d/+tum-offload.added.md
+++ b/changelog.d/+tum-offload.added.md
@@ -1,1 +1,0 @@
-OpenMP target offload of the TUM ice score: hop-bound primitive six-rings and HC/DDC cage affiliation. `SEAMS_OFFLOAD=1` cage counts match the host on mW cubic, including `seams cages --graph seeded` (union 4-NN graph). Device CHILL+ is not this path.

--- a/changelog.d/+tum-stacking.added.md
+++ b/changelog.d/+tum-stacking.added.md
@@ -1,1 +1,0 @@
-Add TUM/rings stacking planes (HC-basal and DDC-equatorial) next to the CHILL+ I_sd molecule-bin reference.

--- a/changelog.d/+water-mask.added.md
+++ b/changelog.d/+water-mask.added.md
@@ -1,1 +1,0 @@
-Build CHILL+, cages, seeded ions and k-NN on an explicit water-type mask (`--water-types`) so substrate and ions never enter the four-neighbour list. The flag loads the mixed dump; ice and cage counts are the water types only.

--- a/docs/orgmode/changelog.org
+++ b/docs/orgmode/changelog.org
@@ -9,6 +9,17 @@ The release history is [[file:../../CHANGELOG.md][CHANGELOG.md]]
 (Keep a Changelog, assembled by towncrier). This page is the
 narrative cut used in the book.
 
+* 2.10.0
+
+Rodger F4 and host \(q_{12}\) are CLI fields. CHILL and CHILL+ use
+the mutual four-nearest graph and an optional water-type mask.
+Incomplete cups sit next to closed signatures. TUM stacking planes
+sit next to the CHILL+ \(I_{sd}\) bins; ~SEAMS_OFFLOAD=1~ runs the
+hop-bound TUM cages (host when there is no device). Ice XXI is the
+Lee 2026 BCT cell plus a tetrahedral six-ring graph. Hexagonal
+channels are stacked six-ring prisms. ~compute dseams~ writes
+CHILL+ from the C ABI and ships ~water.data~.
+
 * 2.9.2
 
 Every host stage of the ring pipeline threads. The cutoff neighbour

--- a/docs/orgmode/reference/cli.org
+++ b/docs/orgmode/reference/cli.org
@@ -34,9 +34,9 @@ frame has no atoms; without it, empty input retains the legacy text output.
 * Commands
 
 The ~command~ positional help string is ~read | chill | chill-plus |
-cages | fingerprint | ions | rdf | cn | hbonds | pairs | density-z |
-domains~. ~chill_plus~ is an accepted alias of ~chill-plus~ (not
-listed in that help string).
+cages | fingerprint | ions | f4 | steinhardt | rdf | cn | hbonds |
+pairs | density-z | domains~. ~chill_plus~ is an accepted alias of
+~chill-plus~ (not listed in that help string).
 
 | command | action | stdout |
 |---------+--------+--------|
@@ -49,6 +49,8 @@ listed in that help string).
 | ~fingerprint --emit-library LABEL~ | the frame's distinct keys as library lines | ~# method M hops H colours C~ then ~key LABEL~ rows |
 | ~fingerprint --library FILE[,FILE...]~ | atoms named by key libraries | ~nop N graph KIND hops H method M matched X label=count ... unmatched=U~ and, with several libraries, ~depth H1=n1 H2=n2~ |
 | ~ions~ | ions classed by their first water shell against the seeded cages | ~nop N ice A ions I in-ice X front Y liquid Z shell S shell-ice F~ |
+| ~f4~ | Rodger F4 on H-O...O-H pairs | ~nop N f4 MEAN n M~ |
+| ~steinhardt~ | host \(q_3\), \(\bar q_3\), \(q_{12}\), \(\bar q_{12}\) | ~nop N q3 A q3bar B q12 C q12bar D~ |
 | ~rdf~ | partial site-site \(g_{IJ}(r)\) | ~# r g count~ then ~# types I J rmax R bins N volume V~ then one ~r g count~ row per bin |
 | ~cn~ | site-site coordination number | ~# site-site~ then ~# types I J cutoff R cn X nI N nJ M volume V~ |
 | ~cn --ions --site~ | cage degree on ~ionCloud~ | ~cage ionCloud types 1 2 cutoff R degree D nCation N nAnion M~ |

--- a/docs/source/Doxyfile_seams.cfg
+++ b/docs/source/Doxyfile_seams.cfg
@@ -33,7 +33,7 @@ GENERATE_LATEX          = NO
 
 # Project Settings
 PROJECT_NAME            = "seams-core"
-PROJECT_NUMBER          = "v2.9.2"
+PROJECT_NUMBER          = "v2.10.0"
 PROJECT_BRIEF           = "libyodaLib, the C++ engine of d-SEAMS"
 
 # Doxygen Settings

--- a/meson.build
+++ b/meson.build
@@ -7,7 +7,7 @@
 #-----------------------------------------------------------------------------------
 
 project('seams-core', ['cpp', 'c'],
-  version: '2.9.2',
+  version: '2.10.0',
   default_options: ['warning_level=2', 'cpp_std=c++20'],
   meson_version: '>=1.3.0')
 

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -14,7 +14,7 @@
 
 stdenv.mkDerivation (finalAttrs: {
   pname = "seams";
-  version = "2.9.2";
+  version = "2.10.0";
 
   src = lib.fileset.toSource {
     root = ./..;

--- a/pixi.toml
+++ b/pixi.toml
@@ -1,6 +1,6 @@
 [workspace]
 name = "seams-core"
-version = "2.9.2"
+version = "2.10.0"
 channels = ["conda-forge"]
 platforms = ["linux-64", "osx-64", "osx-arm64"]
 authors = ["Rohit Goswami <rgoswami@ieee.org>"]


### PR DESCRIPTION
towncrier cut of 2.10.0. Versions in meson, pixi, CITATION, nix, and Doxyfile move together. The book changelog and the CLI command table name F4, Steinhardt, the water-type mask, and TUM offload.

This is the cut after #108-#112. Tag `v2.10.0` on the merge commit.
